### PR TITLE
feat(redis): add ScriptRun API and migrate EvalCtx to ScriptRun for limit, lock and bloom

### DIFF
--- a/core/limit/periodlimit.go
+++ b/core/limit/periodlimit.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	red "github.com/go-redis/redis/v8"
 	"github.com/zeromicro/go-zero/core/stores/redis"
 )
 
@@ -30,7 +29,7 @@ var (
 	ErrUnknownCode = errors.New("unknown status code")
 
 	// to be compatible with aliyun redis, we cannot use `local key = KEYS[1]` to reuse the key
-	periodScript = red.NewScript(`local limit = tonumber(ARGV[1])
+	periodScript = redis.NewScript(`local limit = tonumber(ARGV[1])
 local window = tonumber(ARGV[2])
 local current = redis.call("INCRBY", KEYS[1], 1)
 if current == 1 then

--- a/core/limit/periodlimit.go
+++ b/core/limit/periodlimit.go
@@ -6,23 +6,9 @@ import (
 	"strconv"
 	"time"
 
+	red "github.com/go-redis/redis/v8"
 	"github.com/zeromicro/go-zero/core/stores/redis"
 )
-
-// to be compatible with aliyun redis, we cannot use `local key = KEYS[1]` to reuse the key
-const periodScript = `local limit = tonumber(ARGV[1])
-local window = tonumber(ARGV[2])
-local current = redis.call("INCRBY", KEYS[1], 1)
-if current == 1 then
-    redis.call("expire", KEYS[1], window)
-end
-if current < limit then
-    return 1
-elseif current == limit then
-    return 2
-else
-    return 0
-end`
 
 const (
 	// Unknown means not initialized state.
@@ -39,8 +25,25 @@ const (
 	internalHitQuota  = 2
 )
 
-// ErrUnknownCode is an error that represents unknown status code.
-var ErrUnknownCode = errors.New("unknown status code")
+var (
+	// ErrUnknownCode is an error that represents unknown status code.
+	ErrUnknownCode = errors.New("unknown status code")
+
+	// to be compatible with aliyun redis, we cannot use `local key = KEYS[1]` to reuse the key
+	periodScript = red.NewScript(`local limit = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local current = redis.call("INCRBY", KEYS[1], 1)
+if current == 1 then
+    redis.call("expire", KEYS[1], window)
+end
+if current < limit then
+    return 1
+elseif current == limit then
+    return 2
+else
+    return 0
+end`)
+)
 
 type (
 	// PeriodOption defines the method to customize a PeriodLimit.
@@ -80,7 +83,7 @@ func (h *PeriodLimit) Take(key string) (int, error) {
 
 // TakeCtx requests a permit with context, it returns the permit state.
 func (h *PeriodLimit) TakeCtx(ctx context.Context, key string) (int, error) {
-	resp, err := h.limitStore.EvalCtx(ctx, periodScript, []string{h.keyPrefix + key}, []string{
+	resp, err := h.limitStore.ScriptRunCtx(ctx, periodScript, []string{h.keyPrefix + key}, []string{
 		strconv.Itoa(h.quota),
 		strconv.Itoa(h.calcExpireSeconds()),
 	})

--- a/core/limit/tokenlimit.go
+++ b/core/limit/tokenlimit.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	red "github.com/go-redis/redis/v8"
 	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/redis"
 	xrate "golang.org/x/time/rate"
@@ -24,7 +23,7 @@ const (
 // to be compatible with aliyun redis, we cannot use `local key = KEYS[1]` to reuse the key
 // KEYS[1] as tokens_key
 // KEYS[2] as timestamp_key
-var script = red.NewScript(`local rate = tonumber(ARGV[1])
+var script = redis.NewScript(`local rate = tonumber(ARGV[1])
 local capacity = tonumber(ARGV[2])
 local now = tonumber(ARGV[3])
 local requested = tonumber(ARGV[4])

--- a/core/limit/tokenlimit.go
+++ b/core/limit/tokenlimit.go
@@ -9,16 +9,22 @@ import (
 	"sync/atomic"
 	"time"
 
+	red "github.com/go-redis/redis/v8"
 	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/redis"
 	xrate "golang.org/x/time/rate"
 )
 
 const (
-	// to be compatible with aliyun redis, we cannot use `local key = KEYS[1]` to reuse the key
-	// KEYS[1] as tokens_key
-	// KEYS[2] as timestamp_key
-	script = `local rate = tonumber(ARGV[1])
+	tokenFormat     = "{%s}.tokens"
+	timestampFormat = "{%s}.ts"
+	pingInterval    = time.Millisecond * 100
+)
+
+// to be compatible with aliyun redis, we cannot use `local key = KEYS[1]` to reuse the key
+// KEYS[1] as tokens_key
+// KEYS[2] as timestamp_key
+var script = red.NewScript(`local rate = tonumber(ARGV[1])
 local capacity = tonumber(ARGV[2])
 local now = tonumber(ARGV[3])
 local requested = tonumber(ARGV[4])
@@ -45,11 +51,7 @@ end
 redis.call("setex", KEYS[1], ttl, new_tokens)
 redis.call("setex", KEYS[2], ttl, now)
 
-return allowed`
-	tokenFormat     = "{%s}.tokens"
-	timestampFormat = "{%s}.ts"
-	pingInterval    = time.Millisecond * 100
-)
+return allowed`)
 
 // A TokenLimiter controls how frequently events are allowed to happen with in one second.
 type TokenLimiter struct {
@@ -110,7 +112,7 @@ func (lim *TokenLimiter) reserveN(ctx context.Context, now time.Time, n int) boo
 		return lim.rescueLimiter.AllowN(now, n)
 	}
 
-	resp, err := lim.store.EvalCtx(ctx,
+	resp, err := lim.store.ScriptRunCtx(ctx,
 		script,
 		[]string{
 			lim.tokenKey,

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -87,6 +87,8 @@ type (
 	FloatCmd = red.FloatCmd
 	// StringCmd is an alias of redis.StringCmd.
 	StringCmd = red.StringCmd
+	// Script is an alias of redis.Script.
+	Script = red.Script
 )
 
 // New returns a Redis with given options.
@@ -143,6 +145,11 @@ func newRedis(addr string, opts ...Option) *Redis {
 	}
 
 	return r
+}
+
+// NewScript returns a new Script instance.
+func NewScript(script string) *Script {
+	return red.NewScript(script)
 }
 
 // BitCount is redis bitcount command implementation.
@@ -1631,12 +1638,12 @@ func (s *Redis) ScriptLoadCtx(ctx context.Context, script string) (string, error
 }
 
 // ScriptRun is the implementation of *redis.Script run command.
-func (s *Redis) ScriptRun(script *red.Script, keys []string, args ...any) (any, error) {
+func (s *Redis) ScriptRun(script *Script, keys []string, args ...any) (any, error) {
 	return s.ScriptRunCtx(context.Background(), script, keys, args...)
 }
 
 // ScriptRunCtx is the implementation of *redis.Script run command.
-func (s *Redis) ScriptRunCtx(ctx context.Context, script *red.Script, keys []string, args ...any) (val any, err error) {
+func (s *Redis) ScriptRunCtx(ctx context.Context, script *Script, keys []string, args ...any) (val any, err error) {
 	err = s.brk.DoWithAcceptable(func() error {
 		conn, err := getRedis(s)
 		if err != nil {

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -1630,6 +1630,25 @@ func (s *Redis) ScriptLoadCtx(ctx context.Context, script string) (string, error
 	return conn.ScriptLoad(ctx, script).Result()
 }
 
+// ScriptRun is the implementation of *redis.Script run command.
+func (s *Redis) ScriptRun(script *red.Script, keys []string, args ...any) (any, error) {
+	return s.ScriptRunCtx(context.Background(), script, keys, args...)
+}
+
+// ScriptRunCtx is the implementation of *redis.Script run command.
+func (s *Redis) ScriptRunCtx(ctx context.Context, script *red.Script, keys []string, args ...any) (val any, err error) {
+	err = s.brk.DoWithAcceptable(func() error {
+		conn, err := getRedis(s)
+		if err != nil {
+			return err
+		}
+
+		val, err = script.Run(ctx, conn, keys, args...).Result()
+		return err
+	}, acceptable)
+	return
+}
+
 // Set is the implementation of redis set command.
 func (s *Redis) Set(key, value string) error {
 	return s.SetCtx(context.Background(), key, value)

--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -240,6 +240,24 @@ func TestRedis_Eval(t *testing.T) {
 	})
 }
 
+func TestRedis_ScriptRun(t *testing.T) {
+	runOnRedis(t, func(client *Redis) {
+		sc := red.NewScript(`redis.call("EXISTS", KEYS[1])`)
+		sc2 := red.NewScript(`return redis.call("EXISTS", KEYS[1])`)
+		_, err := New(client.Addr, badType()).ScriptRun(sc, []string{"notexist"})
+		assert.NotNil(t, err)
+		_, err = client.ScriptRun(sc, []string{"notexist"})
+		assert.Equal(t, Nil, err)
+		err = client.Set("key1", "value1")
+		assert.Nil(t, err)
+		_, err = client.ScriptRun(sc, []string{"key1"})
+		assert.Equal(t, Nil, err)
+		val, err := client.ScriptRun(sc2, []string{"key1"})
+		assert.Nil(t, err)
+		assert.Equal(t, int64(1), val)
+	})
+}
+
 func TestRedis_GeoHash(t *testing.T) {
 	runOnRedis(t, func(client *Redis) {
 		_, err := client.GeoHash("parent", "child1", "child2")

--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -242,8 +242,8 @@ func TestRedis_Eval(t *testing.T) {
 
 func TestRedis_ScriptRun(t *testing.T) {
 	runOnRedis(t, func(client *Redis) {
-		sc := red.NewScript(`redis.call("EXISTS", KEYS[1])`)
-		sc2 := red.NewScript(`return redis.call("EXISTS", KEYS[1])`)
+		sc := NewScript(`redis.call("EXISTS", KEYS[1])`)
+		sc2 := NewScript(`return redis.call("EXISTS", KEYS[1])`)
 		_, err := New(client.Addr, badType()).ScriptRun(sc, []string{"notexist"})
 		assert.NotNil(t, err)
 		_, err = client.ScriptRun(sc, []string{"notexist"})

--- a/core/stores/redis/redislock.go
+++ b/core/stores/redis/redislock.go
@@ -20,13 +20,13 @@ const (
 )
 
 var (
-	lockScript = red.NewScript(`if redis.call("GET", KEYS[1]) == ARGV[1] then
+	lockScript = NewScript(`if redis.call("GET", KEYS[1]) == ARGV[1] then
     redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])
     return "OK"
 else
     return redis.call("SET", KEYS[1], ARGV[1], "NX", "PX", ARGV[2])
 end`)
-	delScript = red.NewScript(`if redis.call("GET", KEYS[1]) == ARGV[1] then
+	delScript = NewScript(`if redis.call("GET", KEYS[1]) == ARGV[1] then
     return redis.call("DEL", KEYS[1])
 else
     return 0

--- a/core/stores/redis/redislock.go
+++ b/core/stores/redis/redislock.go
@@ -17,17 +17,20 @@ const (
 	randomLen       = 16
 	tolerance       = 500 // milliseconds
 	millisPerSecond = 1000
-	lockCommand     = `if redis.call("GET", KEYS[1]) == ARGV[1] then
+)
+
+var (
+	lockScript = red.NewScript(`if redis.call("GET", KEYS[1]) == ARGV[1] then
     redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])
     return "OK"
 else
     return redis.call("SET", KEYS[1], ARGV[1], "NX", "PX", ARGV[2])
-end`
-	delCommand = `if redis.call("GET", KEYS[1]) == ARGV[1] then
+end`)
+	delScript = red.NewScript(`if redis.call("GET", KEYS[1]) == ARGV[1] then
     return redis.call("DEL", KEYS[1])
 else
     return 0
-end`
+end`)
 )
 
 // A RedisLock is a redis lock.
@@ -59,7 +62,7 @@ func (rl *RedisLock) Acquire() (bool, error) {
 // AcquireCtx acquires the lock with the given ctx.
 func (rl *RedisLock) AcquireCtx(ctx context.Context) (bool, error) {
 	seconds := atomic.LoadUint32(&rl.seconds)
-	resp, err := rl.store.EvalCtx(ctx, lockCommand, []string{rl.key}, []string{
+	resp, err := rl.store.ScriptRunCtx(ctx, lockScript, []string{rl.key}, []string{
 		rl.id, strconv.Itoa(int(seconds)*millisPerSecond + tolerance),
 	})
 	if err == red.Nil {
@@ -87,7 +90,7 @@ func (rl *RedisLock) Release() (bool, error) {
 
 // ReleaseCtx releases the lock with the given ctx.
 func (rl *RedisLock) ReleaseCtx(ctx context.Context) (bool, error) {
-	resp, err := rl.store.EvalCtx(ctx, delCommand, []string{rl.key}, []string{rl.id})
+	resp, err := rl.store.ScriptRunCtx(ctx, delScript, []string{rl.key}, []string{rl.id})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
https://redis.uptrace.dev/guide/lua-scripting.html#redis-script

The go-redis docs says:
```
Internally, go-redis uses EVALSHA to execute the script and fallbacks to EVAL if the script does not exist.
```