### PR TITLE
And traceid to request Header then can get it in business logical

### DIFF
--- a/rest/handler/tracinghandler.go
+++ b/rest/handler/tracinghandler.go
@@ -31,6 +31,7 @@ func TracingHandler(serviceName, path string) func(http.Handler) http.Handler {
 			sc := span.SpanContext()
 			if sc.HasTraceID() {
 				w.Header().Set(trace.TraceIdKey, sc.TraceID().String())
+				r.Header.Set("x-trace-id-temp", sc.TraceID().String())
 			}
 
 			next.ServeHTTP(w, r.WithContext(spanCtx))


### PR DESCRIPTION
用户代码里面目前获取不到本次调用的 traceid ，可以在tracinghandler.go 中将traceid写入请求的header中，在业务逻辑中可通过r.Header.Get("x-trace-id-temp")获取