### PR TITLE
fix 当表有唯一键时，update()的形参和实参不一致

### DIFF
--- a/tools/goctl/model/sql/template/update.go
+++ b/tools/goctl/model/sql/template/update.go
@@ -20,5 +20,5 @@ func (m *default{{.upperStartCamelObject}}Model) Update(ctx context.Context, {{i
 `
 
 	// UpdateMethod defines an interface method template for generating update codes
-	UpdateMethod = `Update(ctx context.Context, newData *{{.upperStartCamelObject}}) error`
+	UpdateMethod = `Update(ctx context.Context, {{if .containsIndexCache}}newData{{else}}data{{end}} *{{.upperStartCamelObject}}) error`
 )


### PR DESCRIPTION
fix #2009 