### PR TITLE
feat. log Mode add custom

### DIFF
--- a/core/logx/config.go
+++ b/core/logx/config.go
@@ -8,7 +8,7 @@ type LogConf struct {
 	// console: log to console.
 	// file: log to file.
 	// volume: used in k8s, prepend the hostname to the log file name.
-	Mode string `json:",default=console,options=[console,file,volume]"`
+	Mode string `json:",default=console,options=[console,file,volume,custom]"`
 	// Encoding represents the encoding type, default is `json`.
 	// json: json encoding.
 	// plain: plain text encoding, typically used in development.

--- a/core/logx/logs.go
+++ b/core/logx/logs.go
@@ -254,6 +254,8 @@ func SetUp(c LogConf) (err error) {
 			err = setupWithFiles(c)
 		case volumeMode:
 			err = setupWithVolume(c)
+		case customMode:
+			log.Println("logx uses custom mode and you need to pass in the logx.SetWriter() yourself")
 		default:
 			setupWithConsole()
 		}

--- a/core/logx/vars.go
+++ b/core/logx/vars.go
@@ -31,6 +31,7 @@ const (
 
 	fileMode   = "file"
 	volumeMode = "volume"
+	customMode = "custom"
 
 	levelAlert  = "alert"
 	levelInfo   = "info"

--- a/core/logx/writer.go
+++ b/core/logx/writer.go
@@ -263,7 +263,7 @@ func buildPlainFields(fields ...LogField) []string {
 	return items
 }
 
-func combineGlobalFields(fields []LogField) []LogField {
+func CombineGlobalFields(fields []LogField) []LogField {
 	globals := globalFields.Load()
 	if globals == nil {
 		return fields
@@ -287,7 +287,7 @@ func output(writer io.Writer, level string, val any, fields ...LogField) {
 		}
 	}
 
-	fields = combineGlobalFields(fields)
+	fields = CombineGlobalFields(fields)
 
 	switch atomic.LoadUint32(&encoding) {
 	case plainEncodingType:


### PR DESCRIPTION
LogConf.Mode add `custom`.
Facilitates third-party components to use `logx. SetWriter` to control output.