### PR TITLE
fix readme-cn

### DIFF
--- a/readme-cn.md
+++ b/readme-cn.md
@@ -141,7 +141,7 @@ GO111MODULE=on GOPROXY=https://goproxy.cn/,direct go get -u github.com/tal-tech/
 
     编写业务代码：
 
-      * api 文件定义了服务对外 HTTP 接口，可参考 [api 规范](https://github.com/zeromicro/zero-doc/blob/main/doc/goctl.md)
+      * api 文件定义了服务对外 HTTP 接口，可参考 [api 规范](https://github.com/zeromicro/zero-doc/blob/main/docs/zero/goctl-api.md)
       * 可以在 `servicecontext.go` 里面传递依赖给 logic，比如 mysql, redis 等
       * 在 api 定义的 `get/post/put/delete` 等请求对应的 logic 里增加业务处理逻辑
 


### PR DESCRIPTION
这里的链接应该是迁移文档之后忘了改了？: )
是要改成 https://github.com/zeromicro/zero-doc/blob/main/docs/zero/goctl-api.md 吗？