### PR TITLE
feat: add detail type mismatch info in number fields check (#3386)

### DIFF
--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -618,7 +618,7 @@ func (u *Unmarshaler) processFieldPrimitiveWithJSONNumber(fieldType reflect.Type
 
 		target.SetFloat(fValue)
 	default:
-		return newTypeMismatchError(fullName)
+		return newTypeMismatchErrorWithHint(fullName, value.Type().String(), typeKind.String())
 	}
 
 	SetValue(fieldType, value, target)
@@ -1052,6 +1052,10 @@ func newInitError(name string) error {
 
 func newTypeMismatchError(name string) error {
 	return fmt.Errorf("type mismatch for field %q", name)
+}
+
+func newTypeMismatchErrorWithHint(name, errorType, rightType string) error {
+	return fmt.Errorf("type mismatch for field %q, expected %q, got %q", name, rightType, errorType)
 }
 
 func readKeys(key string) []string {

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -3,6 +3,7 @@ package mapping
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -4979,6 +4980,31 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 		err := unmarshaler.UnmarshalValuer(nil, &i)
 		assert.Error(t, err)
 	})
+}
+
+func TestUnmarshalerProcessFieldPrimitiveWithJSONNumber(t *testing.T) {
+	t.Run("wrong type", func(t *testing.T) {
+		expectValue := "1"
+		realValue := 1
+		fieldType := reflect.TypeOf(expectValue)
+		value := reflect.ValueOf(&realValue) // pass a pointer to the value
+		v := json.Number(expectValue)
+		m := NewUnmarshaler("field")
+		err := m.processFieldPrimitiveWithJSONNumber(fieldType, value.Elem(), v, &fieldOptionsWithContext{}, "field")
+		assert.Error(t, err)
+		assert.Equal(t, "type mismatch for field \"field\", expected \"string\", got \"int\"", err.Error())
+	})
+	t.Run("right type", func(t *testing.T) {
+		expectValue := int64(1)
+		realValue := int64(1)
+		fieldType := reflect.TypeOf(expectValue)
+		value := reflect.ValueOf(&realValue) // pass a pointer to the value
+		v := json.Number(strconv.FormatInt(expectValue, 10))
+		m := NewUnmarshaler("field")
+		err := m.processFieldPrimitiveWithJSONNumber(fieldType, value.Elem(), v, &fieldOptionsWithContext{}, "field")
+		assert.NoError(t, err)
+	})
+
 }
 
 func TestGetValueWithChainedKeys(t *testing.T) {

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -4982,6 +4982,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 	})
 }
 
+// TestUnmarshalerProcessFieldPrimitiveWithJSONNumber test the number type check.
 func TestUnmarshalerProcessFieldPrimitiveWithJSONNumber(t *testing.T) {
 	t.Run("wrong type", func(t *testing.T) {
 		expectValue := "1"


### PR DESCRIPTION
add a feature I proposed in #3386 