### PR TITLE
Revert "chore: run unit test with go 1.14"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,8 +27,6 @@ jobs:
 
     - name: Test
       run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-      with:
-        go-version: 1.14
 
     - name: Codecov
       uses: codecov/codecov-action@v2


### PR DESCRIPTION
Reverts zeromicro/go-zero#1084

Checks succeeded, but not with go-version not a valid field.