### PR TITLE
feat: add string to map in httpx parse method

### DIFF
--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -207,6 +207,8 @@ func (u *Unmarshaler) processFieldNotFromString(field reflect.StructField, value
 		return u.fillMap(field, value, mapValue)
 	case valueKind == reflect.String && typeKind == reflect.Slice:
 		return u.fillSliceFromString(fieldType, value, mapValue)
+	case valueKind == reflect.String && typeKind == reflect.Map:
+		return u.fillMapFromString(value, mapValue)
 	case valueKind == reflect.String && derefedFieldType == durationType:
 		return fillDurationValue(fieldType.Kind(), value, mapValue.(string))
 	default:
@@ -527,6 +529,23 @@ func (u *Unmarshaler) fillSliceFromString(fieldType reflect.Type, value reflect.
 	}
 
 	value.Set(conv)
+	return nil
+}
+
+func (u *Unmarshaler) fillMapFromString(value reflect.Value, mapValue interface{}) error {
+	switch v := mapValue.(type) {
+	case fmt.Stringer:
+		if err := jsonx.UnmarshalFromString(v.String(), value.Addr().Interface()); err != nil {
+			return err
+		}
+	case string:
+		if err := jsonx.UnmarshalFromString(v, value.Addr().Interface()); err != nil {
+			return err
+		}
+	default:
+		return errUnsupportedType
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
httpx parseform can't get map from URI query, it's always string, so it will be more convenient to add string to map process when receive frontend get method object params