### PR TITLE
fix concurrent map read and map write

### DIFF
--- a/core/discov/internal/registry.go
+++ b/core/discov/internal/registry.go
@@ -191,9 +191,11 @@ func (c *cluster) handleWatchEvents(key string, events []*clientv3.Event) {
 				})
 			}
 		case clientv3.EventTypeDelete:
+			c.lock.Lock()
 			if vals, ok := c.values[key]; ok {
 				delete(vals, string(ev.Kv.Key))
 			}
+			c.lock.Unlock()
 			for _, l := range listeners {
 				l.OnDelete(KV{
 					Key: string(ev.Kv.Key),


### PR DESCRIPTION
there should be locked, when delete key-value in `c.values`.
``` go
case clientv3.EventTypeDelete:

	if vals, ok := c.values[key]; ok {
		delete(vals, string(ev.Kv.Key))
	}

	for _, l := range listeners {
		l.OnDelete(KV{
			Key: string(ev.Kv.Key),
			Val: string(ev.Kv.Value),
		})
	}
```

