### PR TITLE
Fix:logx with Compress auto delete old logs

### DIFF
--- a/core/logx/rotatelogger.go
+++ b/core/logx/rotatelogger.go
@@ -426,7 +426,6 @@ func gzipFile(file string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
 
 	out, err := os.Create(fmt.Sprintf("%s%s", file, gzipExt))
 	if err != nil {
@@ -440,6 +439,8 @@ func gzipFile(file string) error {
 	} else if err = w.Close(); err != nil {
 		return err
 	}
+
+	in.Close()
 
 	return os.Remove(file)
 }


### PR DESCRIPTION
Under the Windows operating system, if the Compress field of the logx component is set to true, the original uncompressed logs will not be automatically deleted.

This condition could NOT happen under Linux/Centos system.

Description:
logx has a function "gzipFile" in "go-zero/core/logx/rotatelogger.go", this function use "defer in.Close()" to close "in". But before that, "os.Remove(file)" want to delete this file, so it throws an exception "compress error: remove logs/error.log-2023-06-08:The process cannot access the file because it is being used by another process"

Solution:
I change "defer in.Close()" to "in.Close()" and put this code before "return os.Remove(file)" will fix this bug.

The code is:

```
func gzipFile(file string) error {
	in, err := os.Open(file)
	if err != nil {
		return err
	}
	//defer in.Close()

	out, err := os.Create(fmt.Sprintf("%s%s", file, gzipExt))
	if err != nil {
		return err
	}
	defer out.Close()

	w := gzip.NewWriter(out)
	if _, err = io.Copy(w, in); err != nil {
		return err
	} else if err = w.Close(); err != nil {
		return err
	}

        in.Close()
	return os.Remove(file)
}
```
OS: windows 10
go-zero version 1.4.0