### PR TITLE
fix. log global field context key not unique

### DIFF
--- a/core/logx/fields.go
+++ b/core/logx/fields.go
@@ -12,7 +12,7 @@ var (
 	globalFieldsLock sync.Mutex
 )
 
-type contextKey struct{}
+type contextKey int
 
 // AddGlobalFields adds global fields.
 func AddGlobalFields(fields ...LogField) {
@@ -29,16 +29,16 @@ func AddGlobalFields(fields ...LogField) {
 
 // ContextWithFields returns a new context with the given fields.
 func ContextWithFields(ctx context.Context, fields ...LogField) context.Context {
-	if val := ctx.Value(fieldsContextKey); val != nil {
+	if val := ctx.Value(&fieldsContextKey); val != nil {
 		if arr, ok := val.([]LogField); ok {
 			allFields := make([]LogField, 0, len(arr)+len(fields))
 			allFields = append(allFields, arr...)
 			allFields = append(allFields, fields...)
-			return context.WithValue(ctx, fieldsContextKey, allFields)
+			return context.WithValue(ctx, &fieldsContextKey, allFields)
 		}
 	}
 
-	return context.WithValue(ctx, fieldsContextKey, fields)
+	return context.WithValue(ctx, &fieldsContextKey, fields)
 }
 
 // WithFields returns a new logger with the given fields.

--- a/core/logx/fields_test.go
+++ b/core/logx/fields_test.go
@@ -34,7 +34,7 @@ func TestAddGlobalFields(t *testing.T) {
 
 func TestContextWithFields(t *testing.T) {
 	ctx := ContextWithFields(context.Background(), Field("a", 1), Field("b", 2))
-	vals := ctx.Value(fieldsContextKey)
+	vals := ctx.Value(&fieldsContextKey)
 	assert.NotNil(t, vals)
 	fields, ok := vals.([]LogField)
 	assert.True(t, ok)
@@ -43,7 +43,7 @@ func TestContextWithFields(t *testing.T) {
 
 func TestWithFields(t *testing.T) {
 	ctx := WithFields(context.Background(), Field("a", 1), Field("b", 2))
-	vals := ctx.Value(fieldsContextKey)
+	vals := ctx.Value(&fieldsContextKey)
 	assert.NotNil(t, vals)
 	fields, ok := vals.([]LogField)
 	assert.True(t, ok)
@@ -55,7 +55,7 @@ func TestWithFieldsAppend(t *testing.T) {
 	ctx := context.WithValue(context.Background(), dummyKey, "dummy")
 	ctx = ContextWithFields(ctx, Field("a", 1), Field("b", 2))
 	ctx = ContextWithFields(ctx, Field("c", 3), Field("d", 4))
-	vals := ctx.Value(fieldsContextKey)
+	vals := ctx.Value(&fieldsContextKey)
 	assert.NotNil(t, vals)
 	fields, ok := vals.([]LogField)
 	assert.True(t, ok)
@@ -80,8 +80,8 @@ func TestWithFieldsAppendCopy(t *testing.T) {
 	ctxa := ContextWithFields(ctx, af)
 	ctxb := ContextWithFields(ctx, bf)
 
-	assert.EqualValues(t, af, ctxa.Value(fieldsContextKey).([]LogField)[count])
-	assert.EqualValues(t, bf, ctxb.Value(fieldsContextKey).([]LogField)[count])
+	assert.EqualValues(t, af, ctxa.Value(&fieldsContextKey).([]LogField)[count])
+	assert.EqualValues(t, bf, ctxb.Value(&fieldsContextKey).([]LogField)[count])
 }
 
 func BenchmarkAtomicValue(b *testing.B) {


### PR DESCRIPTION
test code 
```go
type Void struct{}

var UniqueKey1 Void
var UniqueKey2 Void

func main() {
    fmt.Printf("%p, %+v\n", &UniqueKey1, UniqueKey1)
    fmt.Printf("%p, %+v\n", &UniqueKey2, UniqueKey2)
    fmt.Println(UniqueKey1 == UniqueKey2)
}
```
console
```
> go run main.go
0x1025eab00, {}
0x1025eab00, {}
true
```

If other libraries also use the wrong type, it can cause a conflict.