### PR TITLE
add sc.Prometheus.Available()

### DIFF
--- a/core/prometheus/config.go
+++ b/core/prometheus/config.go
@@ -6,3 +6,10 @@ type Config struct {
 	Port int    `json:",default=9101"`
 	Path string `json:",default=/metrics"`
 }
+
+func (c *Config) Available() bool {
+	if c.Port == 0 {
+		return false
+	}
+	return true
+}

--- a/core/service/serviceconf.go
+++ b/core/service/serviceconf.go
@@ -50,7 +50,9 @@ func (sc ServiceConf) SetUp() error {
 	}
 
 	sc.initMode()
-	prometheus.StartAgent(sc.Prometheus)
+	if sc.Prometheus.Available() {
+		prometheus.StartAgent(sc.Prometheus)
+	}
 
 	if len(sc.Telemetry.Name) == 0 {
 		sc.Telemetry.Name = sc.Name


### PR DESCRIPTION
解决 在 main 函数中同时启动 rest server 和 kq 时导致 prometheus 无法启动的情况