### PR TITLE
Fix 'no match module' error when run goctl in a directory which follows symbol link

### DIFF
--- a/tools/goctl/util/ctx/gomod.go
+++ b/tools/goctl/util/ctx/gomod.go
@@ -81,7 +81,8 @@ func getRealModule(workDir string, execRun execx.RunFunc) (*Module, error) {
 		return nil, err
 	}
 	for _, m := range modules {
-		if strings.HasPrefix(workDir, m.Dir) {
+		realPath, err := filepath.EvalSymlinks(m.Dir)
+		if err == nil && strings.HasPrefix(workDir, realPath) {
 			return &m, nil
 		}
 	}

--- a/tools/goctl/util/ctx/gomod.go
+++ b/tools/goctl/util/ctx/gomod.go
@@ -61,12 +61,7 @@ func projectFromGoMod(workDir string) (*ProjectContext, error) {
 	var ret ProjectContext
 	ret.WorkDir = workDir
 	ret.Name = filepath.Base(m.Dir)
-	dir, err := pathx.ReadLink(m.Dir)
-	if err != nil {
-		return nil, err
-	}
-
-	ret.Dir = dir
+	ret.Dir = m.Dir
 	ret.Path = m.Path
 	return &ret, nil
 }
@@ -81,8 +76,9 @@ func getRealModule(workDir string, execRun execx.RunFunc) (*Module, error) {
 		return nil, err
 	}
 	for _, m := range modules {
-		realPath, err := filepath.EvalSymlinks(m.Dir)
+		realPath, err := pathx.ReadLink(m.Dir)
 		if err == nil && strings.HasPrefix(workDir, realPath) {
+			m.Dir = realPath
 			return &m, nil
 		}
 	}


### PR DESCRIPTION
If current working directory follows symbol link, 'goctl rpc protoc' command will get 'no match module'. This is because that workDir paramater passed to function getRealModule is a realpath, and m.Dir in the result of command 'go list -json -m' is a symbol link based path. We can use filepath.EvalSymlinks to get m.Dir's realpath, which can fix the issue.
