### PR TITLE
goctl model parser, Field struct to have the name as declared in the model type

### DIFF
--- a/tools/goctl/model/sql/gen/field.go
+++ b/tools/goctl/model/sql/gen/field.go
@@ -38,7 +38,7 @@ func genField(table Table, field *parser.Field) (string, error) {
 	output, err := util.With("types").
 		Parse(text).
 		Execute(map[string]interface{}{
-			"name":       util.SafeString(field.Name.ToCamel()),
+			"name":       field.StructField,
 			"type":       field.DataType,
 			"tag":        tag,
 			"hasComment": field.Comment != "",

--- a/tools/goctl/model/sql/gen/insert.go
+++ b/tools/goctl/model/sql/gen/insert.go
@@ -30,8 +30,7 @@ func genInsert(table Table, withCache, postgreSql bool) (string, string, error) 
 	expressionValues := make([]string, 0)
 	var count int
 	for _, field := range table.Fields {
-		camel := util.SafeString(field.Name.ToCamel())
-		if camel == "CreateTime" || camel == "UpdateTime" || camel == "CreateAt" || camel == "UpdateAt" {
+		if field.StructField == "CreateTime" || field.StructField == "UpdateTime" || field.StructField == "CreateAt" || field.StructField == "UpdateAt" {
 			continue
 		}
 
@@ -47,7 +46,7 @@ func genInsert(table Table, withCache, postgreSql bool) (string, string, error) 
 		} else {
 			expressions = append(expressions, "?")
 		}
-		expressionValues = append(expressionValues, "data."+camel)
+		expressionValues = append(expressionValues, "data."+field.StructField)
 	}
 
 	camel := table.Name.ToCamel()

--- a/tools/goctl/model/sql/gen/update.go
+++ b/tools/goctl/model/sql/gen/update.go
@@ -20,8 +20,7 @@ func genUpdate(table Table, withCache, postgreSql bool) (
 		pkg = "newData."
 	}
 	for _, field := range table.Fields {
-		camel := util.SafeString(field.Name.ToCamel())
-		if camel == "CreateTime" || camel == "UpdateTime" || camel == "CreateAt" || camel == "UpdateAt" {
+		if field.StructField == "CreateTime" || field.StructField == "UpdateTime" || field.StructField == "CreateAt" || field.StructField == "UpdateAt" {
 			continue
 		}
 
@@ -29,7 +28,7 @@ func genUpdate(table Table, withCache, postgreSql bool) (
 			continue
 		}
 
-		expressionValues = append(expressionValues, pkg+camel)
+		expressionValues = append(expressionValues, pkg+field.StructField)
 	}
 
 	keySet := collection.NewSet()

--- a/tools/goctl/model/sql/parser/parser.go
+++ b/tools/goctl/model/sql/parser/parser.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zeromicro/go-zero/tools/goctl/model/sql/converter"
 	"github.com/zeromicro/go-zero/tools/goctl/model/sql/model"
 	"github.com/zeromicro/go-zero/tools/goctl/model/sql/util"
+	goctlutil "github.com/zeromicro/go-zero/tools/goctl/util"
 	"github.com/zeromicro/go-zero/tools/goctl/util/console"
 	"github.com/zeromicro/go-zero/tools/goctl/util/stringx"
 )
@@ -37,6 +38,7 @@ type (
 	Field struct {
 		NameOriginal    string
 		Name            stringx.String
+		StructField     string
 		DataType        string
 		Comment         string
 		SeqInIndex      int
@@ -238,6 +240,7 @@ func convertColumns(columns []*parser.Column, primaryColumn string) (Primary, ma
 		field.Name = stringx.From(column.Name)
 		field.DataType = dataType
 		field.Comment = util.TrimNewLine(comment)
+		field.StructField = goctlutil.SafeString(field.Name.ToCamel())
 
 		if field.Name.Source() == primaryColumn {
 			primaryKey = Primary{
@@ -288,6 +291,7 @@ func ConvertDataType(table *model.Table) (*Table, error) {
 			Comment:         table.PrimaryKey.Comment,
 			SeqInIndex:      seqInIndex,
 			OrdinalPosition: table.PrimaryKey.OrdinalPosition,
+			StructField:     goctlutil.SafeString(stringx.From(table.PrimaryKey.Name).ToCamel()),
 		},
 		AutoIncrement: strings.Contains(table.PrimaryKey.Extra, "auto_increment"),
 	}
@@ -363,6 +367,7 @@ func getTableFields(table *model.Table) (map[string]*Field, error) {
 			Comment:         each.Comment,
 			SeqInIndex:      columnSeqInIndex,
 			OrdinalPosition: each.OrdinalPosition,
+			StructField:     goctlutil.SafeString(stringx.From(each.Name).ToCamel()),
 		}
 		fieldM[each.Name] = field
 	}


### PR DESCRIPTION
The field struct which has the NameOriginal, Name, DataType, Comment, SeqInIndex, OrdinalPosition, should also have the model type name so as to identify or link between the model type and field.
```go
	Field struct {
		NameOriginal    string
		Name            stringx.String
		StructField     string
		DataType        string
		Comment         string
		SeqInIndex      int
		OrdinalPosition int
	}
```


A sample generated model.
eg:
```go
	type Student struct {
		ID         int64           `db:"id"`
		Name       string          `db:"name"`
		Age        sql.NullInt64   `db:"age"`
		Score      sql.NullFloat64 `db:"score"`
		CreateTime time.Time       `db:"create_time"`
		UpdateTime sql.NullTime    `db:"update_time"`
	}
```
The field name should be available while passing the data (parser.Table) object to the template.

A sample generated update function which makes use of the model type to generate the squirrel builder.
eg:
```go
	query, values, err := squirrel.
		Update(m.table).
		SetMap(squirrel.Eq{
			name:        data.Name,
			age:         data.Age,
			score:       data.Score,
			update_time: data.UpdateTime,
		}).
		Where(squirrel.Eq{"id": data.ID}).
		ToSql()
```
