### PR TITLE
passthrough http.Request

### DIFF
--- a/tools/goctl/api/gogen/handler.tpl
+++ b/tools/goctl/api/gogen/handler.tpl
@@ -15,7 +15,9 @@ func {{.HandlerName}}(svcCtx *svc.ServiceContext) http.HandlerFunc {
 			return
 		}
 
-		{{end}}l := {{.LogicName}}.New{{.LogicType}}(r.Context(), svcCtx)
+		ctx := context.WithValue(r.Context(), "go-zero-http-request", r)
+
+		{{end}}l := {{.LogicName}}.New{{.LogicType}}(ctx, svcCtx)
 		{{if .HasResp}}resp, {{end}}err := l.{{.Call}}({{if .HasRequest}}&req{{end}})
 		if err != nil {
 			httpx.ErrorCtx(r.Context(), w, err)


### PR DESCRIPTION
在处理muiltpart的数据，发现zero-examples/monolithic 提供的例子不能跑。

<img width="582" alt="image" src="https://user-images.githubusercontent.com/5006959/211725656-e9e7d963-4290-4f1b-b165-54ebac720c32.png">

原来的模板生成的代码第一个参数是http.Request。新的模板使用context.Context。这个pr在context里面携带http.Request
后面只要加一行代码就可以修复zero-examples/monolithic的代码。