### PR TITLE
makes syncx.Cond satisfy happens-before semantics

### DIFF
--- a/core/syncx/cond.go
+++ b/core/syncx/cond.go
@@ -26,7 +26,7 @@ func (cond *Cond) WaitWithTimeout(timeout time.Duration) (time.Duration, bool) {
 
 	begin := timex.Now()
 	select {
-	case <-cond.signal:
+	case cond.signal <- lang.Placeholder:
 		elapsed := timex.Since(begin)
 		remainTimeout := timeout - elapsed
 		return remainTimeout, true
@@ -37,13 +37,13 @@ func (cond *Cond) WaitWithTimeout(timeout time.Duration) (time.Duration, bool) {
 
 // Wait waits for signals.
 func (cond *Cond) Wait() {
-	<-cond.signal
+	cond.signal <- lang.Placeholder
 }
 
 // Signal wakes one goroutine waiting on c, if there is any.
 func (cond *Cond) Signal() {
 	select {
-	case cond.signal <- lang.Placeholder:
+	case <-cond.signal:
 	default:
 	}
 }


### PR DESCRIPTION
According to [The Go  Memory Model](https://golang.google.cn/ref/mem#chan): a receive from an unbuffered channel is synchronized before the completion of the corresponding send on that channel. Suppose we have a code segment like following:
```
var cond = NewCond()
var a string

func f() {
	a = "hello, world"
	cond.Signal()
}

func main(t *testing.T) {
	go f()
	cond.Wait()
	print(a)
}
```
With current implementation, we cann't guarantee the main function prints "hello world" in the end, thus I made this little change to ensure syncx.Cond satisfy the happens-before semantics.

