### PR TITLE
Fix/del server interceptor duplicate copy md 20220827

### DIFF
--- a/core/trace/tracer.go
+++ b/core/trace/tracer.go
@@ -38,7 +38,7 @@ func (s *metadataSupplier) Keys() []string {
 	return out
 }
 
-// Inject injects the metadata into ctx.
+// Inject injects cross-cutting concerns from the ctx into the metadata.
 func Inject(ctx context.Context, p propagation.TextMapPropagator, metadata *metadata.MD) {
 	p.Inject(ctx, &metadataSupplier{
 		metadata: metadata,

--- a/zrpc/internal/serverinterceptors/tracinginterceptor.go
+++ b/zrpc/internal/serverinterceptors/tracinginterceptor.go
@@ -93,11 +93,8 @@ func (w *serverStream) SendMsg(m interface{}) error {
 }
 
 func startSpan(ctx context.Context, method string) (context.Context, trace.Span) {
-	var md metadata.MD
-	requestMetadata, ok := metadata.FromIncomingContext(ctx)
-	if ok {
-		md = requestMetadata.Copy()
-	} else {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
 		md = metadata.MD{}
 	}
 	bags, spanCtx := ztrace.Extract(ctx, otel.GetTextMapPropagator(), &md)


### PR DESCRIPTION

![Uploading image.png…]()


FromIncomingContext在新版本grpc中也是copy的md，因此外面不需要重复copy了。