### PR TITLE
generates nested types in doc

### DIFF
--- a/tools/goctl/api/docgen/doc.go
+++ b/tools/goctl/api/docgen/doc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"go/format"
 	"html/template"
 	"strconv"
 	"strings"
@@ -35,12 +36,12 @@ func genDoc(api *spec.ApiSpec, dir, filename string) error {
 			routeComment = "N/A"
 		}
 
-		requestContent, err := buildDoc(route.RequestType)
+		requestContent, err := buildDoc(route.RequestType, api)
 		if err != nil {
 			return err
 		}
 
-		responseContent, err := buildDoc(route.ResponseType)
+		responseContent, err := buildDoc(route.ResponseType, api)
 		if err != nil {
 			return err
 		}
@@ -60,7 +61,6 @@ func genDoc(api *spec.ApiSpec, dir, filename string) error {
 		if err != nil {
 			return err
 		}
-
 		builder.Write(tmplBytes.Bytes())
 	}
 
@@ -68,7 +68,7 @@ func genDoc(api *spec.ApiSpec, dir, filename string) error {
 	return err
 }
 
-func buildDoc(route spec.Type) (string, error) {
+func buildDoc(route spec.Type, api *spec.ApiSpec) (string, error) {
 	if route == nil || len(route.Name()) == 0 {
 		return "", nil
 	}
@@ -78,12 +78,15 @@ func buildDoc(route spec.Type) (string, error) {
 	if definedType, ok := route.(spec.DefineStruct); ok {
 		associatedTypes(definedType, &tps)
 	}
-	value, err := gogen.BuildTypes(tps)
+	value, err := gogen.BuildTypes(tps, api)
 	if err != nil {
 		return "", err
 	}
-
-	return fmt.Sprintf("\n\n```golang\n%s\n```\n", value), nil
+	formatted, err := format.Source([]byte(value))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("\n\n```golang\n%s\n```\n", string(formatted)), nil
 }
 
 func associatedTypes(tp spec.DefineStruct, tps *[]spec.Type) {

--- a/tools/goctl/api/gogen/testdata/api_common.api
+++ b/tools/goctl/api/gogen/testdata/api_common.api
@@ -1,0 +1,3 @@
+type Common {
+	Some string `json:"some"` // some imported type
+}

--- a/tools/goctl/api/gogen/testdata/api_has_nested_type.api
+++ b/tools/goctl/api/gogen/testdata/api_has_nested_type.api
@@ -1,0 +1,48 @@
+import "./api_common.api"
+type Resp {
+	R1 string `json:"r1"`
+	R2 bool   `json:"r2"`
+	R3 Common `json:"r3"`
+}
+type CommonResponse {
+	Code    int    `json:"code"` // 100 | 200
+	Message string `json:"message"`
+	Common
+	Response Resp `json:"response"`
+}
+
+type LoginResponseDto {
+	Id          string `bson:"_id" json:"id"`
+	Name        string `json:"name"`
+	AccessToken string `json:"accessToken"`
+}
+
+type UserCreateDto {
+	Id string `json:"id"`
+}
+type LoginRequest {
+	Username string `json:"username,optional"` // user name is optional
+	Password string `json:"password,optional"`
+}
+type LoginResponse {
+	*CommonResponse
+	Result *LoginResponseDto `json:"result"`
+}
+
+type UserCreateRequest {
+	Username string `json:"username,optional"` // some dsada
+	Password string `json:"password,optional"`
+}
+
+type UserCreateResponse {
+	*CommonResponse
+	Result *UserCreateDto `json:"result"` // result
+}
+
+service user-api {
+	@handler UserHandler
+	post /user/signin(UserCreateRequest) returns (UserCreateResponse)
+	
+	@handler LoginHandler
+	post /user/login(LoginRequest) returns (LoginResponse)
+}


### PR DESCRIPTION
Provides the ability to generate nested types 
like
```go
type CommonResponse {
	Code    int    `json:"code"` // 100 | 200
	Message string `json:"message"`
}
type UserCreateDto {
	Id string `json:"id"`
}
type UserCreateResponse {
	CommonResponse
	Result *UserCreateDto `json:"result"` // result
}
```

is generate to 
```go

type UserCreateResponse struct  {
	Code    int    `json:"code"` // 100 | 200
	Message string `json:"message"`
	Result struct {
            Id string `json:"id"`
        } `json:"result"` // result
}
```