### PR TITLE
add a test script for go-zero

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+starttest() {
+	set -e
+	GO111MODULE=on go test -race ./...
+}
+
+if [ -z "${TEST_MOD}" ]; then
+	docker run --rm --name go-zero -ti \
+  		-v `pwd`:/go/src/github.com/zeromicro/go-zero \
+  		--workdir /go/src/github.com/zeromicro/go-zero \
+        --env GOPROXY=https://goproxy.cn\
+		--env TEST_MOD=local \
+  		golang:1.16 \
+  		sh test.sh
+else
+	starttest
+fi
+

--- a/test.sh
+++ b/test.sh
@@ -1,19 +1,19 @@
 #! /bin/sh
 
 starttest() {
-	set -e
-	GO111MODULE=on go test -race ./...
+    set -e
+    GO111MODULE=on go test -race ./...
 }
 
 if [ -z "${TEST_MOD}" ]; then
-	docker run --rm --name go-zero -ti \
-  		-v `pwd`:/go/src/github.com/zeromicro/go-zero \
-  		--workdir /go/src/github.com/zeromicro/go-zero \
-        --env GOPROXY=https://goproxy.cn\
-		--env TEST_MOD=local \
-  		golang:1.16 \
-  		sh test.sh
+    docker run --rm --name go-zero -ti \
+    -v `pwd`:/go/src/github.com/zeromicro/go-zero \
+    --workdir /go/src/github.com/zeromicro/go-zero \
+    --env GOPROXY=https://goproxy.cn\
+    --env TEST_MOD=local \
+    golang:1.16 \
+    sh test.sh
 else
-	starttest
+    starttest
 fi
 


### PR DESCRIPTION
```
leechen@leechen:~/go-zero$ ./test.sh 
go: downloading github.com/stretchr/testify v1.7.0
go: downloading go.etcd.io/etcd/client/v3 v3.5.1
go: downloading github.com/golang/mock v1.6.0
go: downloading gopkg.in/cheggaaa/pb.v1 v1.0.28
go: downloading github.com/spaolacci/murmur3 v1.1.0
go: downloading github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
go: downloading golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
go: downloading github.com/alicebob/miniredis/v2 v2.16.0
go: downloading go.opentelemetry.io/otel v1.1.0
go: downloading go.opentelemetry.io/otel/trace v1.1.0
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading go.opentelemetry.io/otel/sdk v1.1.0
go: downloading k8s.io/utils v0.0.0-20201110183641-67b214c5f920
go: downloading github.com/prometheus/client_golang v1.11.0
go: downloading github.com/olekukonko/tablewriter v0.0.5
go: downloading google.golang.org/grpc v1.42.0
go: downloading go.etcd.io/etcd/api/v3 v3.5.1
go: downloading gopkg.in/h2non/gock.v1 v1.1.2
go: downloading github.com/ClickHouse/clickhouse-go v1.5.1
go: downloading github.com/lib/pq v1.10.3
go: downloading github.com/go-redis/redis v6.15.9+incompatible
go: downloading github.com/go-sql-driver/mysql v1.6.0
go: downloading github.com/DATA-DOG/go-sqlmock v1.5.0
go: downloading go.uber.org/automaxprocs v1.4.0
go: downloading github.com/google/uuid v1.3.0
go: downloading go.opentelemetry.io/otel/exporters/jaeger v1.1.0
go: downloading go.opentelemetry.io/otel/exporters/zipkin v1.1.0
go: downloading google.golang.org/protobuf v1.27.1
go: downloading github.com/justinas/alice v1.2.0
go: downloading github.com/golang-jwt/jwt v3.2.1+incompatible
go: downloading k8s.io/api v0.20.12
go: downloading k8s.io/apimachinery v0.20.12
go: downloading k8s.io/client-go v0.20.12
go: downloading github.com/mattn/go-runewidth v0.0.9
go: downloading golang.org/x/sys v0.0.0-20211106132015-ebca88c72f68
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
go: downloading go.etcd.io/etcd/client/pkg/v3 v3.5.1
go: downloading go.uber.org/zap v1.17.0
go: downloading github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a
go: downloading github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/prometheus/common v0.26.0
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash v1.1.0
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/golang/protobuf v1.5.2
go: downloading github.com/prometheus/procfs v0.6.0
go: downloading github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542
go: downloading github.com/gogo/protobuf v1.3.2
go: downloading github.com/openzipkin/zipkin-go v0.3.0
go: downloading golang.org/x/net v0.0.0-20210928044308-7d9f5e0b762b
go: downloading google.golang.org/genproto v0.0.0-20210928142010-c7af6a1a74c9
go: downloading github.com/google/gofuzz v1.1.0
go: downloading k8s.io/klog/v2 v2.4.0
go: downloading github.com/coreos/go-semver v0.3.0
go: downloading github.com/coreos/go-systemd/v22 v22.3.2
go: downloading go.uber.org/atomic v1.7.0
go: downloading go.uber.org/multierr v1.6.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading sigs.k8s.io/structured-merge-diff/v4 v4.1.2
go: downloading github.com/googleapis/gnostic v0.4.1
go: downloading golang.org/x/crypto v0.0.0-20210920023735-84f357641f63
go: downloading golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
go: downloading github.com/go-logr/logr v0.2.0
go: downloading github.com/json-iterator/go v1.1.11
go: downloading github.com/hashicorp/golang-lru v0.5.1
go: downloading github.com/google/go-cmp v0.5.6
go: downloading golang.org/x/text v0.3.7
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading github.com/modern-go/reflect2 v1.0.1
go: downloading sigs.k8s.io/yaml v1.2.0
go: downloading golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
ok      github.com/zeromicro/go-zero/core/bloom 0.176s
ok      github.com/zeromicro/go-zero/core/breaker       3.542s
ok      github.com/zeromicro/go-zero/core/cmdline       0.068s
ok      github.com/zeromicro/go-zero/core/codec 0.704s
ok      github.com/zeromicro/go-zero/core/collection    8.600s
ok      github.com/zeromicro/go-zero/core/conf  0.098s
ok      github.com/zeromicro/go-zero/core/contextx      0.161s
ok      github.com/zeromicro/go-zero/core/discov        0.099s
ok      github.com/zeromicro/go-zero/core/discov/internal       0.100s
ok      github.com/zeromicro/go-zero/core/errorx        0.029s
ok      github.com/zeromicro/go-zero/core/executors     2.564s
ok      github.com/zeromicro/go-zero/core/filex 0.040s
?       github.com/zeromicro/go-zero/core/fs    [no test files]
ok      github.com/zeromicro/go-zero/core/fx    0.461s
ok      github.com/zeromicro/go-zero/core/hash  1.134s
ok      github.com/zeromicro/go-zero/core/iox   0.082s
ok      github.com/zeromicro/go-zero/core/jsontype      0.067s
?       github.com/zeromicro/go-zero/core/jsonx [no test files]
?       github.com/zeromicro/go-zero/core/lang  [no test files]
ok      github.com/zeromicro/go-zero/core/limit 4.773s
ok      github.com/zeromicro/go-zero/core/load  2.666s
ok      github.com/zeromicro/go-zero/core/logx  0.106s
ok      github.com/zeromicro/go-zero/core/mapping       0.246s
ok      github.com/zeromicro/go-zero/core/mathx 0.190s
ok      github.com/zeromicro/go-zero/core/metric        0.076s
ok      github.com/zeromicro/go-zero/core/mr    0.365s
?       github.com/zeromicro/go-zero/core/naming        [no test files]
ok      github.com/zeromicro/go-zero/core/netx  0.027s
ok      github.com/zeromicro/go-zero/core/proc  0.355s
ok      github.com/zeromicro/go-zero/core/prof  0.070s
?       github.com/zeromicro/go-zero/core/prometheus    [no test files]
ok      github.com/zeromicro/go-zero/core/queue 1.577s
ok      github.com/zeromicro/go-zero/core/rescue        0.069s
ok      github.com/zeromicro/go-zero/core/search        0.033s
ok      github.com/zeromicro/go-zero/core/service       0.085s
ok      github.com/zeromicro/go-zero/core/stat  0.151s
ok      github.com/zeromicro/go-zero/core/stat/internal 0.060s
ok      github.com/zeromicro/go-zero/core/stores/builder        0.040s
ok      github.com/zeromicro/go-zero/core/stores/cache  4.486s
ok      github.com/zeromicro/go-zero/core/stores/clickhouse     0.069s
ok      github.com/zeromicro/go-zero/core/stores/kv     0.597s
ok      github.com/zeromicro/go-zero/core/stores/mongo  0.093s
?       github.com/zeromicro/go-zero/core/stores/mongo/internal [no test files]
ok      github.com/zeromicro/go-zero/core/stores/mongoc 1.123s
ok      github.com/zeromicro/go-zero/core/stores/postgres       0.072s
ok      github.com/zeromicro/go-zero/core/stores/redis  1.675s
?       github.com/zeromicro/go-zero/core/stores/redis/redistest        [no test files]
ok      github.com/zeromicro/go-zero/core/stores/sqlc   1.127s
ok      github.com/zeromicro/go-zero/core/stores/sqlx   7.620s
ok      github.com/zeromicro/go-zero/core/stringx       0.046s
ok      github.com/zeromicro/go-zero/core/syncx 6.717s
ok      github.com/zeromicro/go-zero/core/sysx  0.043s
ok      github.com/zeromicro/go-zero/core/threading     0.095s
ok      github.com/zeromicro/go-zero/core/timex 0.111s
ok      github.com/zeromicro/go-zero/core/trace 0.068s
ok      github.com/zeromicro/go-zero/core/utils 0.087s
ok      github.com/zeromicro/go-zero/rest       0.094s
ok      github.com/zeromicro/go-zero/rest/handler       1.677s
ok      github.com/zeromicro/go-zero/rest/httpx 0.087s
ok      github.com/zeromicro/go-zero/rest/internal      0.088s
ok      github.com/zeromicro/go-zero/rest/internal/cors 0.059s
ok      github.com/zeromicro/go-zero/rest/internal/security     0.062s
ok      github.com/zeromicro/go-zero/rest/pathvar       0.028s
ok      github.com/zeromicro/go-zero/rest/router        0.065s
ok      github.com/zeromicro/go-zero/rest/token 0.031s
ok      github.com/zeromicro/go-zero/zrpc       6.296s
ok      github.com/zeromicro/go-zero/zrpc/internal      0.139s
ok      github.com/zeromicro/go-zero/zrpc/internal/auth 0.092s
ok      github.com/zeromicro/go-zero/zrpc/internal/balancer/p2c 4.229s
ok      github.com/zeromicro/go-zero/zrpc/internal/clientinterceptors   0.305s
ok      github.com/zeromicro/go-zero/zrpc/internal/codes        0.046s
?       github.com/zeromicro/go-zero/zrpc/internal/mock [no test files]
ok      github.com/zeromicro/go-zero/zrpc/internal/serverinterceptors   0.293s
ok      github.com/zeromicro/go-zero/zrpc/resolver      0.311s
ok      github.com/zeromicro/go-zero/zrpc/resolver/internal     0.499s
ok      github.com/zeromicro/go-zero/zrpc/resolver/internal/kube        0.078s
```