### PR TITLE
Optimize routine id

### DIFF
--- a/core/threading/routines.go
+++ b/core/threading/routines.go
@@ -15,7 +15,8 @@ func GoSafe(fn func()) {
 
 // RoutineId is only for debug, never use it in production.
 func RoutineId() uint64 {
-	b := make([]byte, 64)
+	var a [32]byte
+	b := a[:]
 	b = b[:runtime.Stack(b, false)]
 	b = bytes.TrimPrefix(b, []byte("goroutine "))
 	b = b[:bytes.IndexByte(b, ' ')]


### PR DESCRIPTION
Optimize routine id with following:
1. avoid memory escape by allocate memory on stack
2. use smaller memory size, due to probable max routine id prefix is 30 bytes according to `len(fmt.Sprintf("goroutine %d", uint64(math.MaxUint64)))`  

Inspired by [https://github.com/go-sql-driver/mysql/pull/615/files]()