### PR TITLE
Update tag.go

### DIFF
--- a/tools/goctl/model/sql/template/tag.go
+++ b/tools/goctl/model/sql/template/tag.go
@@ -1,4 +1,4 @@
 package template
 
 // Tag defines a tag template text
-const Tag = "`db:\"{{.field}}\"`"
+const Tag = "`db:\"{{.field}}\"` `comment:\"{{.comment}}\"`"


### PR DESCRIPTION
将数据库字段注释以备注的形式放到数据模型结构体后面唯一的作用就是给程序员看! 
但是你将它挪移到结构体字段标签里!我最起码可以通过反射拿到这些注释文字!最起码有利用的可能!
具体使用场景 
1. 给前端表单设计器使用 
3. 可以生成一些文档等等
4. 其他没想到