### PR TITLE
:bug: debug grpc export (#2379)

### DIFF
--- a/core/trace/agent.go
+++ b/core/trace/agent.go
@@ -60,11 +60,12 @@ func createExporter(c Config) (sdktrace.SpanExporter, error) {
 	case kindZipkin:
 		return zipkin.New(c.Endpoint)
 	case kindGrpc:
-		return otlptracegrpc.NewUnstarted(
+		return otlptracegrpc.New(
+			context.Background(),
 			otlptracegrpc.WithInsecure(),
 			otlptracegrpc.WithEndpoint(c.Endpoint),
 			otlptracegrpc.WithDialOption(grpc.WithBlock()),
-		), nil
+		)
 	default:
 		return nil, fmt.Errorf("unknown exporter: %s", c.Batcher)
 	}

--- a/core/trace/agent_test.go
+++ b/core/trace/agent_test.go
@@ -13,7 +13,6 @@ func TestStartAgent(t *testing.T) {
 	const (
 		endpoint1 = "localhost:1234"
 		endpoint2 = "remotehost:1234"
-		endpoint3 = "localhost:1235"
 	)
 	c1 := Config{
 		Name: "foo",
@@ -30,12 +29,12 @@ func TestStartAgent(t *testing.T) {
 	}
 	c4 := Config{
 		Name:     "bla",
-		Endpoint: endpoint3,
+		Endpoint: endpoint1,
 		Batcher:  "otlp",
 	}
 	c5 := Config{
 		Name:     "grpc",
-		Endpoint: endpoint3,
+		Endpoint: endpoint1,
 		Batcher:  "grpc",
 	}
 
@@ -50,7 +49,7 @@ func TestStartAgent(t *testing.T) {
 	defer lock.Unlock()
 
 	// because remotehost cannot be resolved
-	assert.Equal(t, 3, len(agents))
+	assert.Equal(t, 2, len(agents))
 	_, ok := agents[""]
 	assert.True(t, ok)
 	_, ok = agents[endpoint1]


### PR DESCRIPTION
#2379 Fixed the issue that the GRPC exporter did not establish an RPC link 原文使用的 otlptracegrpc.NewUnstarted创建的是一个未建立rpc连接的导出器，无法正常使用；改为otlptracegrpc.New才妥