### PR TITLE
RawFieldNames should ignore the field whose name is start with a dash

### DIFF
--- a/core/stores/builder/builder.go
+++ b/core/stores/builder/builder.go
@@ -45,8 +45,12 @@ func RawFieldNames(in interface{}, postgresSql ...bool) []string {
 			// `db:"id"`
 			// `db:"id,type=char,length=16"`
 			// `db:",type=char,length=16"`
+			// `db:"-,type=char,length=16"`
 			if strings.Contains(tagv, ",") {
 				tagv = strings.TrimSpace(strings.Split(tagv, ",")[0])
+			}
+			if tagv == "-" {
+				continue
 			}
 			if len(tagv) == 0 {
 				tagv = fi.Name

--- a/core/stores/builder/builder_test.go
+++ b/core/stores/builder/builder_test.go
@@ -39,3 +39,33 @@ func TestFieldNamesWithTagOptions(t *testing.T) {
 		assert.Equal(t, expected, out)
 	})
 }
+
+type mockedUserWithDashTag struct {
+	ID       string `db:"id" json:"id,omitempty"`
+	UserName string `db:"user_name" json:"userName,omitempty"`
+	Mobile   string `db:"-" json:"mobile,omitempty"`
+}
+
+func TestFieldNamesWithDashTag(t *testing.T) {
+	t.Run("new", func(t *testing.T) {
+		var u mockedUserWithDashTag
+		out := RawFieldNames(&u)
+		expected := []string{"`id`", "`user_name`"}
+		assert.Equal(t, expected, out)
+	})
+}
+
+type mockedUserWithDashTagAndOptions struct {
+	ID       string `db:"id" json:"id,omitempty"`
+	UserName string `db:"user_name,type=varchar,length=255" json:"userName,omitempty"`
+	Mobile   string `db:"-,type=varchar,length=255" json:"mobile,omitempty"`
+}
+
+func TestFieldNamesWithDashTagAndOptions(t *testing.T) {
+	t.Run("new", func(t *testing.T) {
+		var u mockedUserWithDashTagAndOptions
+		out := RawFieldNames(&u)
+		expected := []string{"`id`", "`user_name`"}
+		assert.Equal(t, expected, out)
+	})
+}


### PR DESCRIPTION
```
type mockedUserWithDashTagAndOptions struct {
	ID       string `db:"id" json:"id,omitempty"`
	UserName string `db:"user_name,type=varchar,length=255" json:"userName,omitempty"`
	Mobile   string `db:"-,type=varchar,length=255" json:"mobile,omitempty"`
}
```

Given a struct above, a call to RawFieldNames(...) will produce a slice like {"`id`", "`user_name`", "`-`"}, which is not expected. Currently, the ignore feature is only works when struct tag is pure dash, without any options.