### PR TITLE
fix: type matching supports string to int

### DIFF
--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -534,8 +534,10 @@ func (u *Unmarshaler) fillSliceValue(slice reflect.Value, index int,
 	baseKind reflect.Kind, value interface{}) error {
 	ithVal := slice.Index(index)
 	switch v := value.(type) {
-	case json.Number:
+	case fmt.Stringer:
 		return setValue(baseKind, ithVal, v.String())
+	case string:
+		return setValue(baseKind, ithVal, v)
 	default:
 		// don't need to consider the difference between int, int8, int16, int32, int64,
 		// uint, uint8, uint16, uint32, uint64, because they're handled as json.Number.

--- a/rest/internal/encoding/parser_test.go
+++ b/rest/internal/encoding/parser_test.go
@@ -38,3 +38,14 @@ func TestParseHeadersMulti(t *testing.T) {
 	assert.Equal(t, 1, val.Baz)
 	assert.True(t, val.Qux)
 }
+
+func TestParseHeadersArrayInt(t *testing.T) {
+	var val struct {
+		Foo []int `header:"foo"`
+	}
+	r := httptest.NewRequest(http.MethodGet, "/any", nil)
+	r.Header.Set("foo", "1")
+	r.Header.Add("foo", "2")
+	assert.Nil(t, ParseHeaders(r.Header, &val))
+	assert.Equal(t, []int{1, 2}, val.Foo)
+}


### PR DESCRIPTION
type matching supports string to int