### PR TITLE
fix: the new  RawFieldNames considers the tag with options.

### DIFF
--- a/core/stores/builder/builder.go
+++ b/core/stores/builder/builder.go
@@ -41,10 +41,25 @@ func RawFieldNames(in interface{}, postgresSql ...bool) []string {
 				out = append(out, fmt.Sprintf("`%s`", fi.Name))
 			}
 		default:
-			if pg {
-				out = append(out, tagv)
+			//get tag name with the tag opton, e.g.:
+			//`db:"id"`
+			//`db:"id,type=char,length=16"`
+			//`db:",type=char,length=16"`
+			if strings.Contains(tagv, ",") {
+				tagv = strings.TrimSpace(strings.Split(tagv, ",")[0])
+			}
+			if tagv != "" {
+				if pg {
+					out = append(out, tagv)
+				} else {
+					out = append(out, fmt.Sprintf("`%s`", tagv))
+				}
 			} else {
-				out = append(out, fmt.Sprintf("`%s`", tagv))
+				if pg {
+					out = append(out, fi.Name)
+				} else {
+					out = append(out, fmt.Sprintf("`%s`", fi.Name))
+				}
 			}
 		}
 	}

--- a/core/stores/builder/builder_test.go
+++ b/core/stores/builder/builder_test.go
@@ -22,3 +22,20 @@ func TestFieldNames(t *testing.T) {
 		assert.Equal(t, expected, out)
 	})
 }
+
+type mockedUserWithOptions struct {
+	ID       string `db:"id" json:"id,omitempty"`
+	UserName string `db:"user_name,type=varchar,length=255" json:"userName,omitempty"`
+	Sex      int    `db:"sex" json:"sex,omitempty"`
+	UUID     string `db:",type=varchar,length=16" uuid:"uuid,omitempty"`
+	Age      int    `db:"age" json:"age"`
+}
+
+func TestFieldNamesWithTagOptions(t *testing.T) {
+	t.Run("new", func(t *testing.T) {
+		var u mockedUserWithOptions
+		out := RawFieldNames(&u)
+		expected := []string{"`id`", "`user_name`", "`sex`", "`UUID`", "`age`"}
+		assert.Equal(t, expected, out)
+	})
+}


### PR DESCRIPTION

The new function RawFieldNames  has considered the following that the tag could have option.

```go
//`db:"id"`
//`db:"id,type=char,length=16"`
//`db:",type=char,length=16"`

```