### PR TITLE
fix: cpu usage calculate error

### DIFF
--- a/core/stat/internal/cpu_linux.go
+++ b/core/stat/internal/cpu_linux.go
@@ -82,7 +82,7 @@ func RefreshCpu() uint64 {
 	cpuDelta := total - preTotal
 	systemDelta := system - preSystem
 	if cpuDelta > 0 && systemDelta > 0 {
-		usage = uint64(float64(cpuDelta*cores*1e3) / (float64(systemDelta) * quota))
+		usage = uint64(float64(cpuDelta*1e3) / float64(systemDelta))
 	}
 	preSystem = system
 	preTotal = total

--- a/core/stat/internal/cpu_linux.go
+++ b/core/stat/internal/cpu_linux.go
@@ -18,43 +18,11 @@ const (
 var (
 	preSystem uint64
 	preTotal  uint64
-	quota     float64
-	cores     uint64
 )
 
 // if /proc not present, ignore the cpu calculation, like wsl linux
 func init() {
-	cpus, err := cpuSets()
-	if err != nil {
-		logx.Error(err)
-		return
-	}
-
-	cores = uint64(len(cpus))
-	sets, err := cpuSets()
-	if err != nil {
-		logx.Error(err)
-		return
-	}
-
-	quota = float64(len(sets))
-	cq, err := cpuQuota()
-	if err == nil {
-		if cq != -1 {
-			period, err := cpuPeriod()
-			if err != nil {
-				logx.Error(err)
-				return
-			}
-
-			limit := float64(cq) / float64(period)
-			if limit < quota {
-				quota = limit
-			}
-		}
-	}
-
-	preSystem, err = systemCpuUsage()
+	preSystem, err := systemCpuUsage()
 	if err != nil {
 		logx.Error(err)
 		return

--- a/core/stat/internal/cpu_linux.go
+++ b/core/stat/internal/cpu_linux.go
@@ -22,7 +22,8 @@ var (
 
 // if /proc not present, ignore the cpu calculation, like wsl linux
 func init() {
-	preSystem, err := systemCpuUsage()
+	var err error
+	preSystem, err = systemCpuUsage()
 	if err != nil {
 		logx.Error(err)
 		return

--- a/core/stat/internal/cpu_linux.go
+++ b/core/stat/internal/cpu_linux.go
@@ -59,33 +59,6 @@ func RefreshCpu() uint64 {
 	return usage
 }
 
-func cpuQuota() (int64, error) {
-	cg, err := currentCgroup()
-	if err != nil {
-		return 0, err
-	}
-
-	return cg.cpuQuotaUs()
-}
-
-func cpuPeriod() (uint64, error) {
-	cg, err := currentCgroup()
-	if err != nil {
-		return 0, err
-	}
-
-	return cg.cpuPeriodUs()
-}
-
-func cpuSets() ([]uint64, error) {
-	cg, err := currentCgroup()
-	if err != nil {
-		return nil, err
-	}
-
-	return cg.cpus()
-}
-
 func systemCpuUsage() (uint64, error) {
 	lines, err := iox.ReadTextLines("/proc/stat", iox.WithoutBlank())
 	if err != nil {


### PR DESCRIPTION
in your code,  usage = uint64(float64(cpuDelta*cores*1e3) / (float64(systemDelta) * quota)).

when host's CPU It's big enough such as 48core, while container's cpu limit is small such as 100m, according to the above calculation method, the result value is likely to be greater than CpuThreshold's max value(1000) in config file.