### PR TITLE
fix: empty slice are set to nil

### DIFF
--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -450,6 +450,12 @@ func (u *Unmarshaler) fillSlice(fieldType reflect.Type, value reflect.Value, map
 	refValue := reflect.ValueOf(mapValue)
 	conv := reflect.MakeSlice(reflect.SliceOf(baseType), refValue.Len(), refValue.Cap())
 
+	// support for empty slice
+	if !refValue.IsNil() && refValue.Len() == 0 {
+		value.Set(conv)
+		return nil
+	}
+
 	var valid bool
 	for i := 0; i < refValue.Len(); i++ {
 		ithValue := refValue.Index(i).Interface()

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -330,28 +330,34 @@ func TestUnmarshalFloat(t *testing.T) {
 
 func TestUnmarshalInt64Slice(t *testing.T) {
 	var v struct {
-		Ages []int64 `key:"ages"`
+		Ages  []int64 `key:"ages"`
+		Slice []int64 `key:"slice"`
 	}
 	m := map[string]interface{}{
-		"ages": []int64{1, 2},
+		"ages":  []int64{1, 2},
+		"slice": []interface{}{},
 	}
 
 	ast := assert.New(t)
 	ast.Nil(UnmarshalKey(m, &v))
 	ast.ElementsMatch([]int64{1, 2}, v.Ages)
+	ast.Equal([]int64{}, v.Slice)
 }
 
 func TestUnmarshalIntSlice(t *testing.T) {
 	var v struct {
-		Ages []int `key:"ages"`
+		Ages  []int `key:"ages"`
+		Slice []int `key:"slice"`
 	}
 	m := map[string]interface{}{
-		"ages": []int{1, 2},
+		"ages":  []int{1, 2},
+		"slice": []interface{}{},
 	}
 
 	ast := assert.New(t)
 	ast.Nil(UnmarshalKey(m, &v))
 	ast.ElementsMatch([]int{1, 2}, v.Ages)
+	ast.Equal([]int{}, v.Slice)
 }
 
 func TestUnmarshalString(t *testing.T) {


### PR DESCRIPTION
support for empty slce, Same behavior as json.Unmarshal

json.Unmarshal
```
%!p(logic.A={[]})
false
[]
```

code

```go
type A struct {
	AA []struct {
		C string
	}
}

var c = A{}
reader := io.LimitReader(strings.NewReader(`{"AA":[]}`), 10000)
err = mapping.UnmarshalJsonReader(reader, &c)
if err != nil {
	t.Fatal(err)
}

fmt.Printf("%#p\n", c)
fmt.Println(c.AA == nil)
fmt.Println(c.AA)
```


before:

```
%!p(logic.A={[]})
true
[]
```

after:

```
%!p(logic.A={[]})
false
[]
```