### PR TITLE
Fix bug in dartgen: Increase the processing logic when route.RequestT…

### DIFF
--- a/tools/goctl/api/dartgen/genapi.go
+++ b/tools/goctl/api/dartgen/genapi.go
@@ -38,7 +38,7 @@ import '../data/{{with .Service}}{{.Name}}{{end}}.dart';
 ///
 /// request: {{with .RequestType}}{{.Name}}{{end}}
 /// response: {{with .ResponseType}}{{.Name}}{{end}}
-Future {{normalizeHandlerName .Handler}}( 
+Future {{normalizeHandlerName .Handler}}(
 	{{if hasUrlPathParams $Route}}{{extractPositionalParamsFromPath $Route}},{{end}}
 	{{if ne .Method "get"}}{{with .RequestType}}{{.Name}} request,{{end}}{{end}}
     {Function({{with .ResponseType}}{{.Name}}{{end}})? ok,

--- a/tools/goctl/api/dartgen/util.go
+++ b/tools/goctl/api/dartgen/util.go
@@ -194,6 +194,10 @@ func extractPositionalParamsFromPath(route spec.Route) string {
 
 func makeDartRequestUrlPath(route spec.Route) string {
 	path := route.Path
+	if route.RequestType == nil {
+		return `"` + path + `"`
+	}
+
 	ds, ok := route.RequestType.(spec.DefineStruct)
 	if !ok {
 		return path


### PR DESCRIPTION
This PR  is improved version of previous PR: https://github.com/zeromicro/go-zero/pull/2891
@fondoger Thanks a lot for your contribution!

Bug: when route.RequestType is nil, api file parsing failed and gen dart code miss quotes. As shown in the following figure:

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/11294011/222874426-48e7f6c1-279b-47f6-9583-54823f103966.png">



Now it is fixed.