### PR TITLE
fix: fixed goctl api go --home parameter error when loading non-exist…

### DIFF
--- a/tools/goctl/util/pathx/file.go
+++ b/tools/goctl/util/pathx/file.go
@@ -145,15 +145,12 @@ func GetTemplateDir(category string) (string, error) {
 		// backward compatible, it will be removed in the feature
 		// backward compatible start.
 		beforeTemplateDir := filepath.Join(home, version.GetGoctlVersion(), category)
-		entries, err := os.ReadDir(beforeTemplateDir)
-		if err != nil {
-			return "", err
-		}
+		entries, _ := os.ReadDir(beforeTemplateDir)
 		infos := make([]fs.FileInfo, 0, len(entries))
 		for _, entry := range entries {
 			info, err := entry.Info()
 			if err != nil {
-				return "", err
+				continue
 			}
 			infos = append(infos, info)
 		}


### PR DESCRIPTION
**Describe the bug**
<img width="437" alt="image" src="https://github.com/zeromicro/go-zero/assets/44083691/7130af5b-9e26-408d-990d-8b0ccf5493af">

```
goctl api go -api ./api/apis/hello.api --dir ./app --home ./api/.goctl

app/etc/test-api.yaml exists, ignored generation
app/internal/config/config.go exists, ignored generation
app/test.go exists, ignored generation
app/internal/svc/servicecontext.go exists, ignored generation
2023/06/05 11:57:01 open api/.goctl/1.5.3/api: no such file or directory

```
the 1.5.3 path is inexplicably found in the file path, causing the generation failure.
By viewing the goctl source code, find the `tools/goctl/util/pathx/file.go` 148 line, beforeTemplateDir does not exist.
```
 beforeTemplateDir := filepath.Join(home, version.GetGoctlVersion(), category)
 entries, err := os.ReadDir(beforeTemplateDir)
 if err != nil {
	return "", err
 }
```
The original code submission history for comparison found that err is not processed, is ignored.
After modification, the run was found to be successful.

```
goctl api go -api ./api/apis/hello.api --dir ./app --home ./api/.goctl

app/etc/test-api.yaml exists, ignored generation
app/internal/config/config.go exists, ignored generation
app/test.go exists, ignored generation
app/internal/svc/servicecontext.go exists, ignored generation
Done.
```


