### PR TITLE
feat: support for unwrapping slice or array parameters in database operations

### DIFF
--- a/core/stores/sqlx/stmt.go
+++ b/core/stores/sqlx/stmt.go
@@ -3,6 +3,8 @@ package sqlx
 import (
 	"context"
 	"database/sql"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/zeromicro/go-zero/core/logx"
@@ -34,7 +36,70 @@ func SetSlowThreshold(threshold time.Duration) {
 	slowThreshold.Set(threshold)
 }
 
+// FormatSql expand slice or array arguments
+func FormatSql(query string, args ...interface{}) (string, []interface{}) {
+	var n0, n1, j int
+	for _, arg := range args {
+		switch av := reflect.ValueOf(arg); av.Kind() {
+		case reflect.Slice, reflect.Array:
+			if j = av.Len(); j > 0 {
+				n0 += j
+				n1++
+			} else {
+				n0++
+			}
+		default:
+			n0++
+		}
+	}
+
+	if n1 == 0 || n0 == 0 {
+		return query, args
+	}
+
+	type argMap struct{ index, len int }
+	var (
+		resp    = make([]interface{}, 0, n0)
+		argMaps = make([]argMap, 0, n1)
+	)
+	n0 = 0
+	for i, arg := range args {
+		switch av := reflect.ValueOf(arg); av.Kind() {
+		case reflect.Slice, reflect.Array:
+			if n1 = av.Len() - 1; n1 >= 0 {
+				for j = 0; j <= n1; j++ {
+					resp = append(resp, av.Index(j).Interface())
+				}
+				argMaps = append(argMaps, argMap{index: i, len: n1})
+				n0 += n1
+			} else {
+				resp = append(resp, "NULL")
+			}
+		default:
+			resp = append(resp, arg)
+		}
+	}
+
+	var b strings.Builder
+	b.Grow(len(query) + 2*n0)
+	n0, n1 = 0, 0
+	for _, v := range query {
+		b.WriteRune(v)
+		if v == '?' && n0 < len(argMaps) {
+			if argMaps[n0].index == n1 {
+				for j = argMaps[n0].len; j > 0; j-- {
+					b.WriteString(",?")
+				}
+				n0++
+			}
+			n1++
+		}
+	}
+	return b.String(), resp
+}
+
 func exec(ctx context.Context, conn sessionConn, q string, args ...interface{}) (sql.Result, error) {
+	q, args = FormatSql(q, args...)
 	guard := newGuard("exec")
 	if err := guard.start(q, args...); err != nil {
 		return nil, err
@@ -47,6 +112,7 @@ func exec(ctx context.Context, conn sessionConn, q string, args ...interface{}) 
 }
 
 func execStmt(ctx context.Context, conn stmtConn, q string, args ...interface{}) (sql.Result, error) {
+	q, args = FormatSql(q, args...)
 	guard := newGuard("execStmt")
 	if err := guard.start(q, args...); err != nil {
 		return nil, err
@@ -60,6 +126,7 @@ func execStmt(ctx context.Context, conn stmtConn, q string, args ...interface{})
 
 func query(ctx context.Context, conn sessionConn, scanner func(*sql.Rows) error,
 	q string, args ...interface{}) error {
+	q, args = FormatSql(q, args...)
 	guard := newGuard("query")
 	if err := guard.start(q, args...); err != nil {
 		return err
@@ -77,6 +144,7 @@ func query(ctx context.Context, conn sessionConn, scanner func(*sql.Rows) error,
 
 func queryStmt(ctx context.Context, conn stmtConn, scanner func(*sql.Rows) error,
 	q string, args ...interface{}) error {
+	q, args = FormatSql(q, args...)
 	guard := newGuard("queryStmt")
 	if err := guard.start(q, args...); err != nil {
 		return err

--- a/core/stores/sqlx/stmt.go
+++ b/core/stores/sqlx/stmt.go
@@ -36,8 +36,7 @@ func SetSlowThreshold(threshold time.Duration) {
 	slowThreshold.Set(threshold)
 }
 
-// FormatSql expand slice or array arguments
-func FormatSql(query string, args ...interface{}) (string, []interface{}) {
+func expandSliceOrArrayArgs(query string, args ...interface{}) (string, []interface{}) {
 	var n0, n1, j int
 	for _, arg := range args {
 		switch av := reflect.ValueOf(arg); av.Kind() {
@@ -99,7 +98,7 @@ func FormatSql(query string, args ...interface{}) (string, []interface{}) {
 }
 
 func exec(ctx context.Context, conn sessionConn, q string, args ...interface{}) (sql.Result, error) {
-	q, args = FormatSql(q, args...)
+	q, args = expandSliceOrArrayArgs(q, args...)
 	guard := newGuard("exec")
 	if err := guard.start(q, args...); err != nil {
 		return nil, err
@@ -112,7 +111,7 @@ func exec(ctx context.Context, conn sessionConn, q string, args ...interface{}) 
 }
 
 func execStmt(ctx context.Context, conn stmtConn, q string, args ...interface{}) (sql.Result, error) {
-	q, args = FormatSql(q, args...)
+	q, args = expandSliceOrArrayArgs(q, args...)
 	guard := newGuard("execStmt")
 	if err := guard.start(q, args...); err != nil {
 		return nil, err
@@ -126,7 +125,7 @@ func execStmt(ctx context.Context, conn stmtConn, q string, args ...interface{})
 
 func query(ctx context.Context, conn sessionConn, scanner func(*sql.Rows) error,
 	q string, args ...interface{}) error {
-	q, args = FormatSql(q, args...)
+	q, args = expandSliceOrArrayArgs(q, args...)
 	guard := newGuard("query")
 	if err := guard.start(q, args...); err != nil {
 		return err
@@ -144,7 +143,7 @@ func query(ctx context.Context, conn sessionConn, scanner func(*sql.Rows) error,
 
 func queryStmt(ctx context.Context, conn stmtConn, scanner func(*sql.Rows) error,
 	q string, args ...interface{}) error {
-	q, args = FormatSql(q, args...)
+	q, args = expandSliceOrArrayArgs(q, args...)
 	guard := newGuard("queryStmt")
 	if err := guard.start(q, args...); err != nil {
 		return err


### PR DESCRIPTION
there is already an issue：https://github.com/zeromicro/go-zero/issues/2122

Support passing in slice or array parameters in sql, slice or array will be expanded, and `?` will be completed

processing method like `gorm`：[statement.go#L237](https://github.com/go-gorm/gorm/blob/3d35ddba55c5777bd4867a50daff1e626d8fdb4a/statement.go#L237)

Now you can write code like，Only `?` are expanded here, so the parentheses on both sides are required

```go
func (m *defaultObjectModel) FindByIds(ctx context.Context, id []int64) ([]Object, error) {
	query := fmt.Sprintf("select %s from %s where `id` in (?)", ObjectRows, m.table)
	var resp []Object
	err := m.conn.QueryRowsCtx(ctx, &resp, query, id) // Automatically unwrap slices or arrays
	switch err {
	case nil:
		return resp, nil
	case sqlc.ErrNotFound:
		return nil, ErrNotFound
	default:
		return nil, err
	}
}
```
