### PR TITLE
Update timeouthandler.go

### DIFF
--- a/rest/handler/timeouthandler.go
+++ b/rest/handler/timeouthandler.go
@@ -68,7 +68,7 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	done := make(chan struct{})
 	tw := &timeoutWriter{
 		w:    w,
-		h:    make(http.Header),
+		h:    w.Header(),
 		req:  r,
 		code: http.StatusOK,
 	}


### PR DESCRIPTION
修复引用timeouthandler后无法写入新的header头，handler函数中无法通过w.Header()获取到中间件设置的响应头