### PR TITLE
feat: reflection grpc service

### DIFF
--- a/tools/goctl/rpc/generator/genmain.go
+++ b/tools/goctl/rpc/generator/genmain.go
@@ -23,6 +23,8 @@ import (
 	"github.com/tal-tech/go-zero/core/conf"
 	"github.com/tal-tech/go-zero/zrpc"
 	"google.golang.org/grpc"
+	"github.com/tal-tech/go-zero/core/service"
+    "google.golang.org/grpc/reflection"
 )
 
 var configFile = flag.String("f", "etc/{{.serviceName}}.yaml", "the config file")
@@ -37,6 +39,13 @@ func main() {
 
 	s := zrpc.MustNewServer(c.RpcServerConf, func(grpcServer *grpc.Server) {
 		{{.pkg}}.Register{{.service}}Server(grpcServer, srv)
+
+		switch c.Mode {
+		case service.DevMode,service.TestMode:
+			reflection.Register(grpcServer)
+		default:
+		}
+
 	})
 	defer s.Stop()
 

--- a/tools/goctl/rpc/generator/genmain.go
+++ b/tools/goctl/rpc/generator/genmain.go
@@ -24,7 +24,7 @@ import (
 	"github.com/tal-tech/go-zero/zrpc"
 	"google.golang.org/grpc"
 	"github.com/tal-tech/go-zero/core/service"
-    "google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/reflection"
 )
 
 var configFile = flag.String("f", "etc/{{.serviceName}}.yaml", "the config file")


### PR DESCRIPTION
Modify the rpc template file, when the mode is dev and test, provide publicly accessible gRPC service, which is convenient for using grpc client tool to call.