### PR TITLE
Fix the problem of package name for generated kt code.

### DIFF
--- a/tools/goctl/api/ktgen/api.tpl
+++ b/tools/goctl/api/ktgen/api.tpl
@@ -1,4 +1,4 @@
-package {{with .Info}}{{.Desc}}{{end}}
+package {{.Pkg}}
 
 import com.google.gson.Gson
 

--- a/tools/goctl/api/ktgen/gen.go
+++ b/tools/goctl/api/ktgen/gen.go
@@ -82,5 +82,9 @@ func genApi(dir, pkg string, api *spec.ApiSpec) error {
 	if e != nil {
 		return e
 	}
-	return t.Execute(file, api)
+	type data struct {
+		*spec.ApiSpec
+		Pkg string
+	}
+	return t.Execute(file, data{api, pkg})
 }


### PR DESCRIPTION
去掉描述作为包名，将命令参数中的包名，作为生成代码的包名