### PR TITLE
refactor(rest): use static config for trace ignore paths.

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -57,5 +57,7 @@ type (
 		Signature    SignatureConf `json:",optional"`
 		// There are default values for all the items in Middlewares.
 		Middlewares MiddlewaresConf
+		// TraceIgnorePaths is paths blacklist for trace middleware.
+		TraceIgnorePaths []string `json:",optional"`
 	}
 )

--- a/rest/engine.go
+++ b/rest/engine.go
@@ -118,7 +118,7 @@ func (ng *engine) buildChainWithNativeMiddlewares(fr featuredRoutes, route Route
 	chn := chain.New()
 
 	if ng.conf.Middlewares.Trace {
-		chn = chn.Append(handler.TracingHandler(ng.conf.Name, route.Path))
+		chn = chn.Append(handler.TracingHandler(ng.conf.Name, route.Path, ng.conf.TraceIgnorePaths))
 	}
 	if ng.conf.Middlewares.Log {
 		chn = chn.Append(ng.getLogHandler())
@@ -202,7 +202,7 @@ func (ng *engine) getShedder(priority bool) load.Shedder {
 func (ng *engine) notFoundHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		chn := chain.New(
-			handler.TracingHandler(ng.conf.Name, ""),
+			handler.TracingHandler(ng.conf.Name, "", ng.conf.TraceIgnorePaths),
 			ng.getLogHandler(),
 		)
 

--- a/rest/engine.go
+++ b/rest/engine.go
@@ -118,7 +118,9 @@ func (ng *engine) buildChainWithNativeMiddlewares(fr featuredRoutes, route Route
 	chn := chain.New()
 
 	if ng.conf.Middlewares.Trace {
-		chn = chn.Append(handler.TracingHandler(ng.conf.Name, route.Path, ng.conf.TraceIgnorePaths))
+		chn = chn.Append(handler.TracingHandler(ng.conf.Name,
+			route.Path,
+			handler.WithTraceIgnorePaths(ng.conf.TraceIgnorePaths)))
 	}
 	if ng.conf.Middlewares.Log {
 		chn = chn.Append(ng.getLogHandler())
@@ -202,7 +204,9 @@ func (ng *engine) getShedder(priority bool) load.Shedder {
 func (ng *engine) notFoundHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		chn := chain.New(
-			handler.TracingHandler(ng.conf.Name, "", ng.conf.TraceIgnorePaths),
+			handler.TracingHandler(ng.conf.Name,
+				"",
+				handler.WithTraceIgnorePaths(ng.conf.TraceIgnorePaths)),
 			ng.getLogHandler(),
 		)
 

--- a/rest/handler/tracinghandler.go
+++ b/rest/handler/tracinghandler.go
@@ -13,18 +13,18 @@ import (
 )
 
 type (
-	// TracingOptions is TracingHandler options.
-	TracingOptions struct {
+	// TracingOption defines the method to customize an tracingOptions.
+	TracingOption func(options *tracingOptions)
+
+	// tracingOptions is TracingHandler options.
+	tracingOptions struct {
 		traceIgnorePaths []string
 	}
-
-	// TracingOption defines the method to customize an tracingOptions.
-	TracingOption func(options *TracingOptions)
 )
 
 // TracingHandler return a middleware that process the opentelemetry.
 func TracingHandler(serviceName, path string, opts ...TracingOption) func(http.Handler) http.Handler {
-	var tracingOptions TracingOptions
+	var tracingOptions tracingOptions
 	for _, opt := range opts {
 		opt(&tracingOptions)
 	}
@@ -71,7 +71,7 @@ func TracingHandler(serviceName, path string, opts ...TracingOption) func(http.H
 
 // WithTraceIgnorePaths specifies the traceIgnorePaths option for TracingHandler.
 func WithTraceIgnorePaths(traceIgnorePaths []string) TracingOption {
-	return func(options *TracingOptions) {
+	return func(options *tracingOptions) {
 		options.traceIgnorePaths = traceIgnorePaths
 	}
 }

--- a/rest/handler/tracinghandler.go
+++ b/rest/handler/tracinghandler.go
@@ -24,13 +24,13 @@ type (
 
 // TracingHandler return a middleware that process the opentelemetry.
 func TracingHandler(serviceName, path string, opts ...TracingOption) func(http.Handler) http.Handler {
-	var tracingOptions tracingOptions
+	var tracingOpts tracingOptions
 	for _, opt := range opts {
-		opt(&tracingOptions)
+		opt(&tracingOpts)
 	}
 
 	ignorePaths := collection.NewSet()
-	ignorePaths.AddStr(tracingOptions.traceIgnorePaths...)
+	ignorePaths.AddStr(tracingOpts.traceIgnorePaths...)
 
 	return func(next http.Handler) http.Handler {
 		propagator := otel.GetTextMapPropagator()

--- a/rest/handler/tracinghandler_test.go
+++ b/rest/handler/tracinghandler_test.go
@@ -27,7 +27,7 @@ func TestOtelHandler(t *testing.T) {
 
 	for _, test := range []string{"", "bar"} {
 		t.Run(test, func(t *testing.T) {
-			h := chain.New(TracingHandler("foo", test, nil)).Then(
+			h := chain.New(TracingHandler("foo", test)).Then(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					span := trace.SpanFromContext(r.Context())
 					assert.True(t, span.SpanContext().IsValid())
@@ -65,7 +65,7 @@ func TestDontTracingSpan(t *testing.T) {
 
 	for _, test := range []string{"", "bar", "foo"} {
 		t.Run(test, func(t *testing.T) {
-			h := chain.New(TracingHandler("foo", test, []string{"bar"})).Then(
+			h := chain.New(TracingHandler("foo", test, WithTraceIgnorePaths([]string{"bar"}))).Then(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					span := trace.SpanFromContext(r.Context())
 					spanCtx := span.SpanContext()
@@ -110,7 +110,7 @@ func TestTraceResponseWriter(t *testing.T) {
 
 	for _, test := range []int{0, 200, 300, 400, 401, 500, 503} {
 		t.Run(strconv.Itoa(test), func(t *testing.T) {
-			h := chain.New(TracingHandler("foo", "bar", nil)).Then(
+			h := chain.New(TracingHandler("foo", "bar")).Then(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					span := trace.SpanFromContext(r.Context())
 					spanCtx := span.SpanContext()

--- a/rest/handler/tracinghandler_test.go
+++ b/rest/handler/tracinghandler_test.go
@@ -27,7 +27,7 @@ func TestOtelHandler(t *testing.T) {
 
 	for _, test := range []string{"", "bar"} {
 		t.Run(test, func(t *testing.T) {
-			h := chain.New(TracingHandler("foo", test)).Then(
+			h := chain.New(TracingHandler("foo", test, nil)).Then(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					span := trace.SpanFromContext(r.Context())
 					assert.True(t, span.SpanContext().IsValid())
@@ -63,12 +63,9 @@ func TestDontTracingSpan(t *testing.T) {
 	})
 	defer ztrace.StopAgent()
 
-	DontTraceSpan("bar")
-	defer notTracingSpans.Delete("bar")
-
 	for _, test := range []string{"", "bar", "foo"} {
 		t.Run(test, func(t *testing.T) {
-			h := chain.New(TracingHandler("foo", test)).Then(
+			h := chain.New(TracingHandler("foo", test, []string{"bar"})).Then(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					span := trace.SpanFromContext(r.Context())
 					spanCtx := span.SpanContext()
@@ -113,7 +110,7 @@ func TestTraceResponseWriter(t *testing.T) {
 
 	for _, test := range []int{0, 200, 300, 400, 401, 500, 503} {
 		t.Run(strconv.Itoa(test), func(t *testing.T) {
-			h := chain.New(TracingHandler("foo", "bar")).Then(
+			h := chain.New(TracingHandler("foo", "bar", nil)).Then(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					span := trace.SpanFromContext(r.Context())
 					spanCtx := span.SpanContext()


### PR DESCRIPTION
BREAKING CHANGE: remove `handler.DontTraceSpan` function, please use `rest.RestConf.TraceIgnorePaths` instead.