### PR TITLE
Fix bug: replace int and float with num type in dart

### DIFF
--- a/tools/goctl/api/dartgen/gendata.go
+++ b/tools/goctl/api/dartgen/gendata.go
@@ -13,7 +13,7 @@ const dataTemplate = `// --{{with .Info}}{{.Title}}{{end}}--
 class {{.Name}}{
 	{{range .Members}}
 	/// {{.Comment}}
-	final {{.Type.Name}} {{lowCamelCase .Name}};
+	final {{if isNumberType .Type.Name}}num{{else}}{{.Type.Name}}{{end}} {{lowCamelCase .Name}};
 	{{end}}
 	{{.Name}}({ {{range .Members}}
 		this.{{lowCamelCase .Name}},{{end}}
@@ -37,7 +37,7 @@ const dataTemplateV2 = `// --{{with .Info}}{{.Title}}{{end}}--
 class {{.Name}} {
 	{{range .Members}}
 	{{if .Comment}}{{.Comment}}{{end}}
-	final {{.Type.Name}} {{lowCamelCase .Name}};
+	final {{if isNumberType .Type.Name}}num{{else}}{{.Type.Name}}{{end}} {{lowCamelCase .Name}};
   {{end}}{{.Name}}({{if .Members}}{
 	{{range .Members}}  required this.{{lowCamelCase .Name}},
 	{{end}}}{{end}});

--- a/tools/goctl/api/dartgen/util.go
+++ b/tools/goctl/api/dartgen/util.go
@@ -57,6 +57,15 @@ func isAtomicType(s string) bool {
 	}
 }
 
+func isNumberType(s string) bool {
+	switch s {
+	case "int", "double":
+		return true
+	default:
+		return false
+	}
+}
+
 func isListType(s string) bool {
 	return strings.HasPrefix(s, "List<")
 }

--- a/tools/goctl/api/dartgen/vars.go
+++ b/tools/goctl/api/dartgen/vars.go
@@ -6,6 +6,7 @@ var funcMap = template.FuncMap{
 	"getBaseName":                     getBaseName,
 	"getPropertyFromMember":           getPropertyFromMember,
 	"isDirectType":                    isDirectType,
+	"isNumberType":                    isNumberType,
 	"isClassListType":                 isClassListType,
 	"getCoreType":                     getCoreType,
 	"lowCamelCase":                    lowCamelCase,


### PR DESCRIPTION
e.g. When data type is double and data value is 1, dart catch error as shown in the following figure
![image](https://user-images.githubusercontent.com/11294011/226110782-615c0286-6250-4b52-b11b-5e634f72cfbe.png)

so I use the num type to be compatible with double and int


