### PR TITLE
Improve logging for response bodies

### DIFF
--- a/rest/handler/loghandler.go
+++ b/rest/handler/loghandler.go
@@ -151,7 +151,7 @@ func dumpResponseBody(response *detailLoggedResponseWriter) string {
 	}
 
 	if (isBinaryContentType(contentType)) {
-		return fmt.Sprintf("[Binary Content] (%s, %d)", contentType, len(respBuf))
+		return fmt.Sprintf("[Binary Content] (Content-Type=%s, %d bytes)", contentType, len(respBuf))
 	}
 
 	if (len(respBuf) > 0) {


### PR DESCRIPTION
- Add a check for binary content types in log handler
- Replace response body dump with a new function that takes into account binary content types
- Add a check for empty response body

[rest/handler/loghandler.go]
- Add a function to check if content type is binary file or stream
- Add a function to dump response body that takes into account binary content types
- Replace the response body dump with the new function
- Add a check for empty response body ### BEGIN GIT COMMIT BEFORE AMEND

### END GIT COMMIT BEFORE AMEND