### PR TITLE
fix goctl api clone template fail

### DIFF
--- a/tools/goctl/api/cmd.go
+++ b/tools/goctl/api/cmd.go
@@ -97,7 +97,7 @@ func init() {
 		" template, --home and --remote cannot be set at the same time, if they are, --remote has higher"+
 		" priority\n\tThe git repo directory must be consistent with the"+
 		" https://github.com/zeromicro/go-zero-template directory structure")
-	Cmd.Flags().StringVar(&apigen.VarStringBranch, "branch", "master", "The branch of the "+
+	Cmd.Flags().StringVar(&apigen.VarStringBranch, "branch", "", "The branch of the "+
 		"remote repo, it does work with --remote")
 
 	dartCmd.Flags().StringVar(&dartgen.VarStringDir, "dir", "", "The target dir")
@@ -124,7 +124,7 @@ func init() {
 		"of the template, --home and --remote cannot be set at the same time, if they are, --remote"+
 		" has higher priority\n\tThe git repo directory must be consistent with the "+
 		"https://github.com/zeromicro/go-zero-template directory structure")
-	goCmd.Flags().StringVar(&gogen.VarStringBranch, "branch", "master", "The branch of "+
+	goCmd.Flags().StringVar(&gogen.VarStringBranch, "branch", "", "The branch of "+
 		"the remote repo, it does work with --remote")
 	goCmd.Flags().StringVar(&gogen.VarStringStyle, "style", "gozero", "The file naming format,"+
 		" see [https://github.com/zeromicro/go-zero/blob/master/tools/goctl/config/readme.md]")
@@ -143,7 +143,7 @@ func init() {
 		"of the template, --home and --remote cannot be set at the same time, if they are, --remote"+
 		" has higher priority\n\tThe git repo directory must be consistent with the "+
 		"https://github.com/zeromicro/go-zero-template directory structure")
-	newCmd.Flags().StringVar(&new.VarStringBranch, "branch", "master", "The branch of "+
+	newCmd.Flags().StringVar(&new.VarStringBranch, "branch", "", "The branch of "+
 		"the remote repo, it does work with --remote")
 	newCmd.Flags().StringVar(&new.VarStringStyle, "style", "gozero", "The file naming format,"+
 		" see [https://github.com/zeromicro/go-zero/blob/master/tools/goctl/config/readme.md]")


### PR DESCRIPTION
fix goctl api, use default(master) branch, clone remote template fail