### PR TITLE
chore: optimize DoWithTimeout

### DIFF
--- a/core/fx/timeout.go
+++ b/core/fx/timeout.go
@@ -27,6 +27,13 @@ func DoWithTimeout(fn func() error, timeout time.Duration, opts ...DoOption) err
 	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
 
+	// check ctx
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	// create channel with buffer size 1 to avoid goroutine leak
 	done := make(chan error, 1)
 	panicChan := make(chan interface{}, 1)

--- a/core/fx/timeout_test.go
+++ b/core/fx/timeout_test.go
@@ -41,3 +41,26 @@ func TestWithCancel(t *testing.T) {
 	}, time.Second, WithContext(ctx))
 	assert.Equal(t, ErrCanceled, err)
 }
+
+func TestDoWithTimeout(t *testing.T) {
+
+	t.Run("cancel", func(t *testing.T) {
+		ctx, cancelFunc := context.WithCancel(context.Background())
+		cancelFunc()
+		err := DoWithTimeout(func() error {
+			return nil
+		}, time.Minute, WithContext(ctx))
+		assert.ErrorIs(t, context.Canceled, err)
+	})
+
+	t.Run("deadlineExceeded", func(t *testing.T) {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancelFunc()
+		time.Sleep(time.Second * 2)
+		err := DoWithTimeout(func() error {
+			return nil
+		}, time.Minute, WithContext(ctx))
+		assert.ErrorIs(t, context.DeadlineExceeded, err)
+	})
+
+}


### PR DESCRIPTION
Maybe ctx stopped or canceled at the beginning.