### PR TITLE
feat: Support model code generation for multi tables

### DIFF
--- a/tools/goctl/goctl.go
+++ b/tools/goctl/goctl.go
@@ -725,7 +725,7 @@ var commands = []cli.Command{
 								Name:  "url",
 								Usage: `the data source of database,like "root:password@tcp(127.0.0.1:3306)/database"`,
 							},
-							cli.StringFlag{
+							cli.StringSliceFlag{
 								Name:  "table, t",
 								Usage: `the table or table globbing patterns in the database`,
 							},

--- a/tools/goctl/model/sql/command/command.go
+++ b/tools/goctl/model/sql/command/command.go
@@ -97,9 +97,9 @@ func MySqlDataSource(ctx *cli.Context) error {
 	return fromMysqlDataSource(url, dir, patterns, cfg, cache, idea)
 }
 
-type Patterns map[string]struct{}
+type patterns map[string]struct{}
 
-func (p Patterns) Match(s string) bool {
+func (p patterns) Match(s string) bool {
 	for v := range p {
 		match, err := filepath.Match(v, s)
 		if err != nil {
@@ -113,7 +113,7 @@ func (p Patterns) Match(s string) bool {
 	return false
 }
 
-func (p Patterns) list() []string {
+func (p patterns) list() []string {
 	var ret []string
 	for v := range p {
 		ret = append(ret, v)
@@ -121,8 +121,8 @@ func (p Patterns) list() []string {
 	return ret
 }
 
-func parseTableList(tableValue []string) Patterns {
-	tablePattern := make(Patterns)
+func parseTableList(tableValue []string) patterns {
+	tablePattern := make(patterns)
 	for _, v := range tableValue {
 		fields := strings.FieldsFunc(v, func(r rune) bool {
 			return r == ','
@@ -200,7 +200,7 @@ func fromDDL(src, dir string, cfg *config.Config, cache, idea bool, database str
 	return nil
 }
 
-func fromMysqlDataSource(url, dir string, patterns Patterns, cfg *config.Config, cache, idea bool) error {
+func fromMysqlDataSource(url, dir string, patterns patterns, cfg *config.Config, cache, idea bool) error {
 	log := console.NewConsole(idea)
 	if len(url) == 0 {
 		log.Error("%v", "expected data source of mysql, but nothing found")

--- a/tools/goctl/model/sql/command/command.go
+++ b/tools/goctl/model/sql/command/command.go
@@ -97,9 +97,9 @@ func MySqlDataSource(ctx *cli.Context) error {
 	return fromMysqlDataSource(url, dir, patterns, cfg, cache, idea)
 }
 
-type patterns map[string]struct{}
+type pattern map[string]struct{}
 
-func (p patterns) Match(s string) bool {
+func (p pattern) Match(s string) bool {
 	for v := range p {
 		match, err := filepath.Match(v, s)
 		if err != nil {
@@ -113,7 +113,7 @@ func (p patterns) Match(s string) bool {
 	return false
 }
 
-func (p patterns) list() []string {
+func (p pattern) list() []string {
 	var ret []string
 	for v := range p {
 		ret = append(ret, v)
@@ -121,8 +121,8 @@ func (p patterns) list() []string {
 	return ret
 }
 
-func parseTableList(tableValue []string) patterns {
-	tablePattern := make(patterns)
+func parseTableList(tableValue []string) pattern {
+	tablePattern := make(pattern)
 	for _, v := range tableValue {
 		fields := strings.FieldsFunc(v, func(r rune) bool {
 			return r == ','
@@ -200,14 +200,14 @@ func fromDDL(src, dir string, cfg *config.Config, cache, idea bool, database str
 	return nil
 }
 
-func fromMysqlDataSource(url, dir string, patterns patterns, cfg *config.Config, cache, idea bool) error {
+func fromMysqlDataSource(url, dir string, tablePat pattern, cfg *config.Config, cache, idea bool) error {
 	log := console.NewConsole(idea)
 	if len(url) == 0 {
 		log.Error("%v", "expected data source of mysql, but nothing found")
 		return nil
 	}
 
-	if len(patterns) == 0 {
+	if len(tablePat) == 0 {
 		log.Error("%v", "expected table or table globbing patterns, but nothing found")
 		return nil
 	}
@@ -229,7 +229,7 @@ func fromMysqlDataSource(url, dir string, patterns patterns, cfg *config.Config,
 
 	matchTables := make(map[string]*model.Table)
 	for _, item := range tables {
-		if !patterns.Match(item) {
+		if !tablePat.Match(item) {
 			continue
 		}
 

--- a/tools/goctl/model/sql/command/command_test.go
+++ b/tools/goctl/model/sql/command/command_test.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,4 +87,31 @@ func TestFromDDl(t *testing.T) {
 	fromDDL("go-zero")
 	_ = os.Remove(filename)
 	fromDDL("1gozero")
+}
+
+func Test_parseTableList(t *testing.T) {
+	testData := []string{"foo", "b*", "bar", "back_up", "foo,bar,b*"}
+	patterns := parseTableList(testData)
+	actual := patterns.list()
+	expected := []string{"foo", "b*", "bar", "back_up"}
+	sort.Slice(actual, func(i, j int) bool {
+		return actual[i] > actual[j]
+	})
+	sort.Slice(expected, func(i, j int) bool {
+		return expected[i] > expected[j]
+	})
+	assert.Equal(t, strings.Join(expected, ","), strings.Join(actual, ","))
+
+	matchTestData := map[string]bool{
+		"foo":     true,
+		"bar":     true,
+		"back_up": true,
+		"bit":     true,
+		"ab":      false,
+		"b":       true,
+	}
+	for v, expected := range matchTestData {
+		actual := patterns.Match(v)
+		assert.Equal(t, expected, actual)
+	}
 }


### PR DESCRIPTION
# Features
See #1794

# Tables
```
+------------------+
| Tables_in_gozero |
+------------------+
| user             |
| order            |
| pay              |
| after_sale       |
| product          |
+------------------+
```

# before

## generates with single table

```shell
$ goctl model mysql datasource --table user --dir .
```

```
$ tree
.
├── usermodel.go
└── usermodel_gen.go
```

## generates with table patterns

```shell
$ goctl model mysql datasource --table="*er" --dir .
```

```
$ tree
.
├── ordermodel.go
├── ordermodel_gen.go
├── usermodel.go
└── usermodel_gen.go
```

# after

## generates with single table & patterns

The same way to generate single table to before

## generates with multi-tables

way 1:

```shell
$ goctl model mysql datasource --table user --table order --dir .
```

way 2:

```shell
$ goctl model mysql datasource --table="user,order"
```

## generates with multi-tables and patterns

```shell
$ goctl model mysql datasource --table user --table="*er"
```

Result:

```
$ tree
.
├── ordermodel.go
├── ordermodel_gen.go
├── usermodel.go
└── usermodel_gen.go
```