### PR TITLE
排除客户端中断导致的503错误

### DIFF
--- a/rest/handler/loghandler.go
+++ b/rest/handler/loghandler.go
@@ -185,7 +185,7 @@ func logBrief(r *http.Request, code int, timer *utils.ElapsedTimer, logs *intern
 		buf.WriteString(fmt.Sprintf("\n%s", body))
 	}
 
-	if ok {
+	if ok || r.Context().Err() == context.Canceled  {
 		logger.Info(buf.String())
 	} else {
 		logger.Error(buf.String())


### PR DESCRIPTION
排除 【当客户端主动中断一个请求，服务会记录一条503错误日志】 的情况