### PR TITLE
When timeout middleware is not enabled, it starts at http. Server's WriteTimeout,Modify the timeouthandler.go logic to support stream response

### DIFF
--- a/rest/handler/timeouthandler.go
+++ b/rest/handler/timeouthandler.go
@@ -68,7 +68,7 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	done := make(chan struct{})
 	tw := &timeoutWriter{
 		w:    w,
-		h:    make(http.Header),
+		h:    w.Header(),
 		req:  r,
 		code: http.StatusOK,
 	}


### PR DESCRIPTION
When timeout middleware is not enabled, it starts at http. Server's WriteTimeout,Modify the timeouthandler.go logic to support stream response