### PR TITLE
feat: add mapping config for filesystem

### DIFF
--- a/rest/engine_test.go
+++ b/rest/engine_test.go
@@ -312,3 +312,6 @@ func (m mockedRouter) SetNotFoundHandler(handler http.Handler) {
 
 func (m mockedRouter) SetNotAllowedHandler(handler http.Handler) {
 }
+
+func (m mockedRouter) SetFileSystemHandlerMap(handlerMap map[string]http.Handler) {
+}

--- a/rest/httpx/router.go
+++ b/rest/httpx/router.go
@@ -8,4 +8,5 @@ type Router interface {
 	Handle(method, path string, handler http.Handler) error
 	SetNotFoundHandler(handler http.Handler)
 	SetNotAllowedHandler(handler http.Handler)
+	SetFileSystemHandlerMap(handlerMap map[string]http.Handler)
 }

--- a/rest/server.go
+++ b/rest/server.go
@@ -183,6 +183,13 @@ func WithNotAllowedHandler(handler http.Handler) RunOption {
 	}
 }
 
+// WithSetFileSystemHandlerMap returns a RunOption with file system handler map set to given handler.
+func WithSetFileSystemHandlerMap(handlerMap map[string]http.Handler) RunOption {
+	return func(server *Server) {
+		server.router.SetFileSystemHandlerMap(handlerMap)
+	}
+}
+
 // WithPrefix adds group as a prefix to the route paths.
 func WithPrefix(group string) RouteOption {
 	return func(r *featuredRoutes) {

--- a/rest/server_test.go
+++ b/rest/server_test.go
@@ -43,6 +43,10 @@ Port: 54321
 		},
 		{
 			c:    cnf,
+			opts: []RunOption{WithRouter(mockedRouter{}), WithSetFileSystemHandlerMap(nil)},
+		},
+		{
+			c:    cnf,
 			opts: []RunOption{WithNotFoundHandler(nil), WithRouter(mockedRouter{})},
 		},
 		{


### PR DESCRIPTION
I wanna using go:embed to serve some static file. So I add a feature. SetFileSystemHandlerMap can make serve handle static file like below

```go
dist, _ := fs.Sub(dist, "dist")
a, _ := fs.Sub(a, "a")
b, _ := fs.Sub(b, "b")
cc := os.DirFS("/some/dir")

frontendFSMap["/"] = http.StripPrefix("/", http.FileServer(http.FS(dist)))
frontendFSMap["/a/a"] = http.StripPrefix("/a/a", http.FileServer(http.FS(a)))
frontendFSMap["/a/b"] = http.StripPrefix("/a/b", http.FileServer(http.FS(b)))
frontendFSMap["/c"] = http.StripPrefix("/c", http.FileServer(http.FS(cc)))
```