### PR TITLE
fix: multiple files import the same api file

### DIFF
--- a/tools/goctl/api/parser/g4/ast/apiparser.go
+++ b/tools/goctl/api/parser/g4/ast/apiparser.go
@@ -156,6 +156,7 @@ func (p *Parser) invokeImportedApi(filename string, imports []*ImportExpr) ([]*A
 		}
 		// ignore already imported file
 		if p.alreadyImported(impPath) {
+			p.importStatck.pop()
 			continue
 		}
 		p.fileMap[impPath] = PlaceHolder{}


### PR DESCRIPTION
fixed: multiple files import the same api file

Program error prompt:
    import cycle not allowed
    
 
But I didn't actually loop in the import file


reappear example:

execute: `goctl api go -api base.api -dir ./api  --style=go_zero`



base.api
```
syntax = "v1"

import "admin_work.api"
import "admin_report.api"
import "admin_retain.api"
```

public.api
```
syntax = "v1"

type UserInfo struct {}
type WorkInfo struct {}
```

query.api
```
syntax = "v1"

type QueryPage struct {}

```

admin_report.api
```
syntax = "v1"

import "query.api"
import "public.api"

@server(
    prefix: report
)
service admin_svr {
    @handler ReportList
    post /list (ReportReq) returns (ReportResp)

}

type (
    ReportReq {
        QueryPage
    }

    ReportResp {
        WorkInfo
        UserInfo
    }
)

```

admin_retain.api
```
syntax = "v1"

import "query.api"

@server(
    prefix: retain
)
service admin_svr {
    @handler RetainList
    post /list (RetainListReq) returns (RetainListResp)
}


type (
    RetainListReq {
        QueryPage
    }
    RetainListResp {
    }
)

```

admin_work.api
```
syntax = "v1"

import "query.api"
import "public.api"

@server(
	prefix: work
)
service admin_svr {
	@handler WorkList
	post /list (WorkListRes) returns (WorkListResp)
}

type (
	WorkListRes {
		QueryPage
	}

	WorkListResp {
		WorkInfo
		UserInfo
	}
)
```









   
 
