### PR TITLE
解决select case 非确定性选择引起的go携程泄漏问题

### DIFF
--- a/core/mr/mapreduce.go
+++ b/core/mr/mapreduce.go
@@ -278,10 +278,6 @@ func (gw guardedWriter) Write(v interface{}) {
 	case <-gw.done:
 		return
 	default:
-	}
-	select {
-	case <-gw.done:
-		return
-	case gw.channel <- v:
+		gw.channel <- v
 	}
 }

--- a/core/mr/mapreduce.go
+++ b/core/mr/mapreduce.go
@@ -232,6 +232,12 @@ func executeMappers(mapper MapFunc, input <-chan interface{}, collector chan<- i
 		select {
 		case <-done:
 			return
+		default:
+			
+		}
+		select {
+		case <-done:
+			return
 		case pool <- lang.Placeholder:
 			item, ok := <-input
 			if !ok {
@@ -285,6 +291,10 @@ func (gw guardedWriter) Write(v interface{}) {
 	case <-gw.done:
 		return
 	default:
-		gw.channel <- v
+	}
+	select {
+	case <-gw.done:
+		return
+	case gw.channel <- v:
 	}
 }


### PR DESCRIPTION
当同时使用通道和选择时，会发生另一种类型的并发错误。 在 Go 中，当一个 select 接收到多个消息时，不能保证哪个会先处理。 这种非确定性的实现
选择导致2处错误。
   第一:Write方法里，假设走到default语句里，done被关闭了，这时候channel的接受者收到done关闭的信号不在接收数据了，这时候还往channel写入数据v,就会永远堵塞住，引起go携程泄漏
第二：executeMappers方法里，假设mapper方法里，执行了canncel方法关闭了done通道，同时还接受到generate channel发送过来的数据，假设在同一时间内，即接收到done关闭的信号，同时还接收到source channel发送过来的数据，go调度器会随机选择一个执行，有可能导致source的数据被多次处理，这时候应该立即丢弃了请求，退出，不在处理