### PR TITLE
fix In `goctl new api`, occur error `invalid character 'A' looking for beginning of value`

### DIFF
--- a/tools/goctl/util/ctx/gomod.go
+++ b/tools/goctl/util/ctx/gomod.go
@@ -1,6 +1,7 @@
 package ctx
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -94,8 +95,11 @@ func getRealModule(workDir string, execRun execx.RunFunc) (*Module, error) {
 }
 
 func decodePackages(rc io.Reader) ([]Module, error) {
+	r := bufio.NewReader(rc)
+	_, _ = r.ReadSlice('{')
+	_ = r.UnreadByte()
 	var modules []Module
-	decoder := json.NewDecoder(rc)
+	decoder := json.NewDecoder(r)
 	for decoder.More() {
 		var m Module
 		if err := decoder.Decode(&m); err != nil {

--- a/tools/goctl/util/ctx/gomod_test.go
+++ b/tools/goctl/util/ctx/gomod_test.go
@@ -3,9 +3,11 @@ package ctx
 import (
 	"bytes"
 	"go/build"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,6 +108,75 @@ func Test_getRealModule(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getRealModule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodePackages(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    io.Reader
+		want    []Module
+		wantErr bool
+	}{
+		{
+			name: "single module",
+			data: strings.NewReader(`{
+						"Path":"foo",
+						"Dir":"/home/foo",
+						"GoMod":"/home/foo/go.mod",
+						"GoVersion":"go1.16"}`),
+			want: []Module{
+				{
+					Path:      "foo",
+					Dir:       "/home/foo",
+					GoMod:     "/home/foo/go.mod",
+					GoVersion: "go1.16",
+				},
+			},
+		},
+		{
+			name: "go work multiple modules",
+			data: strings.NewReader(`
+					{
+						"Path":"foo",
+						"Dir":"/home/foo",
+						"GoMod":"/home/foo/go.mod",
+						"GoVersion":"go1.18"
+					}
+					{
+						"Path":"bar",
+						"Dir":"/home/bar",
+						"GoMod":"/home/bar/go.mod",
+						"GoVersion":"go1.18"
+					}`),
+			want: []Module{
+				{
+					Path:      "foo",
+					Dir:       "/home/foo",
+					GoMod:     "/home/foo/go.mod",
+					GoVersion: "go1.18",
+				},
+				{
+					Path:      "bar",
+					Dir:       "/home/bar",
+					GoMod:     "/home/bar/go.mod",
+					GoVersion: "go1.18",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := decodePackages(tt.data)
+			if err != nil {
+				t.Errorf("decodePackages() error %v,wantErr = %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(result, tt.want) {
+				t.Errorf("decodePackages() = %v,want  %v", result, tt.want)
+
 			}
 		})
 	}

--- a/tools/goctl/util/ctx/gomod_test.go
+++ b/tools/goctl/util/ctx/gomod_test.go
@@ -166,6 +166,24 @@ func TestDecodePackages(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "There are extra characters at the beginning",
+			data: strings.NewReader(`Active code page: 65001
+					{
+						"Path":"foo",
+						"Dir":"/home/foo",
+						"GoMod":"/home/foo/go.mod",
+						"GoVersion":"go1.18"
+					}`),
+			want: []Module{
+				{
+					Path:      "foo",
+					Dir:       "/home/foo",
+					GoMod:     "/home/foo/go.mod",
+					GoVersion: "go1.18",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
In windows10,I want to expenrience go-zero
In execute `goctl new api demo`,occur `occur error `invalid character 'A' looking for beginning of value`
The reason for this error is that my Windows computer is set to use UTF-8 character encoding, so when executing the cmd, there will be a prompt at the beginning saying 'Active code page: 65001', causing issues when validating the JSON format.

windows10下,我想体验go-zero
在执行goctl new api demo时,出现invalid character 'A' looking for beginning of value 的错误
这个错误的原因是我的Windows电脑设置为使用UTF-8字符编码,所以在执行cmd时,开头会有一个提示说'Active code page: 65001',导致验证JSON格式时出问题。

befor:
![image-20230616142034892](https://cdn.jsdelivr.net/gh/2822132073/image/202306161420998.png)

after
![image-20230616142159399](https://cdn.jsdelivr.net/gh/2822132073/image/202306161422465.png)