### PR TITLE
feat: add rest.Server.Router function

### DIFF
--- a/rest/server.go
+++ b/rest/server.go
@@ -72,6 +72,11 @@ func (s *Server) AddRoute(r Route, opts ...RouteOption) {
 	s.AddRoutes([]Route{r}, opts...)
 }
 
+// Router returns the router of the Server.
+func (s *Server) Router() httpx.Router {
+	return s.router
+}
+
 // Start starts the Server.
 // Graceful shutdown is enabled by default.
 // Use proc.SetTimeToForceQuit to customize the graceful shutdown period.


### PR DESCRIPTION
# Background

Before, you need to define rest.Route in every unittest.

```golang
handlers = []rest.Route{
	{
		Method:  http.MethodPost,
		Path:    "/example",
		Handler: api.ExampleHandler(svc),
	},
	...
}
router := NewRouter()
for _, route := range handlers {
	router.Handle(route.Method, route.Path, route.Handler)
}
```

After this, you can use `RegisterHandlers` to reuse code and improve unittest coding experience.

```golang
server := rest.MustNewServer(conf)
handler.RegisterHandlers(server, svc)
router := server.Router()
```