### PR TITLE
fix: go issue 16206

### DIFF
--- a/zrpc/internal/balancer/p2c/p2c.go
+++ b/zrpc/internal/balancer/p2c/p2c.go
@@ -182,14 +182,14 @@ func (p *p2cPicker) logStats() {
 }
 
 type subConn struct {
-	addr     resolver.Address
-	conn     balancer.SubConn
 	lag      uint64
 	inflight int64
 	success  uint64
 	requests int64
 	last     int64
 	pick     int64
+	addr     resolver.Address
+	conn     balancer.SubConn
 }
 
 func (c *subConn) healthy() bool {


### PR DESCRIPTION
p2c.subConn int64字段未对其，导致在Pick中choose(p.conns[0], nil)报错，p2c.go:153