### PR TITLE
support ignore table prefix when generating mysql or postgreSql

### DIFF
--- a/tools/goctl/model/cmd.go
+++ b/tools/goctl/model/cmd.go
@@ -60,6 +60,7 @@ func init() {
 	ddlCmd.Flags().StringVar(&command.VarStringHome, "home", "", "The goctl home path of the template, --home and --remote cannot be set at the same time, if they are, --remote has higher priority")
 	ddlCmd.Flags().StringVar(&command.VarStringRemote, "remote", "", "The remote git repo of the template, --home and --remote cannot be set at the same time, if they are, --remote has higher priority\nThe git repo directory must be consistent with the https://github.com/zeromicro/go-zero-template directory structure")
 	ddlCmd.Flags().StringVar(&command.VarStringBranch, "branch", "", "The branch of the remote repo, it does work with --remote")
+	ddlCmd.Flags().StringVar(&command.VarStringPrefix, "prefix", "", "The prefix of the raw table, it does work with --prefix")
 
 	datasourceCmd.Flags().StringVar(&command.VarStringURL, "url", "", `The data source of database,like "root:password@tcp(127.0.0.1:3306)/database"`)
 	datasourceCmd.Flags().StringSliceVarP(&command.VarStringSliceTable, "table", "t", nil, "The table or table globbing patterns in the database")
@@ -70,6 +71,7 @@ func init() {
 	datasourceCmd.Flags().StringVar(&command.VarStringHome, "home", "", "The goctl home path of the template, --home and --remote cannot be set at the same time, if they are, --remote has higher priority")
 	datasourceCmd.Flags().StringVar(&command.VarStringRemote, "remote", "", "The remote git repo of the template, --home and --remote cannot be set at the same time, if they are, --remote has higher priority\nThe git repo directory must be consistent with the https://github.com/zeromicro/go-zero-template directory structure")
 	datasourceCmd.Flags().StringVar(&command.VarStringBranch, "branch", "", "The branch of the remote repo, it does work with --remote")
+	datasourceCmd.Flags().StringVar(&command.VarStringPrefix, "prefix", "", "The prefix of the raw table, it does work with --prefix")
 
 	pgDatasourceCmd.Flags().StringVar(&command.VarStringURL, "url", "", `The data source of database,like "postgres://root:password@127.0.0.1:5432/database?sslmode=disable"`)
 	pgDatasourceCmd.Flags().StringVarP(&command.VarStringTable, "table", "t", "", "The table or table globbing patterns in the database")
@@ -82,6 +84,7 @@ func init() {
 	pgDatasourceCmd.Flags().StringVar(&command.VarStringHome, "home", "", "The goctl home path of the template, --home and --remote cannot be set at the same time, if they are, --remote has higher priority")
 	pgDatasourceCmd.Flags().StringVar(&command.VarStringRemote, "remote", "", "The remote git repo of the template, --home and --remote cannot be set at the same time, if they are, --remote has higher priority\n\tThe git repo directory must be consistent with the https://github.com/zeromicro/go-zero-template directory structure")
 	pgDatasourceCmd.Flags().StringVar(&command.VarStringBranch, "branch", "", "The branch of the remote repo, it does work with --remote")
+	pgDatasourceCmd.Flags().StringVar(&command.VarStringPrefix, "prefix", "", "The prefix of the raw table, it does work with --prefix")
 
 	mongoCmd.Flags().StringSliceVarP(&mongo.VarStringSliceType, "type", "t", nil, "Specified model type name")
 	mongoCmd.Flags().BoolVarP(&mongo.VarBoolCache, "cache", "c", false, "Generate code with cache [optional]")

--- a/tools/goctl/model/sql/gen/delete.go
+++ b/tools/goctl/model/sql/gen/delete.go
@@ -25,7 +25,7 @@ func genDelete(table Table, withCache, postgreSql bool) (string, string, error) 
 	keyVars := keyVariableSet.KeysStr()
 	sort.Strings(keyVars)
 
-	camel := table.Name.ToCamel()
+	camel := table.Name.RemovePrefix(table.prefix).ToCamel()
 	text, err := pathx.LoadTemplate(category, deleteTemplateFile, template.Delete)
 	if err != nil {
 		return "", "", err

--- a/tools/goctl/model/sql/gen/findone.go
+++ b/tools/goctl/model/sql/gen/findone.go
@@ -8,7 +8,7 @@ import (
 )
 
 func genFindOne(table Table, withCache, postgreSql bool) (string, string, error) {
-	camel := table.Name.ToCamel()
+	camel := table.Name.RemovePrefix(table.prefix).ToCamel()
 	text, err := pathx.LoadTemplate(category, findOneTemplateFile, template.FindOne)
 	if err != nil {
 		return "", "", err

--- a/tools/goctl/model/sql/gen/findonebyfield.go
+++ b/tools/goctl/model/sql/gen/findonebyfield.go
@@ -24,7 +24,7 @@ func genFindOneByField(table Table, withCache, postgreSql bool) (*findOneCode, e
 
 	t := util.With("findOneByField").Parse(text)
 	var list []string
-	camelTableName := table.Name.ToCamel()
+	camelTableName := table.Name.RemovePrefix(table.prefix).ToCamel()
 	for _, key := range table.UniqueCacheKey {
 		in, paramJoinString, originalFieldString := convertJoin(key, postgreSql)
 

--- a/tools/goctl/model/sql/gen/insert.go
+++ b/tools/goctl/model/sql/gen/insert.go
@@ -50,7 +50,7 @@ func genInsert(table Table, withCache, postgreSql bool) (string, string, error) 
 		expressionValues = append(expressionValues, "data."+camel)
 	}
 
-	camel := table.Name.ToCamel()
+	camel := table.Name.RemovePrefix(table.prefix).ToCamel()
 	text, err := pathx.LoadTemplate(category, insertTemplateFile, template.Insert)
 	if err != nil {
 		return "", "", err

--- a/tools/goctl/model/sql/gen/new.go
+++ b/tools/goctl/model/sql/gen/new.go
@@ -24,7 +24,7 @@ func genNew(table Table, withCache, postgreSql bool) (string, error) {
 		Execute(map[string]any{
 			"table":                 t,
 			"withCache":             withCache,
-			"upperStartCamelObject": table.Name.ToCamel(),
+			"upperStartCamelObject": table.Name.RemovePrefix(table.prefix).ToCamel(),
 			"data":                  table,
 		})
 	if err != nil {

--- a/tools/goctl/model/sql/gen/tablename.go
+++ b/tools/goctl/model/sql/gen/tablename.go
@@ -16,7 +16,7 @@ func genTableName(table Table) (string, error) {
 		Parse(text).
 		Execute(map[string]any{
 			"tableName":             table.Name.Source(),
-			"upperStartCamelObject": table.Name.ToCamel(),
+			"upperStartCamelObject": table.Name.RemovePrefix(table.prefix).ToCamel(),
 		})
 	if err != nil {
 		return "", nil

--- a/tools/goctl/model/sql/gen/types.go
+++ b/tools/goctl/model/sql/gen/types.go
@@ -24,8 +24,8 @@ func genTypes(table Table, methods string, withCache bool) (string, error) {
 		Execute(map[string]any{
 			"withCache":             withCache,
 			"method":                methods,
-			"upperStartCamelObject": table.Name.ToCamel(),
-			"lowerStartCamelObject": stringx.From(table.Name.ToCamel()).Untitle(),
+			"upperStartCamelObject": table.Name.RemovePrefix(table.prefix).ToCamel(),
+			"lowerStartCamelObject": stringx.From(table.Name.RemovePrefix(table.prefix).ToCamel()).Untitle(),
 			"fields":                fieldsString,
 			"data":                  table,
 		})

--- a/tools/goctl/model/sql/gen/update.go
+++ b/tools/goctl/model/sql/gen/update.go
@@ -55,7 +55,7 @@ func genUpdate(table Table, withCache, postgreSql bool) (
 			expressionValues, pkg+table.PrimaryKey.Name.ToCamel(),
 		)
 	}
-	camelTableName := table.Name.ToCamel()
+	camelTableName := table.Name.RemovePrefix(table.prefix).ToCamel()
 	text, err := pathx.LoadTemplate(category, updateTemplateFile, template.Update)
 	if err != nil {
 		return "", "", err

--- a/tools/goctl/model/sql/gen/vars.go
+++ b/tools/goctl/model/sql/gen/vars.go
@@ -19,7 +19,7 @@ func genVars(table Table, withCache, postgreSql bool) (string, error) {
 		keys = append(keys, v.VarExpression)
 	}
 
-	camel := table.Name.ToCamel()
+	camel := table.Name.RemovePrefix(table.prefix).ToCamel()
 	text, err := pathx.LoadTemplate(category, varTemplateFile, template.Vars)
 	if err != nil {
 		return "", err

--- a/tools/goctl/util/stringx/string.go
+++ b/tools/goctl/util/stringx/string.go
@@ -140,3 +140,12 @@ func ContainsAny(s string, runes ...rune) bool {
 func ContainsWhiteSpace(s string) bool {
 	return ContainsAny(s, WhiteSpace...)
 }
+
+// RemovePrefix remove string prefix
+func (s String) RemovePrefix(prefix string) String {
+	source := s.source
+	if strings.HasPrefix(source, prefix) {
+		s.source = strings.Replace(source, prefix, "", 1)
+	}
+	return s
+}

--- a/tools/goctl/util/stringx/string_test.go
+++ b/tools/goctl/util/stringx/string_test.go
@@ -192,3 +192,10 @@ func TestUntitle(t *testing.T) {
 		assert.Equal(t, c.want, ret)
 	}
 }
+
+func TestRemovePrefix(t *testing.T) {
+	s := String{
+		source: "tb_sys_user",
+	}
+	assert.Equal(t, "sys_user", s.RemovePrefix("tb_").source)
+}


### PR DESCRIPTION
  considering that prefixes will be added when creating tables in actual use, but want to delete prefixes when generating code. So this request was created.
  I hope the author can adopt it.

  the following are examples of use: 
- mysql-ddl: goctl model mysql ddl -src=./sys.sql -dir=. -c --style=go_zero --prefix=tb_
- mysql-datasource: goctl model mysql datasource -url="root:123456@tcp(127.0.0.1:3306)/demo" -table="tb_*" -dir="./" --prefix=tb_
- postgres-datasource: goctl model pg datasource --url='host=127.0.0.1 port=5432 user=postgres password=123456 dbname=demo sslmode=disable' --schema=public --table=tb_sys_user --prefix=tb_