### PR TITLE
fix: goctl genhandler duplicate rest/httpx & template import custom

### DIFF
--- a/tools/goctl/api/gogen/genhandlers.go
+++ b/tools/goctl/api/gogen/genhandlers.go
@@ -21,15 +21,16 @@ const defaultLogicPackage = "logic"
 var handlerTemplate string
 
 type handlerInfo struct {
-	PkgName        string
-	ImportPackages string
-	HandlerName    string
-	RequestType    string
-	LogicName      string
-	LogicType      string
-	Call           string
-	HasResp        bool
-	HasRequest     bool
+	PkgName            string
+	ImportPackages     string
+	ImportHttpxPackage string
+	HandlerName        string
+	RequestType        string
+	LogicName          string
+	LogicType          string
+	Call               string
+	HasResp            bool
+	HasRequest         bool
 }
 
 func genHandler(dir, rootPkg string, cfg *config.Config, group spec.Group, route spec.Route) error {
@@ -47,15 +48,16 @@ func genHandler(dir, rootPkg string, cfg *config.Config, group spec.Group, route
 	}
 
 	return doGenToFile(dir, handler, cfg, group, route, handlerInfo{
-		PkgName:        pkgName,
-		ImportPackages: genHandlerImports(group, route, parentPkg),
-		HandlerName:    handler,
-		RequestType:    util.Title(route.RequestTypeName()),
-		LogicName:      logicName,
-		LogicType:      strings.Title(getLogicName(route)),
-		Call:           strings.Title(strings.TrimSuffix(handler, "Handler")),
-		HasResp:        len(route.ResponseTypeName()) > 0,
-		HasRequest:     len(route.RequestTypeName()) > 0,
+		PkgName:            pkgName,
+		ImportPackages:     genHandlerImports(group, route, parentPkg),
+		ImportHttpxPackage: fmt.Sprintf("\"%s/rest/httpx\"", vars.ProjectOpenSourceURL),
+		HandlerName:        handler,
+		RequestType:        util.Title(route.RequestTypeName()),
+		LogicName:          logicName,
+		LogicType:          strings.Title(getLogicName(route)),
+		Call:               strings.Title(strings.TrimSuffix(handler, "Handler")),
+		HasResp:            len(route.ResponseTypeName()) > 0,
+		HasRequest:         len(route.RequestTypeName()) > 0,
 	})
 }
 
@@ -99,7 +101,6 @@ func genHandlerImports(group spec.Group, route spec.Route, parentPkg string) str
 	if len(route.RequestTypeName()) > 0 {
 		imports = append(imports, fmt.Sprintf("\"%s\"\n", pathx.JoinPackages(parentPkg, typesDir)))
 	}
-	imports = append(imports, fmt.Sprintf("\"%s/rest/httpx\"", vars.ProjectOpenSourceURL))
 
 	return strings.Join(imports, "\n\t")
 }

--- a/tools/goctl/api/gogen/handler.tpl
+++ b/tools/goctl/api/gogen/handler.tpl
@@ -3,8 +3,8 @@ package {{.PkgName}}
 import (
 	"net/http"
 
-	"github.com/zeromicro/go-zero/rest/httpx"
 	{{.ImportPackages}}
+	{{.ImportHttpxPackage}}
 )
 
 func {{.HandlerName}}(svcCtx *svc.ServiceContext) http.HandlerFunc {


### PR DESCRIPTION
fix: goctl genhandler duplicate rest/httpx & goctl genhandler template support custom import httpx package

Reason:
1、在 handler 层，我对 httpx 包进行了再次封装
2、在某些情况下，我需要控制 httpx 包的导入
3、goctl 1.3.9 会出现两个 rest/httpx 包

Example:
```
# handler.tpl
package {{.PkgName}}

import (
	"net/http"

	"appservice/pkg/resultx"
	{{.ImportPackages}}
        {{if .HasRequest}}
	{{.ImportHttpxPackage}}
        {{end}}
)

func {{.HandlerName}}(svcCtx *svc.ServiceContext) http.HandlerFunc {
	return func(w http.ResponseWriter, r *http.Request) {
		{{if .HasRequest}}var req types.{{.RequestType}}
		if err := httpx.Parse(r, &req); err != nil {
			resultx.HttpParamErrorResult(r, w, err)
			return
		}

		{{end}}l := {{.LogicName}}.New{{.LogicType}}(r.Context(), svcCtx)
		{{if .HasResp}}resp, {{end}}err := l.{{.Call}}({{if .HasRequest}}&req{{end}})

		{{if .HasResp}}resultx.HttpResult(r, w, resp, err){{else}}resultx.HttpResult(r, w, nil, err){{end}}

	}
}

```
