### PR TITLE
Add `opts ...grpc.CallOption` in grpc client

### DIFF
--- a/tools/goctl/rpc/generator/gencall.go
+++ b/tools/goctl/rpc/generator/gencall.go
@@ -23,7 +23,7 @@ package {{.filePackage}}
 
 import (
 	"context"
-    "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	{{.package}}
 
 	"github.com/tal-tech/go-zero/zrpc"


### PR DESCRIPTION
Add `opts...grpc.CallOption` to facilitate customization of interceptor.