### PR TITLE
fix: httpx redeclared in generated handler code (#2133)

### DIFF
--- a/tools/goctl/api/gogen/handler.tpl
+++ b/tools/goctl/api/gogen/handler.tpl
@@ -3,7 +3,6 @@ package {{.PkgName}}
 import (
 	"net/http"
 
-	"github.com/zeromicro/go-zero/rest/httpx"
 	{{.ImportPackages}}
 )
 


### PR DESCRIPTION
tpl 模板中引入的 httpx 包，在下图函数中已经引入，因此删除模板中的引入
![image](https://user-images.githubusercontent.com/57740293/178889096-99344c9d-7f67-4a27-a63c-a932e99119bb.png)
