### PR TITLE
fix: Code generation

### DIFF
--- a/tools/goctl/model/sql/gen/gen.go
+++ b/tools/goctl/model/sql/gen/gen.go
@@ -65,7 +65,7 @@ func NewDefaultGenerator(dir string, cfg *config.Config, opt ...Option) (*defaul
 	}
 
 	dir = dirAbs
-	pkg := filepath.Base(dirAbs)
+	pkg := util.SafeString(filepath.Base(dirAbs))
 	err = pathx.MkdirIfNotExist(dir)
 	if err != nil {
 		return nil, err

--- a/tools/goctl/util/ctx/gomod.go
+++ b/tools/goctl/util/ctx/gomod.go
@@ -13,6 +13,10 @@ import (
 	"github.com/zeromicro/go-zero/tools/goctl/util/pathx"
 )
 
+const goModuleWithoutGoFiles = "command-line-arguments"
+
+var errInvalidGoMod = errors.New("invalid go module")
+
 // Module contains the relative data of go module,
 // which is the result of the command go list
 type Module struct {
@@ -21,6 +25,13 @@ type Module struct {
 	Dir       string
 	GoMod     string
 	GoVersion string
+}
+
+func (m *Module) validate() error {
+	if m.Path == goModuleWithoutGoFiles || m.Dir == "" {
+		return errInvalidGoMod
+	}
+	return nil
 }
 
 // projectFromGoMod is used to find the go module and project file path
@@ -41,6 +52,9 @@ func projectFromGoMod(workDir string) (*ProjectContext, error) {
 
 	m, err := getRealModule(workDir, execx.Run)
 	if err != nil {
+		return nil, err
+	}
+	if err := m.validate(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
### 1. Fix model code generation 
The package name of model comes from the name of the output directory. If this value does not satisfy the golang naming convention, it will cause code generation to fail, so we must handle this value effectively。

### 2. Invalid go module value
If the target path is not in any go module mode and is not under GOPATH, the module value obtained by executing go list -json -m is `command-line-arguments`, which is not a valid go module value and needs to be handled effectively to prevent
```shell
$ GO111MODULE=on go list -json -m
{
	"Path": "command-line-arguments",
	"Main": true,
	"GoVersion": "1.18"
}
```