### PR TITLE
fix bug: crash when generate model with goctl.

### DIFF
--- a/tools/goctl/util/stringx/string.go
+++ b/tools/goctl/util/stringx/string.go
@@ -59,6 +59,7 @@ func (s String) Title() string {
 
 // ToCamel converts the input text into camel case
 func (s String) ToCamel() string {
+	s.source = strings.ReplaceAll(s.source, "-", "_")
 	list := s.splitBy(func(r rune) bool {
 		return r == '_'
 	}, true)


### PR DESCRIPTION
situation: column name with line.

CREATE TABLE `test` (
  `id` int NOT NULL AUTO_INCREMENT,
  `zh-cn` text CHARACTER SET utf8 COLLATE utf8_general_ci COMMENT '中文简体',
  PRIMARY KEY (`id`) USING BTREE,
) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;