### PR TITLE
fix: panic on convert to string on fillSliceFromString()

### DIFF
--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -498,8 +498,15 @@ func (u *Unmarshaler) fillSlice(fieldType reflect.Type, value reflect.Value, map
 
 func (u *Unmarshaler) fillSliceFromString(fieldType reflect.Type, value reflect.Value, mapValue interface{}) error {
 	var slice []interface{}
-	if err := jsonx.UnmarshalFromString(mapValue.(string), &slice); err != nil {
-		return err
+	switch v := mapValue.(type) {
+	case json.Number:
+		if err := jsonx.UnmarshalFromString(v.String(), &slice); err != nil {
+			return err
+		}
+	default:
+		if err := jsonx.UnmarshalFromString(mapValue.(string), &slice); err != nil {
+			return err
+		}
 	}
 
 	baseFieldType := Deref(fieldType.Elem())

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -2791,7 +2791,7 @@ func BenchmarkDefaultValue(b *testing.B) {
 }
 
 func TestUnmarshalJsonReaderArray(t *testing.T) {
-	payload := "{\"id\": [123]}"
+	payload := "{\"id\": 123}"
 	var res struct {
 		ID []string   `json:"id"`
 	}

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -2789,3 +2789,14 @@ func BenchmarkDefaultValue(b *testing.B) {
 		}
 	}
 }
+
+func TestUnmarshalJsonReaderArray(t *testing.T) {
+	payload := "{\"id\": [123]}"
+	var res struct {
+		ID []string   `json:"id"`
+	}
+	reader := strings.NewReader(payload)
+	err := UnmarshalJsonReader(reader, &res)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(res.ID))
+}


### PR DESCRIPTION
 fix: 修复fillSliceFromString()方法中mapValue 强转string后的panic 错误