### PR TITLE
Fix bug in dart api gen: path parameter is not replaced

### DIFF
--- a/tools/goctl/api/dartgen/util.go
+++ b/tools/goctl/api/dartgen/util.go
@@ -185,7 +185,8 @@ func extractPositionalParamsFromPath(route spec.Route) string {
 
 	var params []string
 	for _, member := range ds.GetTagMembers(pathTagKey) {
-		params = append(params, fmt.Sprintf("%s %s", member.Type.Name(), getPropertyFromMember(member)))
+		dartType := member.Type.Name()
+		params = append(params, fmt.Sprintf("%s %s", dartType, getPropertyFromMember(member)))
 	}
 
 	return strings.Join(params, ", ")
@@ -199,7 +200,8 @@ func makeDartRequestUrlPath(route spec.Route) string {
 	}
 
 	for _, member := range ds.GetTagMembers(pathTagKey) {
-		path = strings.ReplaceAll(path, ":"+pathTagKey, "${"+getPropertyFromMember(member)+"}")
+		paramName := member.Tags()[0].Name
+		path = strings.ReplaceAll(path, ":"+paramName, "${"+getPropertyFromMember(member)+"}")
 	}
 
 	return `"` + path + `"`


### PR DESCRIPTION
This PR fixes the bug in previous PR: https://github.com/zeromicro/go-zero/pull/2887

Bug: `pathTagKey` was used by mistake, whose value is always `path`.
Now it is fixed.