### PR TITLE
feat: supports `importValue` for more path formats

### DIFF
--- a/tools/goctl/api/parser/g4/ast/apiparser.go
+++ b/tools/goctl/api/parser/g4/ast/apiparser.go
@@ -114,13 +114,16 @@ func (p *Parser) parse(filename, content string) (*Api, error) {
 	apiAstList = append(apiAstList, root)
 	for _, imp := range root.Import {
 		dir := filepath.Dir(p.src)
-		imp := filepath.Join(dir, imp.Value.Text())
-		data, err := p.readContent(imp)
+		impPath := strings.ReplaceAll(imp.Value.Text(), "\"", "")
+		if !filepath.IsAbs(impPath) {
+			impPath = filepath.Join(dir, impPath)
+		}
+		data, err := p.readContent(impPath)
 		if err != nil {
 			return nil, err
 		}
 
-		nestedApi, err := p.invoke(imp, data)
+		nestedApi, err := p.invoke(impPath, data)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/goctl/api/parser/g4/gen/api/baseparser.go
+++ b/tools/goctl/api/parser/g4/gen/api/baseparser.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	versionRegex     = `(?m)"v[1-9][0-9]*"`
-	importValueRegex = `(?m)"(/?[a-zA-Z0-9_#-])+\.api"`
+	importValueRegex = `(?m)"\/?(([a-zA-Z0-9.]+)+(\/?){1})+([a-zA-Z0-9]+)+\.api"`
 	tagRegex         = `(?m)\x60[a-z]+:".+"\x60`
 )
 

--- a/tools/goctl/api/parser/g4/gen/api/baseparser_test.go
+++ b/tools/goctl/api/parser/g4/gen/api/baseparser_test.go
@@ -9,3 +9,24 @@ import (
 func TestMatch(t *testing.T) {
 	assert.False(t, matchRegex("v1ddd", versionRegex))
 }
+
+func TestImportRegex(t *testing.T) {
+	tests := []struct {
+		value   string
+		matched bool
+	}{
+		{`"bar.api"`, true},
+		{`"foo/bar.api"`, true},
+		{`"/foo/bar.api"`, true},
+		{`"../foo/bar.api"`, true},
+		{`"../../foo/bar.api"`, true},
+
+		{`"bar..api"`, false},
+		{`"//bar.api"`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			assert.Equal(t, tt.matched, matchRegex(tt.value, importValueRegex))
+		})
+	}
+}


### PR DESCRIPTION
`importValueRegex` now can match more path formats

Resolves: #1568