### PR TITLE
fix: goctl pg gen will extract all fields when the same table name exists in different schemas (#3496)

### DIFF
--- a/tools/goctl/model/sql/model/postgresqlmodel.go
+++ b/tools/goctl/model/sql/model/postgresqlmodel.go
@@ -72,7 +72,8 @@ from (
                 t.typname     AS type,
                 a.atttypmod   AS lengthvar,
                 a.attnotnull  AS not_null,
-                b.description AS comment
+                b.description AS comment,
+                (c.relnamespace::regnamespace)::varchar AS schema_name
          FROM pg_class c,
               pg_attribute a
                   LEFT OUTER JOIN pg_description b ON a.attrelid = b.objoid AND a.attnum = b.objsubid,
@@ -81,10 +82,11 @@ from (
            and a.attnum > 0
            and a.attrelid = c.oid
            and a.atttypid = t.oid
- 		 GROUP BY a.attnum, c.relname, a.attname, t.typname, a.atttypmod, a.attnotnull, b.description
+ 		 GROUP BY a.attnum, c.relname, a.attname, t.typname, a.atttypmod, a.attnotnull, b.description, c.relnamespace::regnamespace
          ORDER BY a.attnum) AS t
-         left join information_schema.columns AS c on t.relname = c.table_name 
-		and t.field = c.column_name and c.table_schema = $2`
+         left join information_schema.columns AS c on t.relname = c.table_name and t.schema_name = c.table_schema
+		and t.field = c.column_name
+		where c.table_schema = $2`
 
 	var reply []*PostgreColumn
 	err := m.conn.QueryRowsPartial(&reply, querySql, table, schema)


### PR DESCRIPTION
Create two same tables in different schemas would cause error.
Because the origin sql would find all the tables, then left join these tables to the  specific schema.
It didn't filter the specific schema when it use left join!
Like this:
```sql=
select t.num,t.field,t.type,t.not_null,t.comment, c.column_default, identity_increment
from (
         SELECT a.attnum AS num,
                c.relname,
                a.attname     AS field,
                t.typname     AS type,
                a.atttypmod   AS lengthvar,
                a.attnotnull  AS not_null,
                b.description AS comment
         FROM pg_class c,
              pg_attribute a
                  LEFT OUTER JOIN pg_description b ON a.attrelid = b.objoid AND a.attnum = b.objsubid,
              pg_type t
         WHERE c.relname = $1
           and a.attnum > 0
           and a.attrelid = c.oid
           and a.atttypid = t.oid
 		 GROUP BY a.attnum, c.relname, a.attname, t.typname, a.atttypmod, a.attnotnull, b.description
         ORDER BY a.attnum) AS t
         left join information_schema.columns AS c on t.relname = c.table_name 
		and t.field = c.column_name and c.table_schema = $2
```
<img width="844" alt="截圖 2023-08-24 上午12 01 37" src="https://github.com/zeromicro/go-zero/assets/38785340/747644e4-4c28-40e8-ba5d-c44191fa0469">

This is a fixed code privoded by #3496
```sql=
select t.num,t.field,t.type,t.not_null,t.comment, c.column_default, identity_increment
from (
         SELECT a.attnum AS num,
                c.relname,
                a.attname     AS field,
                t.typname     AS type,
                a.atttypmod   AS lengthvar,
                a.attnotnull  AS not_null,
                b.description AS comment,
                (c.relnamespace::regnamespace)::varchar AS schema_name
         FROM pg_class c,
              pg_attribute a
                  LEFT OUTER JOIN pg_description b ON a.attrelid = b.objoid AND a.attnum = b.objsubid,
              pg_type t
         WHERE c.relname = $1
           and a.attnum > 0
           and a.attrelid = c.oid
           and a.atttypid = t.oid
 		 GROUP BY a.attnum, c.relname, a.attname, t.typname, a.atttypmod, a.attnotnull, b.description, c.relnamespace::regnamespace
         ORDER BY a.attnum) AS t
         left join information_schema.columns AS c on t.relname = c.table_name and t.schema_name = c.table_schema
		and t.field = c.column_name
		where c.table_schema = $2
```
And It will work like this:
<img width="844" alt="截圖 2023-08-23 下午11 58 26" src="https://github.com/zeromicro/go-zero/assets/38785340/bd7db02d-e422-43e6-9f6e-971230427f59">
