### PR TITLE
fix(metrics): enable prometheus global switch when user enable devsever metrics

### DIFF
--- a/core/prometheus/agent.go
+++ b/core/prometheus/agent.go
@@ -21,6 +21,11 @@ func Enabled() bool {
 	return enabled.True()
 }
 
+// Enable enables prometheus.
+func Enable() {
+	enabled.Set(true)
+}
+
 // StartAgent starts a prometheus agent.
 func StartAgent(c Config) {
 	if len(c.Host) == 0 {

--- a/internal/devserver/server.go
+++ b/internal/devserver/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/felixge/fgprof"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/zeromicro/go-zero/core/logx"
+	"github.com/zeromicro/go-zero/core/prometheus"
 	"github.com/zeromicro/go-zero/core/threading"
 	"github.com/zeromicro/go-zero/internal/health"
 )
@@ -42,6 +43,8 @@ func (s *Server) addRoutes() {
 
 	// metrics
 	if s.config.EnableMetrics {
+		// enable prometheus global switch
+		prometheus.Enable()
 		s.handleFunc(s.config.MetricsPath, promhttp.Handler().ServeHTTP)
 	}
 	// pprof


### PR DESCRIPTION
`DevServer` aim to replace old prometheus agent, but the global switcher of prometheus pkg is not enable when using `DevServer`.