### PR TITLE
Added support for setting the parameter size accepted by the interface and custom timeout and maxbytes in API file

### DIFF
--- a/rest/engine.go
+++ b/rest/engine.go
@@ -94,7 +94,7 @@ func (ng *engine) bindRoute(fr featuredRoutes, router httpx.Router, metrics *sta
 		handler.TimeoutHandler(ng.checkedTimeout(fr.timeout)),
 		handler.RecoverHandler,
 		handler.MetricHandler(metrics),
-		handler.MaxBytesHandler(ng.conf.MaxBytes),
+		handler.MaxBytesHandler(ng.checkedMaxBytes(fr.maxBytes)),
 		handler.GunzipHandler,
 	)
 	chain = ng.appendAuthHandler(fr, chain, verifier)
@@ -125,6 +125,15 @@ func (ng *engine) checkedTimeout(timeout time.Duration) time.Duration {
 	}
 
 	return time.Duration(ng.conf.Timeout) * time.Millisecond
+}
+
+func (ng *engine) checkedMaxBytes(bytes int64) int64 {
+
+	if bytes > 0 {
+		return bytes
+	}
+
+	return ng.conf.MaxBytes
 }
 
 func (ng *engine) createMetrics() *stat.Metrics {

--- a/rest/engine_test.go
+++ b/rest/engine_test.go
@@ -194,6 +194,41 @@ func TestEngine_checkedTimeout(t *testing.T) {
 	}
 }
 
+func TestEngine_checkedMaxBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxBytes int64
+		expect   int64
+	}{
+		{
+			name:   "not set",
+			expect: 1000,
+		},
+		{
+			name:     "less",
+			maxBytes: 500,
+			expect:   500,
+		},
+		{
+			name:     "equal",
+			maxBytes: 1000,
+			expect:   1000,
+		},
+		{
+			name:     "more",
+			maxBytes: 1500,
+			expect:   1500,
+		},
+	}
+
+	ng := newEngine(RestConf{
+		MaxBytes: 1000,
+	})
+	for _, test := range tests {
+		assert.Equal(t, test.expect, ng.checkedMaxBytes(test.maxBytes))
+	}
+}
+
 func TestEngine_notFoundHandler(t *testing.T) {
 	logx.Disable()
 

--- a/rest/server.go
+++ b/rest/server.go
@@ -223,6 +223,13 @@ func WithTimeout(timeout time.Duration) RouteOption {
 	}
 }
 
+// WithMaxBytes returns a RouteOption to set maxBytes with given value.
+func WithMaxBytes(maxBytes int64) RouteOption {
+	return func(r *featuredRoutes) {
+		r.maxBytes = maxBytes
+	}
+}
+
 // WithTLSConfig returns a RunOption that with given tls config.
 func WithTLSConfig(cfg *tls.Config) RunOption {
 	return func(svr *Server) {

--- a/rest/types.go
+++ b/rest/types.go
@@ -36,5 +36,6 @@ type (
 		jwt       jwtSetting
 		signature signatureSetting
 		routes    []Route
+		maxBytes  int64
 	}
 )

--- a/tools/goctl/api/gogen/genroutes.go
+++ b/tools/goctl/api/gogen/genroutes.go
@@ -35,7 +35,7 @@ func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
 `
 	routesAdditionTemplate = `
 	server.AddRoutes(
-		{{.routes}} {{.jwt}}{{.signature}} {{.prefix}} {{.timeout}} {{.maxBytes}}
+		{{.routes}} {{.jwt}}{{.signature}} {{.prefix}} {{.timeout}}
 	)
 `
 )
@@ -58,8 +58,6 @@ type (
 		jwtEnabled       bool
 		signatureEnabled bool
 		authName         string
-		maxBytes         string
-		maxBytesEnable   bool
 		timeout          string
 		timeoutEnable    bool
 		middlewares      []string
@@ -124,11 +122,6 @@ rest.WithPrefix("%s"),`, g.prefix)
 			timeout = fmt.Sprintf("rest.WithTimeout(%d),", duration)
 		}
 
-		var maxBytes string
-		if g.maxBytesEnable {
-			maxBytes = fmt.Sprintf("rest.WithMaxBytes(%s),", g.maxBytes)
-		}
-
 		var routes string
 		if len(g.middlewares) > 0 {
 			gbuilder.WriteString("\n}...,")
@@ -149,7 +142,6 @@ rest.WithPrefix("%s"),`, g.prefix)
 			"jwt":       jwt,
 			"signature": signature,
 			"prefix":    prefix,
-			"maxBytes":  maxBytes,
 			"timeout":   timeout,
 		}); err != nil {
 			return err
@@ -225,13 +217,7 @@ func getRoutes(api *spec.ApiSpec) ([]group, error) {
 				handler: handler,
 			})
 		}
-		// 获取maxBytes
-		maxBytes := g.GetAnnotation("maxBytes")
-		if len(maxBytes) > 0 {
-			groupedRoutes.maxBytesEnable = true
-			groupedRoutes.maxBytes = maxBytes
-		}
-		// 获取timeout
+
 		timeout := g.GetAnnotation("timeout")
 
 		if len(timeout) > 0 {


### PR DESCRIPTION
It can be used like this
```go
func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
	server.AddRoutes(
		[]rest.Route{
			{
				Method:  http.MethodPost,
				Path:    "/upload",
				Handler: UploadHandler(serverCtx),
			},
		},
		rest.WithMaxBytes(52428800),
	)
}
```

custom timeout and maxbytes in api file can be used like this
The unit of timeout is `time.Second`

```go
@server(
	timeout: 2
	maxBytes: 1234
	group: user
)
service user {
	@handler getUser // etst
	get /users/id (request) returns (response)
}
```

general code 
```go
// Code generated by goctl. DO NOT EDIT.
package handler

import (
	"net/http"
	"time"

	user "joj-backend/api/internal/handler/user"
	"joj-backend/api/internal/svc"

	"github.com/zeromicro/go-zero/rest"
)

func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
	server.AddRoutes(
		[]rest.Route{
			{
				Method:  http.MethodGet,
				Path:    "/users/id",
				Handler: user.GetUserHandler(serverCtx),
			},
		}, rest.WithTimeout(2*time.Second), rest.WithMaxBytes(1234),
	)
}
```
