### PR TITLE
update goctl rpc protoc --help usage text

### DIFF
--- a/tools/goctl/goctl.go
+++ b/tools/goctl/goctl.go
@@ -558,7 +558,7 @@ var commands = []cli.Command{
 			{
 				Name:        "protoc",
 				Usage:       "generate grpc code",
-				UsageText:   `example: goctl rpc protoc xx.proto --go_out=./pb --go-grpc_out=./pb --zrpc_out=.`,
+				UsageText:   `example: goctl rpc protoc *.proto --go_out=. --go-grpc_out=. --zrpc_out=.`,
 				Description: "for details, see https://go-zero.dev/cn/goctl-rpc.html",
 				Action:      rpc.ZRPC,
 				Flags: []cli.Flag{


### PR DESCRIPTION
对应文档中的方式二的工作流程
https://go-zero.dev/cn/goctl-rpc.html

1.  goctl 生成一个.proto 文件后
2. 修改proto文件
3. 运行 goctl rpc protoc --help，然后复制这个help信息的命令直接运行就可以了

这样做的好处是 只需修改message 和 service 定义 .proto 文件前面的 option go_pacakge 啥的都不用动
定义好proto文件之后，只需在.proto 所在的文件夹里复制help信息里的`goctl rpc protoc *.proto --go_out=. --go-grpc_out=. --zrpc_out=.` 直接就可以运行
对不清楚这些参数 --go_out=. --go-grpc_out=. --zrpc_out=. 具体含义的新手更友好

对新人来 先按流程跑起来比较重要，细节后面再慢慢了解
