### PR TITLE
[dart-gen] Fix nullable list item issue

### DIFF
--- a/tools/goctl/api/dartgen/gendata.go
+++ b/tools/goctl/api/dartgen/gendata.go
@@ -60,7 +60,7 @@ class {{.Name}} {
 				{{if isDirectType .Type.Name}}
 					{{lowCamelCase .Name}}
 				{{else if isClassListType .Type.Name}}
-					{{lowCamelCase .Name}}{{if isNullableType .Type.Name}}?{{end}}.map((i) => i.toJson())
+					{{lowCamelCase .Name}}{{if isNullableType .Type.Name}}?{{end}}.map((i) => i{{if isListItemsNullable .Type.Name}}?{{end}}.toJson())
 				{{else}}
 					{{lowCamelCase .Name}}{{if isNullableType .Type.Name}}?{{end}}.toJson()
 				{{end}}

--- a/tools/goctl/api/dartgen/util.go
+++ b/tools/goctl/api/dartgen/util.go
@@ -74,6 +74,10 @@ func isClassListType(s string) bool {
 	return strings.HasPrefix(s, "List<") && !isAtomicType(getCoreType(s))
 }
 
+func isListItemsNullable(s string) bool {
+	return isListType(s) && isNullableType(getCoreType(s))
+}
+
 func isMapType(s string) bool {
 	return strings.HasPrefix(s, "Map<")
 }

--- a/tools/goctl/api/dartgen/vars.go
+++ b/tools/goctl/api/dartgen/vars.go
@@ -8,6 +8,7 @@ var funcMap = template.FuncMap{
 	"isDirectType":                    isDirectType,
 	"isNumberType":                    isNumberType,
 	"isClassListType":                 isClassListType,
+	"isListItemsNullable":             isListItemsNullable,
 	"isNullableType":                  isNullableType,
 	"appendNullCoalescing":            appendNullCoalescing,
 	"appendDefaultEmptyValue":         appendDefaultEmptyValue,


### PR DESCRIPTION
Suppose we have a `hello.api` looks like this:

```go
// hello.api
type Greet {
      Items []*GreetItem `json:"greet"`
}
type GreetItems {
      FirstName string `json:"firstName"`
      LastName string `json:"lastName"`
}
```

**Current Behavior**

Currently, the generated `.dart` code could not compile, because variable `i` whose type is `GreetItem?` is not null safe.
If the one of the list item variable `i` is null, the the code will crash.

```dart

class Greet {
  final List<GreetItem?> items;
  Greet({
    required this.items,
  });
  factory Greet.fromJson(Map<String, dynamic> m) {
    return Greet(
      items: ((m['greet'] ?? []) as List<dynamic>)
          .map((i) => GreetItem?.fromJson(i))
          .toList(),
    );
  }
  Map<String, dynamic> toJson() {
    return {
      'greet': items.map((i) => i.toJson()),         #### Could not compile
    };
  }
}
```

**After fix**

After fix in this PR, the generated code is null safe and can be compiled normally.

```dart
class Greet {
  final List<GreetItem?> items;
  Greet({
    required this.items,
  });
  factory Greet.fromJson(Map<String, dynamic> m) {
    return Greet(
      items: ((m['greet'] ?? []) as List<dynamic>)
          .map((i) => GreetItem?.fromJson(i))
          .toList(),
    );
  }
  Map<String, dynamic> toJson() {
    return {
      'greet': items.map((i) => i?.toJson()),         ### `i.toJson()` was replaced by `i?.toJson()`
    };
  }
}
```