### PR TITLE
将goctl生成mysql和pg的_gen.go文件修改成根据style一样的文件风格

### DIFF
--- a/tools/goctl/model/sql/gen/gen.go
+++ b/tools/goctl/model/sql/gen/gen.go
@@ -165,7 +165,11 @@ func (g *defaultGenerator) createFile(modelList map[string]*codeTuple) error {
 			return err
 		}
 
-		name := util.SafeString(modelFilename) + "_gen.go"
+		name, err := format.FileNamingFormat(g.cfg.NamingFormat,
+			fmt.Sprintf("%s_model_gen.go", tn.Source()))
+		if err != nil {
+			return err
+		}
 		filename := filepath.Join(dirAbs, name)
 		err = os.WriteFile(filename, []byte(codes.modelCode), os.ModePerm)
 		if err != nil {


### PR DESCRIPTION
修改前，
1.当--style="go_zero"现有生成的文件风格是XXX_model_gen.go。
2.当--style="gozero"现有生成的文件风格是XXXmodel_gen.go。
3. 当--style="goZero"现有生成的文件风格是XXX Model_gen.go。

修改后，
1.当--style="go_zero"现有生成的文件风格是XXX_model_gen.go。
2.当--style="gozero"现有生成的文件风格是XXXmodelgen.go。
3. 当--style="goZero"现有生成的文件风格是XXX ModelGen.go。