### PR TITLE
support custom maxBytes in API file

### DIFF
--- a/tools/goctl/api/gogen/genroutes.go
+++ b/tools/goctl/api/gogen/genroutes.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -36,7 +37,7 @@ func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
 `
 	routesAdditionTemplate = `
 	server.AddRoutes(
-		{{.routes}} {{.jwt}}{{.signature}} {{.prefix}} {{.timeout}}
+		{{.routes}} {{.jwt}}{{.signature}} {{.prefix}} {{.timeout}} {{.maxBytes}}
 	)
 `
 	timeoutThreshold = time.Millisecond
@@ -64,6 +65,7 @@ type (
 		middlewares      []string
 		prefix           string
 		jwtTrans         string
+		maxBytes         string
 	}
 	route struct {
 		method  string
@@ -127,8 +129,18 @@ rest.WithPrefix("%s"),`, g.prefix)
 				return fmt.Errorf("timeout should not less than 1ms, now %v", duration)
 			}
 
-			timeout = fmt.Sprintf("rest.WithTimeout(%d * time.Millisecond),", duration/time.Millisecond)
+			timeout = fmt.Sprintf("\n rest.WithTimeout(%d * time.Millisecond),", duration/time.Millisecond)
 			hasTimeout = true
+		}
+
+		var maxBytes string
+		if len(g.maxBytes) > 0 {
+			_, err := strconv.ParseInt(g.maxBytes, 10, 64)
+			if err != nil {
+				return fmt.Errorf("maxBytes %s parse error,it is an invalid number", g.maxBytes)
+			}
+
+			maxBytes = fmt.Sprintf("\n rest.WithMaxBytes(%s),", g.maxBytes)
 		}
 
 		var routes string
@@ -152,6 +164,7 @@ rest.WithPrefix("%s"),`, g.prefix)
 			"signature": signature,
 			"prefix":    prefix,
 			"timeout":   timeout,
+			"maxBytes":  maxBytes,
 		}); err != nil {
 			return err
 		}
@@ -230,6 +243,7 @@ func getRoutes(api *spec.ApiSpec) ([]group, error) {
 		}
 
 		groupedRoutes.timeout = g.GetAnnotation("timeout")
+		groupedRoutes.maxBytes = g.GetAnnotation("maxBytes")
 
 		jwt := g.GetAnnotation("jwt")
 		if len(jwt) > 0 {


### PR DESCRIPTION
custom maxBytes in api file can be used like this
```go
type Request {
	Name string `path:"name,options=you|me"`
}

type Response {
	Message string `json:"message"`
}

@server(
	maxBytes: 1024
)
service A-api {
	@handler GreetHandler
	get /greet/from/:name(Request) returns (Response)
}
```
general code
```go
// Code generated by goctl. DO NOT EDIT.
package handler

import (
	"net/http"

	"test/internal/svc"

	"github.com/zeromicro/go-zero/rest"
)

func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
	server.AddRoutes(
		[]rest.Route{
			{
				Method:  http.MethodGet,
				Path:    "/greet/from/:name",
				Handler: GreetHandler(serverCtx),
			},
		},
		rest.WithMaxBytes(1024),
	)
}
```

For example, in the application of single architecture, there is a function to upload excel files and import data. At this time, the restapi interface for uploading files needs to increase the limit of the request body parameters. Although there is a `rest.WithMaxBytes` method, it cannot be generated through the api file. Once the api file is modified and regenerated, it will be very troublesome to manually modify the code.