### PR TITLE
1 second may not be able to finish finishing touches under high load

### DIFF
--- a/core/proc/shutdown.go
+++ b/core/proc/shutdown.go
@@ -56,7 +56,7 @@ func gracefulStop(signals chan os.Signal) {
 	signal.Stop(signals)
 
 	logx.Info("Got signal SIGTERM, shutting down...")
-	go wrapUpListeners.notifyListeners()
+	wrapUpListeners.notifyListeners()
 
 	time.Sleep(wrapUpTime)
 	go shutdownListeners.notifyListeners()


### PR DESCRIPTION
在高负载的情况下，1秒钟可能无法完成剩余请求的收尾工作。
如果这个时候shutdown监听列表中存在数据库或者中间件连接的关闭功能，会导致剩余请求报错。

---

1 second may not be able to finish finishing touches under high load.
If there is a database or middleware `connection close function` in the `shutdownListeners list` at this time, it will cause errors for the remaining requests.