### PR TITLE
feat: support for httpc  form-data parameter

### DIFF
--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -2,9 +2,13 @@ package gateway
 
 import (
 	"context"
+	"flag"
+	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -42,6 +46,33 @@ func dialer() func(context.Context, string) (net.Conn, error) {
 		return listener.Dial()
 	}
 }
+
+func TestPostFormData(t *testing.T) {
+
+	type Request struct {
+		Node   string `path:"node"`
+		ID     int    `form:"id"`
+		Header string `header:"X-Header"`
+	}
+	var domain = flag.String("domain", "http://localhost:3333", "the domain to request")
+	flag.Parse()
+
+	req := Request{
+		Node:   "foo",
+		ID:     1024,
+		Header: "foo-header",
+	}
+	resp, err := httpc.Do(context.Background(), http.MethodPost, *domain+"/nodes/:node", req)
+	// resp, err := httpc.Do(context.Background(), http.MethodPost, *domain+"/nodes/:node", req)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	io.Copy(os.Stdout, resp.Body)
+}
+
+
 
 func TestMustNewServer(t *testing.T) {
 	var c GatewayConf

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -47,30 +47,6 @@ func dialer() func(context.Context, string) (net.Conn, error) {
 	}
 }
 
-func TestPostFormData(t *testing.T) {
-
-	type Request struct {
-		Node   string `path:"node"`
-		ID     int    `form:"id"`
-		Header string `header:"X-Header"`
-	}
-	var domain = flag.String("domain", "http://localhost:3333", "the domain to request")
-	flag.Parse()
-
-	req := Request{
-		Node:   "foo",
-		ID:     1024,
-		Header: "foo-header",
-	}
-	resp, err := httpc.Do(context.Background(), http.MethodPost, *domain+"/nodes/:node", req)
-	// resp, err := httpc.Do(context.Background(), http.MethodPost, *domain+"/nodes/:node", req)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	io.Copy(os.Stdout, resp.Body)
-}
 
 
 

--- a/rest/httpc/requests.go
+++ b/rest/httpc/requests.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	nurl "net/url"
+	"os"
 	"strings"
 
 	"github.com/zeromicro/go-zero/core/lang"
@@ -81,9 +83,12 @@ func buildRequest(ctx context.Context, method, url string, data any) (*http.Requ
 		return nil, err
 	}
 
+	var contentType string
 	var reader io.Reader
+
 	jsonVars, hasJsonBody := val[jsonKey]
-	formVars, hasFormBody := val[formKey]
+	_, hasFormBody := val[formKey]
+
 	if hasJsonBody && hasFormBody {
 		return nil, fmt.Errorf("cannot have both json and form body")
 	}
@@ -96,30 +101,52 @@ func buildRequest(ctx context.Context, method, url string, data any) (*http.Requ
 		if err := enc.Encode(jsonVars); err != nil {
 			return nil, err
 		}
-
 		reader = &buf
+		contentType = header.JsonContentType
 	} else if hasFormBody {
-		formData := nurl.Values{}
-		for k, v := range formVars {
-			formData.Add(k, fmt.Sprint(v))
+		var b bytes.Buffer
+		w := multipart.NewWriter(&b)
+
+		for k, v := range val[formKey] {
+			if filePath, isFile := v.(string); isFile && strings.HasPrefix(filePath, "@") {
+				// Handle as a file
+				file, err := os.Open(filePath[1:])
+				if err != nil {
+					return nil, err
+				}
+				defer file.Close()
+				part, err := w.CreateFormFile(k, filePath[1:])
+				if err != nil {
+					return nil, err
+				}
+				io.Copy(part, file)
+			} else {
+				// Handle as a normal field
+				fw, err := w.CreateFormField(k)
+				if err != nil {
+					return nil, err
+				}
+				if _, err = fw.Write([]byte(fmt.Sprintf("%v", v))); err != nil {
+					return nil, err
+				}
+			}
 		}
+		err := w.Close()
+		if err != nil {
+			return nil, err
+		}
+		reader = &b
+		contentType = w.FormDataContentType()
 
-		reader = strings.NewReader(formData.Encode())
 	}
-
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), reader)
 	if err != nil {
 		return nil, err
 	}
-
-	// req.URL.RawQuery = buildFormQuery(u, val[formKey])
-
 	fillHeader(req, val[headerKey])
-	if hasJsonBody {
-		req.Header.Set(header.ContentType, header.JsonContentType)
-	}
-	if hasFormBody {
-		req.Header.Set(header.ContentType, header.FormContentType)
+	// Set Content-Type header
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
 	}
 
 	return req, nil

--- a/rest/internal/header/headers.go
+++ b/rest/internal/header/headers.go
@@ -7,4 +7,6 @@ const (
 	ContentType = "Content-Type"
 	// JsonContentType is the content type for JSON.
 	JsonContentType = "application/json; charset=utf-8"
+	// FormContentType is the content type for form data.
+	FormContentType = "multipart/form-data"
 )


### PR DESCRIPTION
The httpclient form-data parameter is not sent as rawquery, it is deliver as body.
https://github.com/zeromicro/go-zero/issues/3500