### PR TITLE
Fix Dart API generation bugs; Add ability to generate API for path parameters

### DIFF
--- a/tools/goctl/api/dartgen/genapi.go
+++ b/tools/goctl/api/dartgen/genapi.go
@@ -30,7 +30,7 @@ Future {{pathToFuncName .Path}}( {{if ne .Method "get"}}{{with .RequestType}}{{.
 {{end}}`
 
 const apiTemplateV2 = `import 'api.dart';
-import '../data/{{with .Info}}{{getBaseName .Title}}{{end}}.dart';
+import '../data/{{with .Service}}{{.Name}}{{end}}.dart';
 {{with .Service}}
 /// {{.Name}}
 {{range .Routes}}

--- a/tools/goctl/api/dartgen/genapi.go
+++ b/tools/goctl/api/dartgen/genapi.go
@@ -33,16 +33,18 @@ const apiTemplateV2 = `import 'api.dart';
 import '../data/{{with .Service}}{{.Name}}{{end}}.dart';
 {{with .Service}}
 /// {{.Name}}
-{{range .Routes}}
+{{range $i, $Route := .Routes}}
 /// --{{.Path}}--
 ///
 /// request: {{with .RequestType}}{{.Name}}{{end}}
 /// response: {{with .ResponseType}}{{.Name}}{{end}}
-Future {{normalizeHandlerName .Handler}}( {{if ne .Method "get"}}{{with .RequestType}}{{.Name}} request,{{end}}{{end}}
+Future {{normalizeHandlerName .Handler}}( 
+	{{if hasUrlPathParams $Route}}{{extractPositionalParamsFromPath $Route}},{{end}}
+	{{if ne .Method "get"}}{{with .RequestType}}{{.Name}} request,{{end}}{{end}}
     {Function({{with .ResponseType}}{{.Name}}{{end}})? ok,
     Function(String)? fail,
     Function? eventually}) async {
-  await api{{if eq .Method "get"}}Get{{else}}Post{{end}}('{{.Path}}',{{if ne .Method "get"}}request,{{end}}
+  await api{{if eq .Method "get"}}Get{{else}}Post{{end}}({{makeDartRequestUrlPath $Route}},{{if ne .Method "get"}}request,{{end}}
   	 ok: (data) {
     if (ok != null) ok({{with .ResponseType}}{{.Name}}.fromJson(data){{end}});
   }, fail: fail, eventually: eventually);

--- a/tools/goctl/api/dartgen/genapi.go
+++ b/tools/goctl/api/dartgen/genapi.go
@@ -38,7 +38,7 @@ import '../data/{{with .Service}}{{.Name}}{{end}}.dart';
 ///
 /// request: {{with .RequestType}}{{.Name}}{{end}}
 /// response: {{with .ResponseType}}{{.Name}}{{end}}
-Future {{pathToFuncName .Path}}( {{if ne .Method "get"}}{{with .RequestType}}{{.Name}} request,{{end}}{{end}}
+Future {{normalizeHandlerName .Handler}}( {{if ne .Method "get"}}{{with .RequestType}}{{.Name}} request,{{end}}{{end}}
     {Function({{with .ResponseType}}{{.Name}}{{end}})? ok,
     Function(String)? fail,
     Function? eventually}) async {

--- a/tools/goctl/api/dartgen/util.go
+++ b/tools/goctl/api/dartgen/util.go
@@ -11,6 +11,12 @@ import (
 	"github.com/zeromicro/go-zero/tools/goctl/api/util"
 )
 
+func normalizeHandlerName(handlerName string) string {
+	handler := strings.Replace(handlerName, "Handler", "", 1)
+	handler = lowCamelCase(handler)
+	return handler
+}
+
 func lowCamelCase(s string) string {
 	if len(s) < 1 {
 		return ""
@@ -18,21 +24,6 @@ func lowCamelCase(s string) string {
 
 	s = util.ToCamelCase(util.ToSnakeCase(s))
 	return util.ToLower(s[:1]) + s[1:]
-}
-
-func pathToFuncName(path string) string {
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
-	}
-	if !strings.HasPrefix(path, "/api") {
-		path = "/api" + path
-	}
-
-	path = strings.Replace(path, "/", "_", -1)
-	path = strings.Replace(path, "-", "_", -1)
-
-	camel := util.ToCamelCase(path)
-	return util.ToLower(camel[:1]) + camel[1:]
 }
 
 func getBaseName(str string) string {

--- a/tools/goctl/api/dartgen/vars.go
+++ b/tools/goctl/api/dartgen/vars.go
@@ -8,8 +8,8 @@ var funcMap = template.FuncMap{
 	"isDirectType":          isDirectType,
 	"isClassListType":       isClassListType,
 	"getCoreType":           getCoreType,
-	"pathToFuncName":        pathToFuncName,
 	"lowCamelCase":          lowCamelCase,
+	"normalizeHandlerName":  normalizeHandlerName,
 }
 
 const (

--- a/tools/goctl/api/dartgen/vars.go
+++ b/tools/goctl/api/dartgen/vars.go
@@ -3,13 +3,16 @@ package dartgen
 import "text/template"
 
 var funcMap = template.FuncMap{
-	"getBaseName":           getBaseName,
-	"getPropertyFromMember": getPropertyFromMember,
-	"isDirectType":          isDirectType,
-	"isClassListType":       isClassListType,
-	"getCoreType":           getCoreType,
-	"lowCamelCase":          lowCamelCase,
-	"normalizeHandlerName":  normalizeHandlerName,
+	"getBaseName":                     getBaseName,
+	"getPropertyFromMember":           getPropertyFromMember,
+	"isDirectType":                    isDirectType,
+	"isClassListType":                 isClassListType,
+	"getCoreType":                     getCoreType,
+	"lowCamelCase":                    lowCamelCase,
+	"normalizeHandlerName":            normalizeHandlerName,
+	"hasUrlPathParams":                hasUrlPathParams,
+	"extractPositionalParamsFromPath": extractPositionalParamsFromPath,
+	"makeDartRequestUrlPath":          makeDartRequestUrlPath,
 }
 
 const (


### PR DESCRIPTION
Fix Dart API generation bugs; Add ability to generate API for path parameters

Suppose I have a following API definition, filename is `greet.api`:

```
service greet-api {
	@handler GreetHandler
	get /from/:name(GreetRequest) returns (GreetResponse)
}
```

## Bug 1: Dart import path does not match actual dart file path.

Actual dart file path is `../data/greet-api.dart`
Generated import path is `import '../data/greet.dart'`. This is **WRONG** because it took the `greet.api` file name by mistake.

This bug was solved by replacing the import path to the actual file path. Now it looks like this:
`import '../data/greet-api.dart'`

## Bug 2: Generated API function name is not a valid function name

Generated dart function name is: 
```dart
Future apiFrom:name( 
    {Function(GreetResponse)? ok,
    Function(String)? fail,
    Function? eventually}) async {
  await apiGet('/from/:name',
  	 ok: (data) {
    if (ok != null) ok(GreetResponse.fromJson(data));
  }, fail: fail, eventually: eventually);
}
```

The function name `apiFrom:name` is not a valid function name, which results a compilation error.

This bug was solved by replacing the function to the actual handler name, which is `Greet` by removing the suffix `Handler` from `GreetHandler` in this case. Now it looks like this:
```dart
Future Greet( 
    {Function(GreetResponse)? ok,
    Function(String)? fail,
    Function? eventually}) async {
  await apiGet('/from/:name',
  	 ok: (data) {
    if (ok != null) ok(GreetResponse.fromJson(data));
  }, fail: fail, eventually: eventually);
}
```

## Bug 3: It does not support `path` tag generation

The following code is not correct, because the path param `:name` should be replace by a real parameter value, whereas it isn't.
```dart
Future Greet( 
    {Function(GreetResponse)? ok,
    Function(String)? fail,
    Function? eventually}) async {
  await apiGet('/from/:name',
  	 ok: (data) {
    if (ok != null) ok(GreetResponse.fromJson(data));
  }, fail: fail, eventually: eventually);
}
```
After adding support to generate API for `path` parameters. API users can now pass in the real parameter value for `name`. Now it looks like this:
```dart
Future Greet( 
    String name,
    {Function(GreetResponse)? ok,
    Function(String)? fail,
    Function? eventually}) async {
  await apiGet("/from/${name}",
  	 ok: (data) {
    if (ok != null) ok(GreetResponse.fromJson(data));
  }, fail: fail, eventually: eventually);
}
```
