### PR TITLE
fix -cache=true insert no clean cache

### DIFF
--- a/tools/goctl/model/sql/gen/insert.go
+++ b/tools/goctl/model/sql/gen/insert.go
@@ -55,7 +55,6 @@ func genInsert(table Table, withCache, postgreSql bool) (string, string, error) 
 		Parse(text).
 		Execute(map[string]interface{}{
 			"withCache":             withCache,
-			"containsIndexCache":    table.ContainsUniqueCacheKey,
 			"upperStartCamelObject": camel,
 			"lowerStartCamelObject": stringx.From(camel).Untitle(),
 			"expression":            strings.Join(expressions, ", "),

--- a/tools/goctl/model/sql/template/insert.go
+++ b/tools/goctl/model/sql/template/insert.go
@@ -3,13 +3,11 @@ package template
 // Insert defines a template for insert code in model
 var Insert = `
 func (m *default{{.upperStartCamelObject}}Model) Insert(ctx context.Context, data *{{.upperStartCamelObject}}) (sql.Result,error) {
-	{{if .withCache}}{{if .containsIndexCache}}{{.keys}}
+	{{if .withCache}}{{.keys}}
     ret, err := m.ExecCtx(ctx, func(ctx context.Context, conn sqlx.SqlConn) (result sql.Result, err error) {
 		query := fmt.Sprintf("insert into %s (%s) values ({{.expression}})", m.table, {{.lowerStartCamelObject}}RowsExpectAutoSet)
 		return conn.ExecCtx(ctx, query, {{.expressionValues}})
 	}, {{.keyValues}}){{else}}query := fmt.Sprintf("insert into %s (%s) values ({{.expression}})", m.table, {{.lowerStartCamelObject}}RowsExpectAutoSet)
-    ret,err:=m.ExecNoCacheCtx(ctx, query, {{.expressionValues}})
-	{{end}}{{else}}query := fmt.Sprintf("insert into %s (%s) values ({{.expression}})", m.table, {{.lowerStartCamelObject}}RowsExpectAutoSet)
     ret,err:=m.conn.ExecCtx(ctx, query, {{.expressionValues}}){{end}}
 	return ret,err
 }


### PR DESCRIPTION
在生成model代码指定-cache=true时，如果表中只有主键没有其他唯一索引时候，insert是不删除缓存的，但是findone会查缓存，这样会有问题在findone不存在的数据时候会缓存* ，那先findone在insert就会有问题

When the generated model code specifies - cache = true, if there is only a primary key in the table and there is no other unique index, the insert will not delete the cache, but findone will check the cache, which will cause problems. If there is no data in findone, it will cache *, then findone will have problems in the insert first