### PR TITLE
fix default grpc-gateway connect timeout

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -38,6 +38,7 @@ func MustNewServer(c GatewayConf, opts ...Option) *Server {
 	svr := &Server{
 		Server:    rest.MustNewServer(c.RestConf),
 		upstreams: c.Upstreams,
+		timeout:   time.Duration(c.Timeout) * time.Millisecond,
 	}
 	for _, opt := range opts {
 		opt(svr)


### PR DESCRIPTION
Fix the problem that the default grpc-gateway connects to the rpc server timeout

bug issue: #3140

reason: https://github.com/zeromicro/go-zero/commit/0d5a68869dbc06db9fed6ed429a6b301e4b9f176#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b