### PR TITLE
interface conversion: *handler.timeoutWriter is not http.Hijacker: missing method Hijack

### DIFF
--- a/rest/handler/timeouthandler.go
+++ b/rest/handler/timeouthandler.go
@@ -125,6 +125,14 @@ type timeoutWriter struct {
 
 var _ http.Pusher = (*timeoutWriter)(nil)
 
+func (tw *timeoutWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacked, ok := tw.w.(http.Hijacker); ok {
+		return hijacked.Hijack()
+	}
+
+	return nil, nil, errors.New("server doesn't support hijacking")
+}
+
 // Header returns the underline temporary http.Header.
 func (tw *timeoutWriter) Header() http.Header { return tw.h }
 

--- a/rest/handler/timeouthandler.go
+++ b/rest/handler/timeouthandler.go
@@ -1,11 +1,13 @@
 package handler
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"path"
 	"runtime"

--- a/rest/handler/timeouthandler_test.go
+++ b/rest/handler/timeouthandler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/rest/internal/response"
 )
 
 func init() {
@@ -132,6 +133,30 @@ func TestTimeoutClientClosed(t *testing.T) {
 	resp := httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
 	assert.Equal(t, statusClientClosedRequest, resp.Code)
+}
+
+func TestTimeoutHijack(t *testing.T) {
+	resp := httptest.NewRecorder()
+
+	writer := &timeoutWriter{
+		w: &response.WithCodeResponseWriter{
+			Writer: resp,
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		writer.Hijack()
+	})
+
+	writer = &timeoutWriter{
+		w: &response.WithCodeResponseWriter{
+			Writer: mockedHijackable{resp},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		writer.Hijack()
+	})
 }
 
 func TestTimeoutPusher(t *testing.T) {


### PR DESCRIPTION
fix

interface conversion: *handler.timeoutWriter is not http.Hijacker: missing method Hijack