### PR TITLE
Updated MySQL生成表结构体遇到关键字db部分保持原字段名定义

### DIFF
--- a/tools/goctl/model/sql/gen/field.go
+++ b/tools/goctl/model/sql/gen/field.go
@@ -24,7 +24,7 @@ func genFields(fields []*parser.Field) (string, error) {
 }
 
 func genField(field *parser.Field) (string, error) {
-	tag, err := genTag(field.Name.Source())
+	tag, err := genTag(field.NameOriginal)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
现有`user.sql`

~~~sql
CREATE TABLE `user` (
  `id` int(8) NOT NULL AUTO_INCREMENT,
  `type` int(8) NOT NULL DEFAULT '0' COMMENT '类型',
  PRIMARY KEY (`id`),
  KEY `uid` (`uid`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
~~~

在执行`goctl model mysql ddl -src="./user.sql" -dir="." -c` 时提示如下

~~~bash
[EscapeGolangKeyword]: go keyword is forbidden "type", converted into "tp"
~~~

生成的代码中User struct如下

~~~go
	User struct {
		Id int64 `db:"id"`
		Tp int64 `db:"tp"` // 类型
	}
~~~

此代码需要将 `db:"tp"` 改为 `db:"type"` 方可使用，此即当前PR解决的问题。