### PR TITLE
add ServeHTTP to Server/Engin for doing Httptest

### DIFF
--- a/rest/server.go
+++ b/rest/server.go
@@ -307,3 +307,8 @@ func newCorsRouter(router httpx.Router, headerFn func(http.Header), origins ...s
 func (c *corsRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c.middleware(c.Router.ServeHTTP)(w, r)
 }
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.ngin.bindRoutes(s.router)
+	s.router.ServeHTTP(w, r)
+}


### PR DESCRIPTION
Is similar to gin-gonic , allow developer to do a unit test with all defined router without starting a HTTP Server.
For example:
server := MustNewServer(...)
server.addRoute(...) // router a
server.addRoute(...) // router b
server.addRoute(...) // router c

req, _ := http.NewRequest(...) 
w := httptest.NewRecorder(...)
server.ServeHTTP(w,req)

//TODO : test after response