### PR TITLE
fix: replace goctl ExactValidArgs to MatchAll

### DIFF
--- a/tools/goctl/api/cmd.go
+++ b/tools/goctl/api/cmd.go
@@ -51,7 +51,7 @@ var (
 		Use:     "new",
 		Short:   "Fast create api service",
 		Example: "goctl api new [options] service-name",
-		Args:    cobra.ExactValidArgs(1),
+		Args:    cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return new.CreateServiceCommand(args)
 		},

--- a/tools/goctl/compare/cmd/cmd.go
+++ b/tools/goctl/compare/cmd/cmd.go
@@ -9,7 +9,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "compare",
 	Short: "Compare the goctl commands generated results between urfave and cobra",
-	Args:  cobra.ExactValidArgs(1),
+	Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		dir := args[0]
 		testdata.MustRun(dir)

--- a/tools/goctl/rpc/cmd.go
+++ b/tools/goctl/rpc/cmd.go
@@ -18,7 +18,7 @@ var (
 	newCmd = &cobra.Command{
 		Use:   "new",
 		Short: "Generate rpc demo service",
-		Args:  cobra.ExactValidArgs(1),
+		Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		RunE:  cli.RPCNew,
 	}
 
@@ -34,7 +34,7 @@ var (
 		Use:     "protoc",
 		Short:   "Generate grpc code",
 		Example: "goctl rpc protoc xx.proto --go_out=./pb --go-grpc_out=./pb --zrpc_out=.",
-		Args:    cobra.ExactValidArgs(1),
+		Args:    cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		RunE:    cli.ZRPC,
 	}
 )


### PR DESCRIPTION
ExactValidArgs is Deprecated
use MatchAll(ExactArgs(n), OnlyValidArgs) instead