### PR TITLE
增加选择redis的数据库的功能

### DIFF
--- a/core/stores/redis/conf.go
+++ b/core/stores/redis/conf.go
@@ -18,6 +18,7 @@ type (
 		Type string `json:",default=node,options=node|cluster"`
 		Pass string `json:",optional"`
 		Tls  bool   `json:",default=false,options=true|false"`
+		Db   int    `json:",default=0"`
 	}
 
 	// A RedisKeyConf is a redis config with key.
@@ -38,6 +39,9 @@ func (rc RedisConf) NewRedis() *Redis {
 	}
 	if rc.Tls {
 		opts = append(opts, WithTLS())
+	}
+	if rc.Db > 0 {
+		opts = append(opts, WithDb(rc.Db))
 	}
 
 	return New(rc.Host, opts...)

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -45,6 +45,7 @@ type (
 		Pass string
 		tls  bool
 		brk  breaker.Breaker
+		Db   int
 	}
 
 	// RedisNode interface represents a redis node.
@@ -1769,6 +1770,12 @@ func WithPass(pass string) Option {
 func WithTLS() Option {
 	return func(r *Redis) {
 		r.tls = true
+	}
+}
+
+func WithDb(db int) Option {
+	return func(r *Redis) {
+		r.Db = db
 	}
 }
 

--- a/core/stores/redis/redisclientmanager.go
+++ b/core/stores/redis/redisclientmanager.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io"
 
 	red "github.com/go-redis/redis"
@@ -17,7 +18,7 @@ const (
 var clientManager = syncx.NewResourceManager()
 
 func getClient(r *Redis) (*red.Client, error) {
-	val, err := clientManager.GetResource(r.Addr, func() (io.Closer, error) {
+	val, err := clientManager.GetResource(fmt.Sprintf("%s:%d", r.Addr, r.Db), func() (io.Closer, error) {
 		var tlsConfig *tls.Config
 		if r.tls {
 			tlsConfig = &tls.Config{
@@ -27,7 +28,7 @@ func getClient(r *Redis) (*red.Client, error) {
 		store := red.NewClient(&red.Options{
 			Addr:         r.Addr,
 			Password:     r.Pass,
-			DB:           defaultDatabase,
+			DB:           r.Db,
 			MaxRetries:   maxRetries,
 			MinIdleConns: idleConns,
 			TLSConfig:    tlsConfig,


### PR DESCRIPTION
当前redis模块无法通过配置文件或者redis.New()来选择数据库