### PR TITLE
[collection] Add `TimingWheel.HasKey()` method and test

### DIFF
--- a/core/collection/timingwheel.go
+++ b/core/collection/timingwheel.go
@@ -162,6 +162,11 @@ func (tw *TimingWheel) Stop() {
 	close(tw.stopChannel)
 }
 
+func (tw *TimingWheel) HasKey(key any) bool {
+	_, ok := tw.timers.Get(key)
+	return ok
+}
+
 func (tw *TimingWheel) drainAll(fn func(key, value any)) {
 	runner := threading.NewTaskRunner(drainWorkers)
 	for _, slot := range tw.slots {


### PR DESCRIPTION
Closes #2918 . See the issue for more description.

`TimingWheel.HasKey()` is a natural requirement, to check whether a task does exist or not.