### PR TITLE
Add method label for prometheus middleware metrics

### DIFF
--- a/rest/engine.go
+++ b/rest/engine.go
@@ -136,7 +136,7 @@ func (ng *engine) buildChainWithNativeMiddlewares(fr featuredRoutes, route Route
 		chn = chn.Append(ng.getLogHandler())
 	}
 	if ng.conf.Middlewares.Prometheus {
-		chn = chn.Append(handler.PrometheusHandler(route.Path))
+		chn = chn.Append(handler.PrometheusHandler(route.Path, route.Method))
 	}
 	if ng.conf.Middlewares.MaxConns {
 		chn = chn.Append(handler.MaxConnsHandler(ng.conf.MaxConns))

--- a/rest/handler/prometheushandler.go
+++ b/rest/handler/prometheushandler.go
@@ -18,7 +18,7 @@ var (
 		Subsystem: "requests",
 		Name:      "duration_ms",
 		Help:      "http server requests duration(ms).",
-		Labels:    []string{"path"},
+		Labels:    []string{"path", "method"},
 		Buckets:   []float64{5, 10, 25, 50, 100, 250, 500, 1000},
 	})
 
@@ -27,19 +27,19 @@ var (
 		Subsystem: "requests",
 		Name:      "code_total",
 		Help:      "http server requests error count.",
-		Labels:    []string{"path", "code"},
+		Labels:    []string{"path", "code", "method"},
 	})
 )
 
 // PrometheusHandler returns a middleware that reports stats to prometheus.
-func PrometheusHandler(path string) func(http.Handler) http.Handler {
+func PrometheusHandler(path, method string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			startTime := timex.Now()
 			cw := &response.WithCodeResponseWriter{Writer: w}
 			defer func() {
-				metricServerReqDur.Observe(int64(timex.Since(startTime)/time.Millisecond), path)
-				metricServerReqCodeTotal.Inc(path, strconv.Itoa(cw.Code))
+				metricServerReqDur.Observe(int64(timex.Since(startTime)/time.Millisecond), path, method)
+				metricServerReqCodeTotal.Inc(path, strconv.Itoa(cw.Code), method)
 			}()
 
 			next.ServeHTTP(cw, r)

--- a/rest/handler/prometheushandler_test.go
+++ b/rest/handler/prometheushandler_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPromMetricHandler_Disabled(t *testing.T) {
-	promMetricHandler := PrometheusHandler("/user/login")
+	promMetricHandler := PrometheusHandler("/user/login", http.MethodGet)
 	handler := promMetricHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -26,7 +26,7 @@ func TestPromMetricHandler_Enabled(t *testing.T) {
 		Host: "localhost",
 		Path: "/",
 	})
-	promMetricHandler := PrometheusHandler("/user/login")
+	promMetricHandler := PrometheusHandler("/user/login", http.MethodGet)
 	handler := promMetricHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))


### PR DESCRIPTION
Add 'method' label for prometheus middleware metrics to resolve issue #3076