### PR TITLE
replace strings.Title to cases.Title

### DIFF
--- a/tools/goctl/go.mod
+++ b/tools/goctl/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/zeromicro/antlr v0.0.1
 	github.com/zeromicro/ddl-parser v1.0.4
 	github.com/zeromicro/go-zero v1.3.4
+	golang.org/x/text v0.3.7
 	google.golang.org/grpc v1.46.2
 	google.golang.org/protobuf v1.28.0
 )

--- a/tools/goctl/util/stringx/string.go
+++ b/tools/goctl/util/stringx/string.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var WhiteSpace = []rune{'\n', '\t', '\f', '\v', ' '}
@@ -49,12 +52,12 @@ func (s String) Source() string {
 	return s.source
 }
 
-// Title calls the strings.Title
+// Title calls the cases.Title
 func (s String) Title() string {
 	if s.IsEmptyOrSpace() {
 		return s.source
 	}
-	return strings.Title(s.source)
+	return cases.Title(language.English).String(s.source)
 }
 
 // ToCamel converts the input text into camel case

--- a/tools/goctl/util/stringx/string_test.go
+++ b/tools/goctl/util/stringx/string_test.go
@@ -40,3 +40,27 @@ func TestString_Camel2Snake(t *testing.T) {
 	ret2 := From("测试Test_Data_test_data").ToSnake()
 	assert.Equal(t, "测试_test__data_test_data", ret2)
 }
+
+func TestTitle(t *testing.T) {
+	cases := []struct {
+		src  string
+		exec string
+	}{
+		{
+			src:  "hello world!",
+			exec: "Hello World!",
+		},
+		{
+			src:  "go zero",
+			exec: "Go Zero",
+		},
+		{
+			src:  "测试this is data",
+			exec: "测试This Is Data",
+		},
+	}
+	for _, c := range cases {
+		ret := From(c.src).Title()
+		assert.Equal(t, c.exec, ret)
+	}
+}


### PR DESCRIPTION
strings.Title is Deprecated, because the rule Title uses for word boundaries does not handle Unicode