### PR TITLE
expose `collection.newTimingWheelWithClock()`

### DIFF
--- a/core/collection/timingwheel.go
+++ b/core/collection/timingwheel.go
@@ -69,10 +69,10 @@ func NewTimingWheel(interval time.Duration, numSlots int, execute Execute) (*Tim
 			interval, numSlots, execute)
 	}
 
-	return newTimingWheelWithClock(interval, numSlots, execute, timex.NewTicker(interval))
+	return NewTimingWheelWithClock(interval, numSlots, execute, timex.NewTicker(interval))
 }
 
-func newTimingWheelWithClock(interval time.Duration, numSlots int, execute Execute,
+func NewTimingWheelWithClock(interval time.Duration, numSlots int, execute Execute,
 	ticker timex.Ticker) (*TimingWheel, error) {
 	tw := &TimingWheel{
 		interval:      interval,

--- a/core/collection/timingwheel_test.go
+++ b/core/collection/timingwheel_test.go
@@ -26,7 +26,7 @@ func TestNewTimingWheel(t *testing.T) {
 
 func TestTimingWheel_Drain(t *testing.T) {
 	ticker := timex.NewFakeTicker()
-	tw, _ := newTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
+	tw, _ := NewTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
 	}, ticker)
 	tw.SetTimer("first", 3, testStep*4)
 	tw.SetTimer("second", 5, testStep*7)
@@ -62,7 +62,7 @@ func TestTimingWheel_Drain(t *testing.T) {
 func TestTimingWheel_SetTimerSoon(t *testing.T) {
 	run := syncx.NewAtomicBool()
 	ticker := timex.NewFakeTicker()
-	tw, _ := newTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
+	tw, _ := NewTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
 		assert.True(t, run.CompareAndSwap(false, true))
 		assert.Equal(t, "any", k)
 		assert.Equal(t, 3, v.(int))
@@ -78,7 +78,7 @@ func TestTimingWheel_SetTimerSoon(t *testing.T) {
 func TestTimingWheel_SetTimerTwice(t *testing.T) {
 	run := syncx.NewAtomicBool()
 	ticker := timex.NewFakeTicker()
-	tw, _ := newTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
+	tw, _ := NewTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
 		assert.True(t, run.CompareAndSwap(false, true))
 		assert.Equal(t, "any", k)
 		assert.Equal(t, 5, v.(int))
@@ -96,7 +96,7 @@ func TestTimingWheel_SetTimerTwice(t *testing.T) {
 
 func TestTimingWheel_SetTimerWrongDelay(t *testing.T) {
 	ticker := timex.NewFakeTicker()
-	tw, _ := newTimingWheelWithClock(testStep, 10, func(k, v interface{}) {}, ticker)
+	tw, _ := NewTimingWheelWithClock(testStep, 10, func(k, v interface{}) {}, ticker)
 	defer tw.Stop()
 	assert.NotPanics(t, func() {
 		tw.SetTimer("any", 3, -testStep)
@@ -105,7 +105,7 @@ func TestTimingWheel_SetTimerWrongDelay(t *testing.T) {
 
 func TestTimingWheel_SetTimerAfterClose(t *testing.T) {
 	ticker := timex.NewFakeTicker()
-	tw, _ := newTimingWheelWithClock(testStep, 10, func(k, v interface{}) {}, ticker)
+	tw, _ := NewTimingWheelWithClock(testStep, 10, func(k, v interface{}) {}, ticker)
 	tw.Stop()
 	assert.Equal(t, ErrClosed, tw.SetTimer("any", 3, testStep))
 }
@@ -113,7 +113,7 @@ func TestTimingWheel_SetTimerAfterClose(t *testing.T) {
 func TestTimingWheel_MoveTimer(t *testing.T) {
 	run := syncx.NewAtomicBool()
 	ticker := timex.NewFakeTicker()
-	tw, _ := newTimingWheelWithClock(testStep, 3, func(k, v interface{}) {
+	tw, _ := NewTimingWheelWithClock(testStep, 3, func(k, v interface{}) {
 		assert.True(t, run.CompareAndSwap(false, true))
 		assert.Equal(t, "any", k)
 		assert.Equal(t, 3, v.(int))
@@ -139,7 +139,7 @@ func TestTimingWheel_MoveTimer(t *testing.T) {
 func TestTimingWheel_MoveTimerSoon(t *testing.T) {
 	run := syncx.NewAtomicBool()
 	ticker := timex.NewFakeTicker()
-	tw, _ := newTimingWheelWithClock(testStep, 3, func(k, v interface{}) {
+	tw, _ := NewTimingWheelWithClock(testStep, 3, func(k, v interface{}) {
 		assert.True(t, run.CompareAndSwap(false, true))
 		assert.Equal(t, "any", k)
 		assert.Equal(t, 3, v.(int))
@@ -155,7 +155,7 @@ func TestTimingWheel_MoveTimerSoon(t *testing.T) {
 func TestTimingWheel_MoveTimerEarlier(t *testing.T) {
 	run := syncx.NewAtomicBool()
 	ticker := timex.NewFakeTicker()
-	tw, _ := newTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
+	tw, _ := NewTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
 		assert.True(t, run.CompareAndSwap(false, true))
 		assert.Equal(t, "any", k)
 		assert.Equal(t, 3, v.(int))
@@ -173,7 +173,7 @@ func TestTimingWheel_MoveTimerEarlier(t *testing.T) {
 
 func TestTimingWheel_RemoveTimer(t *testing.T) {
 	ticker := timex.NewFakeTicker()
-	tw, _ := newTimingWheelWithClock(testStep, 10, func(k, v interface{}) {}, ticker)
+	tw, _ := NewTimingWheelWithClock(testStep, 10, func(k, v interface{}) {}, ticker)
 	tw.SetTimer("any", 3, testStep)
 	assert.NotPanics(t, func() {
 		tw.RemoveTimer("any")
@@ -236,7 +236,7 @@ func TestTimingWheel_SetTimer(t *testing.T) {
 			}
 			var actual int32
 			done := make(chan lang.PlaceholderType)
-			tw, err := newTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
+			tw, err := NewTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
 				assert.Equal(t, 1, key.(int))
 				assert.Equal(t, 2, value.(int))
 				actual = atomic.LoadInt32(&count)
@@ -317,7 +317,7 @@ func TestTimingWheel_SetAndMoveThenStart(t *testing.T) {
 			}
 			var actual int32
 			done := make(chan lang.PlaceholderType)
-			tw, err := newTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
+			tw, err := NewTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
 				actual = atomic.LoadInt32(&count)
 				close(done)
 			}, ticker)
@@ -405,7 +405,7 @@ func TestTimingWheel_SetAndMoveTwice(t *testing.T) {
 			}
 			var actual int32
 			done := make(chan lang.PlaceholderType)
-			tw, err := newTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
+			tw, err := NewTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
 				actual = atomic.LoadInt32(&count)
 				close(done)
 			}, ticker)
@@ -486,7 +486,7 @@ func TestTimingWheel_ElapsedAndSet(t *testing.T) {
 			}
 			var actual int32
 			done := make(chan lang.PlaceholderType)
-			tw, err := newTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
+			tw, err := NewTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
 				actual = atomic.LoadInt32(&count)
 				close(done)
 			}, ticker)
@@ -577,7 +577,7 @@ func TestTimingWheel_ElapsedAndSetThenMove(t *testing.T) {
 			}
 			var actual int32
 			done := make(chan lang.PlaceholderType)
-			tw, err := newTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
+			tw, err := NewTimingWheelWithClock(testStep, test.slots, func(key, value interface{}) {
 				actual = atomic.LoadInt32(&count)
 				close(done)
 			}, ticker)
@@ -612,7 +612,7 @@ func TestMoveAndRemoveTask(t *testing.T) {
 		}
 	}
 	var keys []int
-	tw, _ := newTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
+	tw, _ := NewTimingWheelWithClock(testStep, 10, func(k, v interface{}) {
 		assert.Equal(t, "any", k)
 		assert.Equal(t, 3, v.(int))
 		keys = append(keys, v.(int))


### PR DESCRIPTION
It would be convenient if we could expose `newTimingWheelWithClock()` to the endpoint user.

Closes #2786 . The issue contains more details.