### PR TITLE
fix: 修复 api 使用 group 时生成的 handler.go 中 import logic 包未使用别名的问题

### DIFF
--- a/tools/goctl/api/gogen/genhandlers.go
+++ b/tools/goctl/api/gogen/genhandlers.go
@@ -93,8 +93,16 @@ func genHandlers(dir, rootPkg string, cfg *config.Config, api *spec.ApiSpec) err
 }
 
 func genHandlerImports(group spec.Group, route spec.Route, parentPkg string) string {
-	var imports []string
-	imports = append(imports, fmt.Sprintf("\"%s\"",
+	var (
+		logicPrefix string
+		imports     []string
+	)
+	_, exists := group.Annotation.Properties["group"]
+	if exists {
+		logicPrefix = fmt.Sprintf("%s ", defaultLogicPackage)
+	}
+
+	imports = append(imports, fmt.Sprintf("%s\"%s\"", logicPrefix,
 		pathx.JoinPackages(parentPkg, getLogicFolderPath(group, route))))
 	imports = append(imports, fmt.Sprintf("\"%s\"", pathx.JoinPackages(parentPkg, contextDir)))
 	if len(route.RequestTypeName()) > 0 {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49554487/176846726-7b516deb-d214-422b-9a28-dff1e65f91e0.png)
