### PR TITLE
fixbug:superfluous response.WriteHeader

### DIFF
--- a/rest/handler/timeouthandler.go
+++ b/rest/handler/timeouthandler.go
@@ -183,7 +183,9 @@ func (tw *timeoutWriter) writeHeaderLocked(code int) {
 func (tw *timeoutWriter) WriteHeader(code int) {
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
-	tw.writeHeaderLocked(code)
+	if !tw.wroteHeader {
+		tw.writeHeaderLocked(code)
+	}
 }
 
 func checkWriteHeaderCode(code int) {


### PR DESCRIPTION
In special cases where the method (http.Write) is needed for business logic, within the interceptor TimeoutHandler, WriteHeader code:200 is automatically written inside the overwritten method (timeriter.write), Then the case <-done of timeoutHandler.ServeHTTP continues to call the method (WriteHeader, Write), resulting in an error "http: superfluous response.WriteHeader call from ..."