### PR TITLE
improve: number range compare left and righ value

### DIFF
--- a/core/mapping/marshaler_test.go
+++ b/core/mapping/marshaler_test.go
@@ -261,6 +261,26 @@ func TestMarshal_RangeOut(t *testing.T) {
 	}
 }
 
+func TestMarshal_RangeIllegal(t *testing.T) {
+	tests := []interface{}{
+		struct {
+			Int int `json:"int,range=[3:1]"`
+		}{
+			Int: 2,
+		},
+		struct {
+			Int int `json:"int,range=(3:1]"`
+		}{
+			Int: 2,
+		},
+	}
+
+	for _, test := range tests {
+		_, err := Marshal(test)
+		assert.Equal(t, err, errNumberRange)
+	}
+}
+
 func TestMarshal_FromString(t *testing.T) {
 	v := struct {
 		Age int `json:"age,string"`

--- a/core/mapping/utils.go
+++ b/core/mapping/utils.go
@@ -311,6 +311,10 @@ func parseNumberRange(str string) (*numberRange, error) {
 		right = math.MaxFloat64
 	}
 
+	if left >= right {
+		return nil, errNumberRange
+	}
+
 	return &numberRange{
 		left:         left,
 		leftInclude:  leftInclude,


### PR DESCRIPTION
使用range定义范围的时候,left>right 定义不应该通过，虽然validate的时候有报错，感觉可用加一下。个人愚见^_^