### PR TITLE
fix: fix(gctl): apiparser_parser auto format

### DIFF
--- a/tools/goctl/api/parser/g4/gen/api/apiparser_parser.go
+++ b/tools/goctl/api/parser/g4/gen/api/apiparser_parser.go
@@ -634,6 +634,3 @@ func NewSyntaxLitContext(parser antlr.Parser, parent antlr.ParserRuleContext, in
 
 	return p
 }
-
-
-

--- a/tools/goctl/api/parser/g4/gen/api/file_splitor_test.go
+++ b/tools/goctl/api/parser/g4/gen/api/file_splitor_test.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"log"
 	"os"
@@ -61,7 +62,12 @@ import "github.com/zeromicro/antlr"
 			}
 		}
 
-		err = ioutil.WriteFile(fp, buffer.Bytes(), os.ModePerm)
+		src, err := format.Source(buffer.Bytes())
+		if err != nil {
+			fmt.Printf("%+v\n", err)
+			break
+		}
+		err = ioutil.WriteFile(fp, src, os.ModePerm)
 		if err != nil {
 			fmt.Printf("%+v\n", err)
 		}


### PR DESCRIPTION
Each time test `TestFileSplitor` is executed, an extra newline will be generated at the end of the file `apiparser_parser.go`. 