### PR TITLE
chore(action): upgrade actions/stale & actions/setup-go & codecov/codecov-action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ^1.16
         id: go
@@ -34,14 +34,14 @@ jobs:
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
 
   test-win:
     name: Windows
     runs-on: windows-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ^1.16
 

--- a/.github/workflows/issue-translator.yml
+++ b/.github/workflows/issue-translator.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: tomsun28/issues-translate-action@v2.6
+      - uses: usthe/issues-translate-action@v2.7
         with:
           IS_MODIFY_TITLE: true
           # not require, default false, . Decide whether to modify the issue title

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,7 +7,7 @@ jobs:
   close-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v6
         with:
           days-before-issue-stale: 365
           days-before-issue-close: 90


### PR DESCRIPTION
- [x] actions/stale
- [x] actions/setup-go
- [x] codecov/codecov-action
- [x] tomsun28/issues-translate-action:
  -  [x] waiting for merge https://github.com/usthe/issues-translate-action/pull/72
  - [x] waiting for release: https://github.com/usthe/issues-translate-action/pull/72#issuecomment-1280155397

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12