### PR TITLE
Add ErrParamError

### DIFF
--- a/rest/httpx/requests.go
+++ b/rest/httpx/requests.go
@@ -1,16 +1,13 @@
 package httpx
 
 import (
-	"io"
+	"errors"
 	"net/http"
 	"strings"
 	"sync/atomic"
 
 	"github.com/zeromicro/go-zero/core/mapping"
-	"github.com/zeromicro/go-zero/core/validation"
-	"github.com/zeromicro/go-zero/rest/internal/encoding"
 	"github.com/zeromicro/go-zero/rest/internal/header"
-	"github.com/zeromicro/go-zero/rest/pathvar"
 )
 
 const (
@@ -26,54 +23,13 @@ var (
 	formUnmarshaler = mapping.NewUnmarshaler(formKey, mapping.WithStringValues(), mapping.WithOpaqueKeys())
 	pathUnmarshaler = mapping.NewUnmarshaler(pathKey, mapping.WithStringValues(), mapping.WithOpaqueKeys())
 	validator       atomic.Value
+	ErrParamError   = errors.New("param error")
 )
 
 // Validator defines the interface for validating the request.
 type Validator interface {
 	// Validate validates the request and parsed data.
 	Validate(r *http.Request, data any) error
-}
-
-// Parse parses the request.
-func Parse(r *http.Request, v any) error {
-	if err := ParsePath(r, v); err != nil {
-		return err
-	}
-
-	if err := ParseForm(r, v); err != nil {
-		return err
-	}
-
-	if err := ParseHeaders(r, v); err != nil {
-		return err
-	}
-
-	if err := ParseJsonBody(r, v); err != nil {
-		return err
-	}
-
-	if valid, ok := v.(validation.Validator); ok {
-		return valid.Validate()
-	} else if val := validator.Load(); val != nil {
-		return val.(Validator).Validate(r, v)
-	}
-
-	return nil
-}
-
-// ParseHeaders parses the headers request.
-func ParseHeaders(r *http.Request, v any) error {
-	return encoding.ParseHeaders(r.Header, v)
-}
-
-// ParseForm parses the form request.
-func ParseForm(r *http.Request, v any) error {
-	params, err := GetFormValues(r)
-	if err != nil {
-		return err
-	}
-
-	return formUnmarshaler.Unmarshal(params, v)
 }
 
 // ParseHeader parses the request header and returns a map.
@@ -96,28 +52,6 @@ func ParseHeader(headerValue string) map[string]string {
 	}
 
 	return ret
-}
-
-// ParseJsonBody parses the post request which contains json in body.
-func ParseJsonBody(r *http.Request, v any) error {
-	if withJsonBody(r) {
-		reader := io.LimitReader(r.Body, maxBodyLen)
-		return mapping.UnmarshalJsonReader(reader, v)
-	}
-
-	return mapping.UnmarshalJsonMap(nil, v)
-}
-
-// ParsePath parses the symbols reside in url path.
-// Like http://localhost/bag/:name
-func ParsePath(r *http.Request, v any) error {
-	vars := pathvar.Vars(r)
-	m := make(map[string]any, len(vars))
-	for k, v := range vars {
-		m[k] = v
-	}
-
-	return pathUnmarshaler.Unmarshal(m, v)
 }
 
 // SetValidator sets the validator.

--- a/rest/httpx/requests_1.20.go
+++ b/rest/httpx/requests_1.20.go
@@ -1,0 +1,84 @@
+//go:build go1.20
+
+package httpx
+
+import (
+	"errors"
+	"github.com/zeromicro/go-zero/core/mapping"
+	"github.com/zeromicro/go-zero/core/validation"
+	"github.com/zeromicro/go-zero/rest/internal/encoding"
+	"github.com/zeromicro/go-zero/rest/pathvar"
+	"io"
+	"net/http"
+)
+
+// Parse parses the request.
+func Parse(r *http.Request, v any) error {
+	if err := ParsePath(r, v); err != nil {
+		return err
+	}
+
+	if err := ParseForm(r, v); err != nil {
+		return err
+	}
+
+	if err := ParseHeaders(r, v); err != nil {
+		return err
+	}
+
+	if err := ParseJsonBody(r, v); err != nil {
+		return err
+	}
+
+	if valid, ok := v.(validation.Validator); ok {
+		return wrapError(valid.Validate())
+	} else if val := validator.Load(); val != nil {
+		return wrapError(val.(Validator).Validate(r, v))
+	}
+
+	return nil
+}
+
+// ParseHeaders parses the headers request.
+func ParseHeaders(r *http.Request, v any) error {
+	return wrapError(encoding.ParseHeaders(r.Header, v))
+}
+
+// ParseForm parses the form request.
+func ParseForm(r *http.Request, v any) error {
+	params, err := GetFormValues(r)
+	if err != nil {
+		return err
+	}
+
+	return wrapError(formUnmarshaler.Unmarshal(params, v))
+}
+
+// ParseJsonBody parses the post request which contains json in body.
+func ParseJsonBody(r *http.Request, v any) error {
+	if withJsonBody(r) {
+		reader := io.LimitReader(r.Body, maxBodyLen)
+		return mapping.UnmarshalJsonReader(reader, v)
+	}
+
+	return wrapError(mapping.UnmarshalJsonMap(nil, v))
+}
+
+// ParsePath parses the symbols reside in url path.
+// Like http://localhost/bag/:name
+func ParsePath(r *http.Request, v any) error {
+	vars := pathvar.Vars(r)
+	m := make(map[string]any, len(vars))
+	for k, v := range vars {
+		m[k] = v
+	}
+
+	return wrapError(pathUnmarshaler.Unmarshal(m, v))
+}
+
+func wrapError(err error) error {
+	if err != nil {
+		return errors.Join(ErrParamError, err)
+	}
+	return nil
+}

--- a/rest/httpx/requests_lt1.20.go
+++ b/rest/httpx/requests_lt1.20.go
@@ -1,0 +1,76 @@
+//go:build !go1.20
+
+package httpx
+
+import (
+	"github.com/zeromicro/go-zero/core/mapping"
+	"github.com/zeromicro/go-zero/core/validation"
+	"github.com/zeromicro/go-zero/rest/internal/encoding"
+	"github.com/zeromicro/go-zero/rest/pathvar"
+	"io"
+	"net/http"
+)
+
+// Parse parses the request.
+func Parse(r *http.Request, v any) error {
+	if err := ParsePath(r, v); err != nil {
+		return err
+	}
+
+	if err := ParseForm(r, v); err != nil {
+		return err
+	}
+
+	if err := ParseHeaders(r, v); err != nil {
+		return err
+	}
+
+	if err := ParseJsonBody(r, v); err != nil {
+		return err
+	}
+
+	if valid, ok := v.(validation.Validator); ok {
+		return valid.Validate()
+	} else if val := validator.Load(); val != nil {
+		return val.(Validator).Validate(r, v)
+	}
+
+	return nil
+}
+
+// ParseHeaders parses the headers request.
+func ParseHeaders(r *http.Request, v any) error {
+	return encoding.ParseHeaders(r.Header, v)
+}
+
+// ParseForm parses the form request.
+func ParseForm(r *http.Request, v any) error {
+	params, err := GetFormValues(r)
+	if err != nil {
+		return err
+	}
+
+	return formUnmarshaler.Unmarshal(params, v)
+}
+
+// ParseJsonBody parses the post request which contains json in body.
+func ParseJsonBody(r *http.Request, v any) error {
+	if withJsonBody(r) {
+		reader := io.LimitReader(r.Body, maxBodyLen)
+		return mapping.UnmarshalJsonReader(reader, v)
+	}
+
+	return mapping.UnmarshalJsonMap(nil, v)
+}
+
+// ParsePath parses the symbols reside in url path.
+// Like http://localhost/bag/:name
+func ParsePath(r *http.Request, v any) error {
+	vars := pathvar.Vars(r)
+	m := make(map[string]any, len(vars))
+	for k, v := range vars {
+		m[k] = v
+	}
+
+	return pathUnmarshaler.Unmarshal(m, v)
+}


### PR DESCRIPTION
fix issue #3128 

只针对go>=1.20版本做了处理，<1.20版本代码不变（有兴趣的朋友可以根据issue里提议做处理）。
处理后，可以用如下代码区分error是否为参数错误，并分离具体参数错误的原因。
```
         if errors.Is(err, httpx.ErrParamError) {
		if multipleError, ok := err.(interface{ Unwrap() []error }); ok {
			parts := make([]string, len(multipleError.Unwrap()))
			for e, err := range multipleError.Unwrap() {
				parts[e] = err.Error()
			}
			// remove first element if size greater than 1
			if len(parts) > 1 {
				parts = parts[1:] // 移除httpx.ErrParamError自身（根据需要）
			}
			errorMsg = strings.Join(parts, ":")
		}else{
			errorMsg = err.Error()
		}
	}
```