### PR TITLE
fix function param type define error

### DIFF
--- a/tools/goctl/api/gogen/logic.tpl
+++ b/tools/goctl/api/gogen/logic.tpl
@@ -18,7 +18,7 @@ func New{{.logic}}(ctx context.Context, svcCtx *svc.ServiceContext) *{{.logic}} 
 	}
 }
 
-func (l *{{.logic}}) {{.function}}({{.request}}) {{.responseType}} {
+func (l *{{.logic}}) {{.function}}(*{{.request}}) {{.responseType}} {
 	// todo: add your logic here and delete this line
 
 	{{.returnString}}


### PR DESCRIPTION
fix error when generate logic code.
In handle tpl file,the funcition is called: l.{{.Call}}({{if .HasRequest}}&req{{end}}), the last param is address, but in logic define, the last param is strcut, so my vscode report error.