### PR TITLE
feature(stream): add Copy

### DIFF
--- a/core/fx/stream.go
+++ b/core/fx/stream.go
@@ -438,8 +438,8 @@ func (s Stream) Tail(n int64) Stream {
 // Copy returns multiple streams copied.
 // streamParam specifies the name and buffer size of the replicated stream.
 func (s Stream) Copy(streamParam map[string]int) (streamMap map[string]Stream) {
-	streamMap = map[string]Stream{}
 
+	streamMap = map[string]Stream{}
 	chans := make([]chan interface{}, 0, len(streamParam))
 	for name, bufferSize := range streamParam {
 		c := make(chan interface{}, bufferSize)

--- a/core/fx/stream.go
+++ b/core/fx/stream.go
@@ -444,8 +444,7 @@ func (s Stream) Copy(streamParam map[string]int) (streamMap map[string]Stream) {
 	chans := make([]chan interface{}, 0, len(streamParam))
 	for name, bufferSize := range streamParam {
 		c := make(chan interface{}, bufferSize)
-		stream := Range(c)
-		streamMap[name] = stream
+		streamMap[name] = Range(c)
 		chans = append(chans, c)
 	}
 

--- a/core/fx/stream.go
+++ b/core/fx/stream.go
@@ -437,10 +437,9 @@ func (s Stream) Tail(n int64) Stream {
 
 // Copy returns multiple streams copied.
 // streamParam specifies the name and buffer size of the replicated stream.
-// The copied stream and the original stream must execute in parallel.
 func (s Stream) Copy(streamParam map[string]int) (streamMap map[string]Stream) {
-
 	streamMap = map[string]Stream{}
+
 	chans := make([]chan interface{}, 0, len(streamParam))
 	for name, bufferSize := range streamParam {
 		c := make(chan interface{}, bufferSize)
@@ -462,6 +461,7 @@ func (s Stream) Copy(streamParam map[string]int) (streamMap map[string]Stream) {
 			close(c)
 		}
 	}()
+
 	return
 }
 

--- a/core/fx/stream_test.go
+++ b/core/fx/stream_test.go
@@ -569,3 +569,22 @@ func runCheckedTest(t *testing.T, fn func(t *testing.T)) {
 	time.Sleep(time.Millisecond)
 	assert.True(t, runtime.NumGoroutine() <= goroutines)
 }
+
+func TestStream_Copy(t *testing.T) {
+
+	copyStream := Just(1, 2, 3, 4, 5).Copy(map[string]int{
+		"a": 10,
+		"b": 10,
+	})
+	c := make(chan struct{})
+	go func() {
+		assert.Equal(t, 2, copyStream["a"].Filter(func(item interface{}) bool {
+			return item.(int)%2 == 0
+		}).Count())
+		<-c
+	}()
+	assert.Equal(t, 3, copyStream["b"].Filter(func(item interface{}) bool {
+		return item.(int)%2 != 0
+	}).Count())
+	c <- struct{}{}
+}


### PR DESCRIPTION
example:

```go
copyStream := Just(1, 2, 3, 4, 5).Copy(map[string]int{
		"mysql": 10, // buffer size
		"kafka": 2, // buffer size
	})
	group := sync.WaitGroup{}
	group.Add(1)
	go func() {
		defer group.Done()
		copyStream["mysql"].Filter(func(item interface{}) bool {
			return item.(int)%2 == 0
		}).Parallel(func(item interface{}) {
			// sends mysql
			return
		}, WithWorkers(100))

	}()
	group.Add(1)

	go func() {
		defer group.Done()
		copyStream["kafka"].Filter(func(item interface{}) bool {
			return item.(int)%2 != 0
		}).Parallel(func(item interface{}) {
			// sends kafka
			return
		}, WithWorkers(100))

	}()
	group.Wait()
```
