### PR TITLE
feat(goctl): better generate the api code of typescript

### DIFF
--- a/tools/goctl/api/spec/example_test.go
+++ b/tools/goctl/api/spec/example_test.go
@@ -1,0 +1,15 @@
+package spec_test
+
+import (
+	"fmt"
+	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
+)
+
+func ExampleMember_GetEnumOptions() {
+	member := spec.Member{
+		Tag: `json:"foo,options=foo|bar|options|123"`,
+	}
+	fmt.Println(member.GetEnumOptions())
+	// Output:
+	// [foo bar options 123]
+}

--- a/tools/goctl/api/spec/fn.go
+++ b/tools/goctl/api/spec/fn.go
@@ -154,6 +154,27 @@ func (m Member) IsTagMember(tagKey string) bool {
 	return false
 }
 
+// GetEnumOptions return a slice contains all enumeration options
+func (m Member) GetEnumOptions() []string {
+	if !m.IsBodyMember() {
+		return nil
+	}
+
+	tags := m.Tags()
+	for _, tag := range tags {
+		if tag.Key == bodyTagKey {
+			options := tag.Options
+			for _, option := range options {
+				if strings.Index(option, "options=") == 0 {
+					option = strings.TrimPrefix(option, "options=")
+					return strings.Split(option, "|")
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // GetBodyMembers returns all json fields
 func (t DefineStruct) GetBodyMembers() []Member {
 	var result []Member

--- a/tools/goctl/api/tsgen/util.go
+++ b/tools/goctl/api/tsgen/util.go
@@ -19,7 +19,7 @@ const (
 
 func writeProperty(writer io.Writer, member spec.Member, indent int) error {
 	writeIndent(writer, indent)
-	ty, err := goTypeToTs(member.Type, false)
+	ty, err := genTsType(member)
 	if err != nil {
 		return err
 	}
@@ -50,6 +50,19 @@ func writeIndent(writer io.Writer, indent int) {
 	for i := 0; i < indent; i++ {
 		fmt.Fprint(writer, "\t")
 	}
+}
+
+func genTsType(m spec.Member) (ty string, err error) {
+	ty, err = goTypeToTs(m.Type, false)
+	if enums := m.GetEnumOptions(); enums != nil {
+		if ty == "string" {
+			for i := range enums {
+				enums[i] = "'" + enums[i] + "'"
+			}
+		}
+		ty = strings.Join(enums, " | ")
+	}
+	return
 }
 
 func goTypeToTs(tp spec.Type, fromPacket bool) (string, error) {

--- a/tools/goctl/api/tsgen/util_test.go
+++ b/tools/goctl/api/tsgen/util_test.go
@@ -1,0 +1,38 @@
+package tsgen
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
+	"testing"
+)
+
+func TestGenTsType(t *testing.T) {
+	member := spec.Member{
+		Name:     "foo",
+		Type:     spec.PrimitiveType{RawName: "string"},
+		Tag:      `json:"foo,options=foo|bar|options|123"`,
+		Comment:  "",
+		Docs:     nil,
+		IsInline: false,
+	}
+	ty, err := genTsType(member)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, `'foo' | 'bar' | 'options' | '123'`, ty)
+
+	member.IsInline = true
+	ty, err = genTsType(member)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, `'foo' | 'bar' | 'options' | '123'`, ty)
+
+	member.Type = spec.PrimitiveType{RawName: "int"}
+	member.Tag = `json:"foo,options=1|3|4|123"`
+	ty, err = genTsType(member)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, `1 | 3 | 4 | 123`, ty)
+}


### PR DESCRIPTION
When generating the api code of typescript, if the tag contains the options modifier, the union type is generated instead of the declared type. Here is an example.

Api:

```api
type SomeType {
	Foo string `json:"foo,options=foo,bar,options,123"`
	Bar int `json:"bar,options=1,3,4,123"`
}
```

Typescript:

```typescript
export interface SomeType {
    foo: 'foo' | 'bar' | 'options' | '123'
    bar: 1 | 3 | 4 | 123
}
```

This can provide a good intelligent complement for the front-end IDE.

I have completed  the test file.