### PR TITLE
fix(mongo): fix file name generation errors

### DIFF
--- a/tools/goctl/model/mongo/generate/generate.go
+++ b/tools/goctl/model/mongo/generate/generate.go
@@ -97,7 +97,7 @@ func generateCustomModel(ctx *Context) error {
 
 func generateTypes(ctx *Context) error {
 	for _, t := range ctx.Types {
-		fn, err := format.FileNamingFormat(ctx.Cfg.NamingFormat, t+"types")
+		fn, err := format.FileNamingFormat(ctx.Cfg.NamingFormat, t+"_types")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Before this, no matter what style is used, lowercase file names without underscores will be generated.