### PR TITLE
no \t to space line

### DIFF
--- a/tools/goctl/api/format/format.go
+++ b/tools/goctl/api/format/format.go
@@ -171,7 +171,9 @@ func apiFormat(data string, skipCheckDeclare bool, filename ...string) (string, 
 				tapCount++
 			}
 		}
-		util.WriteIndent(&builder, tapCount)
+		if line != "" {
+			util.WriteIndent(&builder, tapCount)
+		}
 		builder.WriteString(line + pathx.NL)
 		if strings.HasSuffix(noCommentLine, leftParenthesis) || strings.HasSuffix(noCommentLine, leftBrace) {
 			tapCount++

--- a/tools/goctl/api/format/format_test.go
+++ b/tools/goctl/api/format/format_test.go
@@ -26,6 +26,11 @@ service A-api {
 handler: GreetHandler
   )
   get /greet/from/:name(Request) returns (Response)
+
+@server(
+handler: GreetHandler2
+  )
+  get /greet/from2/:name(Request) returns (Response)
 }
 `
 
@@ -41,6 +46,11 @@ service A-api {
 		handler: GreetHandler
 	)
 	get /greet/from/:name(Request) returns (Response)
+
+	@server(
+		handler: GreetHandler2
+	)
+	get /greet/from2/:name(Request) returns (Response)
 }`
 )
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28895116/234751366-c7053655-d318-42a2-b027-5d1d864fa382.png)

before this, there will be meaningless tabs between multiple request definitions.