### PR TITLE
[bugfix] add go work use project_name

### DIFF
--- a/tools/goctl/util/ctx/context.go
+++ b/tools/goctl/util/ctx/context.go
@@ -2,6 +2,7 @@ package ctx
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 
 	"github.com/zeromicro/go-zero/tools/goctl/rpc/execx"
@@ -37,6 +38,16 @@ func Prepare(workDir string) (*ProjectContext, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// add go work support
+	f := filepath.Join(workDir, "/../go.work")
+	if _, err := os.Stat(f); err == nil {
+		_, err = execx.Run("go work use "+name, filepath.Join(workDir, "/.."))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return background(workDir)
 }
 


### PR DESCRIPTION
If the `go.work` file exists in the parent directory after the project is created, but the project directory is not added, it will cause the situation that `go list -json -m` in the current workspace does not return new project info