### PR TITLE
Modify the type of secret in JWT

### DIFF
--- a/rest/engine.go
+++ b/rest/engine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/justinas/alice"
@@ -54,7 +55,15 @@ func (ng *engine) addRoutes(r featuredRoutes) {
 func (ng *engine) appendAuthHandler(fr featuredRoutes, chain alice.Chain,
 	verifier func(alice.Chain) alice.Chain) alice.Chain {
 	if fr.jwt.enabled {
-		if len(fr.jwt.prevSecret) == 0 {
+		//check prevSecret whether exists,if only can be string or pointer
+		var hasPreSecret bool
+		if prevSecretStr, ok := fr.jwt.prevSecret.(string); ok && len(prevSecretStr) > 0 {
+			hasPreSecret = true
+		}
+		if reflect.ValueOf(fr.jwt.prevSecret).Kind() == reflect.Ptr && fr.jwt.prevSecret != nil {
+			hasPreSecret = true
+		}
+		if hasPreSecret {
 			chain = chain.Append(handler.Authorize(fr.jwt.secret,
 				handler.WithUnauthorizedCallback(ng.unauthorizedCallback)))
 		} else {

--- a/rest/handler/authhandler.go
+++ b/rest/handler/authhandler.go
@@ -31,7 +31,7 @@ var (
 type (
 	// A AuthorizeOptions is authorize options.
 	AuthorizeOptions struct {
-		PrevSecret string
+		PrevSecret interface{}
 		Callback   UnauthorizedCallback
 	}
 
@@ -42,7 +42,7 @@ type (
 )
 
 // Authorize returns an authorization middleware.
-func Authorize(secret string, opts ...AuthorizeOption) func(http.Handler) http.Handler {
+func Authorize(secret interface{}, opts ...AuthorizeOption) func(http.Handler) http.Handler {
 	var authOpts AuthorizeOptions
 	for _, opt := range opts {
 		opt(&authOpts)
@@ -84,7 +84,7 @@ func Authorize(secret string, opts ...AuthorizeOption) func(http.Handler) http.H
 }
 
 // WithPrevSecret returns an AuthorizeOption with setting previous secret.
-func WithPrevSecret(secret string) AuthorizeOption {
+func WithPrevSecret(secret interface{}) AuthorizeOption {
 	return func(opts *AuthorizeOptions) {
 		opts.PrevSecret = secret
 	}

--- a/rest/server.go
+++ b/rest/server.go
@@ -116,7 +116,7 @@ func WithCustomCors(middlewareFn func(header http.Header), notAllowedFn func(htt
 }
 
 // WithJwt returns a func to enable jwt authentication in given route.
-func WithJwt(secret string) RouteOption {
+func WithJwt(secret interface{}) RouteOption {
 	return func(r *featuredRoutes) {
 		validateSecret(secret)
 		r.jwt.enabled = true
@@ -126,7 +126,7 @@ func WithJwt(secret string) RouteOption {
 
 // WithJwtTransition returns a func to enable jwt authentication as well as jwt secret transition.
 // Which means old and new jwt secrets work together for a period.
-func WithJwtTransition(secret, prevSecret string) RouteOption {
+func WithJwtTransition(secret interface{}, prevSecret interface{}) RouteOption {
 	return func(r *featuredRoutes) {
 		// why not validate prevSecret, because prevSecret is an already used one,
 		// even it not meet our requirement, we still need to allow the transition.
@@ -261,8 +261,10 @@ func handleError(err error) {
 	panic(err)
 }
 
-func validateSecret(secret string) {
-	if len(secret) < 8 {
-		panic("secret's length can't be less than 8")
+func validateSecret(secret interface{}) {
+	if secretStr, ok := secret.(string); ok {
+		if len(secretStr) < 8 {
+			panic("secret's length can't be less than 8")
+		}
 	}
 }

--- a/rest/token/tokenparser.go
+++ b/rest/token/tokenparser.go
@@ -78,10 +78,14 @@ func (tp *TokenParser) ParseToken(r *http.Request, secret, prevSecret string) (*
 	return token, nil
 }
 
-func (tp *TokenParser) doParseToken(r *http.Request, secret string) (*jwt.Token, error) {
+func (tp *TokenParser) doParseToken(r *http.Request, secret interface{}) (*jwt.Token, error) {
 	return request.ParseFromRequest(r, request.AuthorizationHeaderExtractor,
 		func(token *jwt.Token) (interface{}, error) {
-			return []byte(secret), nil
+			if secretByte, ok := secret.(string); ok {
+				return []byte(secretByte), nil
+			} else {
+				return secret, nil
+			}
 		}, request.WithParser(newParser()))
 }
 

--- a/rest/token/tokenparser_test.go
+++ b/rest/token/tokenparser_test.go
@@ -11,6 +11,58 @@ import (
 	"github.com/zeromicro/go-zero/core/timex"
 )
 
+const privateSecret = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDnfKw2I9iHe5JK
+T7o3FLP7vY3jDTB+5Ey/T7k8Hp6IqEOBUcpc+ECuMKoTYzNLQvMMgcL4+qauZHEO
+pKSx0n0CwFP8kkYpDH4Y0JvIueV7IE+0ZqHqysDH1lU1MhqrPPk5676kVpFSvEek
+7fWaZG4NhpwYbiYuZoWjaOcJDlE2vmnicWVv5iYwhtUtpuXMhgMIVSoxzgUOlLSl
+LC7eBAYXLL+IloZpdRjWv0gVxU5Odvlh4tHqaaqGLiNW6zqUprvVCSBVvjiBBY65
+GuDvtQ2sv6bGReDts/hZAUqB9xTXQWK4YcIka9dXnJ9WZlAY4P5np3WiBBY6Z14h
+pdekOMo3AgMBAAECggEAa+6gaRnrkrgWLJnh7F610LHAH1Z9/xw5gJYOey6XooY5
++2kEXrbNiapdEm8VcokDxBgYrXhJEVT5teckd1j6OrcsMb6OAgO2I6HYkQ3EJtWY
+9DdKVaw1mLehwQzcjG0Ak3YMzJkkZxwsl4TwGA2tlpbl3yo0mTvqIZf+6SUIzum0
+TUlDwnNRqPUU0worN9cgmVY8iwvFB9TFfjUcq0e8oKd2RTcK1y5PWhE16s2iqQqp
+kbdFetT24+fNcI1LZBvrUVhYsGCSK9sNvaA9jKUJ3NHcX7iXc5eVBc2MB5x9Uoon
+6U/UHIdFsvDu4u7Em3XmJLHsZA030IFlLaaAg1EQaQKBgQD9A/MOfcwxoz5F73F2
+vo7HFUVcRVDQD8dowoqQfld+hNcZVYlMbBxs+JqNiXMox2aUNgJioYHNMFns6KQJ
+1gleRWOW/XLzIiCX688POJyPJAXMM3MRido1oTZbPT3FQuE3s6vxOpAMzpWmd9vq
+VoH0bMkW6QKzJb2voO6lpCVVVQKBgQDqN7ZR0iXZzsQxPkR2HfB2FDsTn+WRhd7J
+WeaaNOkLCFW99AGW3ShcTyNp3I8GKfNcbiErEEjwuPloN4xZeVg2Lu2LFNegt+5+
+NNZemvu4gEzdlawWJ9lAt3PsovHJO7Fad1zF/ogezBgwn+T5PWla+K507IyAVHMT
+8M3/jyWhWwKBgFZW7q5XR0L5DdsXpoR66oYNQCoIjVcyyz14hYhhVMIb2rsOcVfe
+3KRjAXqjGOUlhl+1PoMh0gWPJmCt0qx4maHN0/pGat+FGdI96d6r1uERzditBetK
+O2hppv7jmxyhgfFcIqSi810rce3ooOcKtjYOmWB0CzPPATfZlxZ3OTYxAoGAeX36
+sciLX8b0WALPqmFvWSC3YD+h6nGBlfpvNvBZLiLdrxHCPUps5C0c1o3VFsJt/TUX
+OWpSG6Qno1qlD8h07G49Q9bE3xZpvMeVpy9HgXXz6UD5KejztbEzjb0cJGE1ZxLh
+acbVPvxpU9etA2hKnSi//eCyJOMpal+Py4+qWl8CgYBSCrw+sae1x0tHYaO6Nrvs
+sN682QT+oBvfU80+IN49CRcB6MS/8RyOqI29FsShPydauyCV4jl+EpXucf20m2Qb
+lkeE4QCcWaCltaDvYFeWOCXtv7jQQwTSRafLJFt3lJLNn8zf7Mjyckp12DREkROd
+0YDdOe3wXidBuP9PY4FJWQ==
+-----END PRIVATE KEY-----
+`
+
+const publicSecret = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA53ysNiPYh3uSSk+6NxSz
++72N4w0wfuRMv0+5PB6eiKhDgVHKXPhArjCqE2MzS0LzDIHC+PqmrmRxDqSksdJ9
+AsBT/JJGKQx+GNCbyLnleyBPtGah6srAx9ZVNTIaqzz5Oeu+pFaRUrxHpO31mmRu
+DYacGG4mLmaFo2jnCQ5RNr5p4nFlb+YmMIbVLablzIYDCFUqMc4FDpS0pSwu3gQG
+Fyy/iJaGaXUY1r9IFcVOTnb5YeLR6mmqhi4jVus6lKa71QkgVb44gQWOuRrg77UN
+rL+mxkXg7bP4WQFKgfcU10FiuGHCJGvXV5yfVmZQGOD+Z6d1ogQWOmdeIaXXpDjK
+NwIDAQAB
+-----END PUBLIC KEY-----
+`
+
+const publicPreSecret = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1UVZIUsajbnEOfad37X8
+GdpfkNZNxwZ4aqySb1AwyOUiJv4/tMzUxXb+ZxGtk6hj+35MDAvRJbhFWGc3cyui
+1kwTDIHzXzx0I4uadknlJ0dJx+rupkfJZvvP9ECpLdgAPR1+HAzJsx4BM5cJXMNp
+9fK2dGdYqEdPmUbxENYNUQdzlWCTo1Md3ETPBONS0Q2pBDip0upSczzR2qLJ9O2V
+Fyq4Y59FDAXWP8BGSvv/IRT3AOiWVa0SUIcax14iFRZEJ9uvl8/e1isErsHXpA5X
+NTjld9jgf+8mCynWhr2xuG8PHsAUP0eIain/zEj8xQVfYK1/7D1K4qNa3ugzltJ0
+OwIDAQAB
+-----END PUBLIC KEY-----
+`
+
 func TestTokenParser(t *testing.T) {
 	const (
 		key     = "14F17379-EB8F-411B-8F12-6929002DCA76"
@@ -68,6 +120,63 @@ func TestTokenParser_Expired(t *testing.T) {
 	tok, err = parser.ParseToken(req, key, prevKey)
 	assert.Nil(t, err)
 	assert.Equal(t, "value", tok.Claims.(jwt.MapClaims)["key"])
+}
+
+func TestTokenParser_WithPemFile(t *testing.T) {
+	const (
+		key     = publicSecret
+		prevKey = publicPreSecret
+	)
+	keys := []struct {
+		key     string
+		prevKey string
+	}{
+		{
+			key,
+			prevKey,
+		},
+		{
+			key,
+			"",
+		},
+	}
+	for _, pair := range keys {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		encodeKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(privateSecret))
+		assert.Nil(t, err)
+		token, err := buildPemToken(encodeKey, map[string]interface{}{
+			"key": "value",
+		}, 3600)
+		assert.Nil(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		parser := NewTokenParser(WithResetDuration(time.Minute))
+		decodeKey, err := jwt.ParseRSAPublicKeyFromPEM([]byte(pair.key))
+		assert.Nil(t, err)
+		var decodePreKey interface{}
+		decodePreKey = ""
+		if len(pair.prevKey) > 0 {
+			decodePreKey, err = jwt.ParseRSAPublicKeyFromPEM([]byte(pair.prevKey))
+			assert.Nil(t, err)
+		}
+		tok, err := parser.ParseToken(req, decodeKey, decodePreKey)
+		assert.Nil(t, err)
+		assert.Equal(t, "value", tok.Claims.(jwt.MapClaims)["key"])
+	}
+}
+
+// generate public key
+func buildPemToken(pem interface{}, payloads map[string]interface{}, seconds int64) (string, error) {
+	now := time.Now().Unix()
+	claims := make(jwt.MapClaims)
+	claims["exp"] = now + seconds
+	claims["iat"] = now
+	for k, v := range payloads {
+		claims[k] = v
+	}
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Claims = claims
+	// 继续添加秘钥值，生成最后一部分
+	return token.SignedString(pem)
 }
 
 func buildToken(secretKey string, payloads map[string]interface{}, seconds int64) (string, error) {

--- a/rest/types.go
+++ b/rest/types.go
@@ -21,8 +21,8 @@ type (
 
 	jwtSetting struct {
 		enabled    bool
-		secret     string
-		prevSecret string
+		secret     interface{}
+		prevSecret interface{}
 	}
 
 	signatureSetting struct {


### PR DESCRIPTION
如果需要自定义jwt的secret，可以在goctl中自定义routers的模板，添加如下函数,不需要自定义secret的用户也可以无感升级
```golang
func getJwtSecret(serverCtx *svc.ServiceContext) interface{}{
	fileByte, _ := ioutil.ReadFile("jwt_public_key.pem")
        pem, _ := jwt.ParseRSAPublicKeyFromPEM(fileByte)
	return  pem
}

rest.WithJwt(getJwtSecret(serverCtx)),
```