### PR TITLE
fix resource manager dead lock

### DIFF
--- a/core/syncx/resourcemanager.go
+++ b/core/syncx/resourcemanager.go
@@ -57,8 +57,8 @@ func (manager *ResourceManager) GetResource(key string, create func() (io.Closer
 		}
 
 		manager.lock.Lock()
+		defer manager.lock.Unlock()
 		manager.resources[key] = resource
-		manager.lock.Unlock()
 
 		return resource, nil
 	})

--- a/core/syncx/resourcemanager_test.go
+++ b/core/syncx/resourcemanager_test.go
@@ -74,6 +74,12 @@ func TestResourceManager_UseAfterClose(t *testing.T) {
 			return nil, errors.New("fail")
 		})
 		assert.NotNil(t, err)
+
+		assert.Panics(t, func() {
+			_, err = manager.GetResource("key", func() (io.Closer, error) {
+				return &dummyResource{age: 123}, nil
+			})
+		})
 	}
 }
 


### PR DESCRIPTION
after resource manager close reuse this manager to get resource, it would be a dead lock
```go
// playground
manager := NewResourceManager()
	defer manager.Close()

	_, err := manager.GetResource("key", func() (io.Closer, error) {
		return nil, errors.New("fail")
	})
	assert.NotNil(t, err)
	if assert.NoError(t, manager.Close()) {
		_, err = manager.GetResource("key", func() (io.Closer, error) {
			return nil, errors.New("fail")
		})
		assert.NotNil(t, err)
                // !!! here should be a panic
		assert.Panics(t, func() {
			_, err = manager.GetResource("key", func() (io.Closer, error) {
				return &dummyResource{age: 123}, nil
			})
		})
	}
```