### PR TITLE
update api gen go logic

### DIFF
--- a/tools/goctl/api/gogen/genlogic.go
+++ b/tools/goctl/api/gogen/genlogic.go
@@ -66,8 +66,8 @@ func genLogicByRoute(dir, rootPkg string, cfg *config.Config, group spec.Group, 
 	var requestString string
 	if len(route.ResponseTypeName()) > 0 {
 		resp := responseGoTypeName(route, typesPacket)
-		responseString = "(resp " + resp + ", err error)"
-		returnString = "return"
+		responseString = "(" + resp + ", error)"
+		returnString = "return " + responseReturnGoTypeName(route, typesPacket) + "{}, nil"
 	} else {
 		responseString = "error"
 		returnString = "return nil"

--- a/tools/goctl/api/gogen/util.go
+++ b/tools/goctl/api/gogen/util.go
@@ -161,6 +161,22 @@ func responseGoTypeName(r spec.Route, pkg ...string) string {
 	return resp
 }
 
+func responseReturnGoTypeName(r spec.Route, pkg ...string) string {
+	if r.ResponseType == nil {
+		return ""
+	}
+
+	resp := golangExpr(r.ResponseType, pkg...)
+	switch r.ResponseType.(type) {
+	case spec.DefineStruct:
+		if !strings.HasPrefix(resp, "*") {
+			return "&" + resp
+		}
+	}
+
+	return resp
+}
+
 func requestGoTypeName(r spec.Route, pkg ...string) string {
 	if r.RequestType == nil {
 		return ""


### PR DESCRIPTION
改之前 ![451647935256_ pic](https://user-images.githubusercontent.com/1277047/159433002-7b05db72-10f0-478b-8bf7-67226d0363e2.jpg)

改之后 ![471647935284_ pic](https://user-images.githubusercontent.com/1277047/159433007-0510b04a-ce67-4e84-b73a-23cbd75800b0.jpg)

改了之后， 更方便复制[这个](https://github.com/zeromicro/zero-doc/blob/main/doc/shorturl-en.md#7-modify-api-gateway-to-call-transform-rpc-service)的代码

```
  // manual code start
	resp, err := l.svcCtx.Transformer.Expand(l.ctx, &transformer.ExpandReq{
		Shorten: req.Shorten,
	})
	if err != nil {
		return nil, err
	}

	return &types.ExpandResp{
		Url: resp.Url,
	}, nil
  // manual code stop
```

直接复制到原来生成的函数体里，会报错，得做一些修改，才能编译通过

改之后，直接复制粘贴就可以了
