### PR TITLE
fix: prevent ring index overflow

### DIFF
--- a/core/collection/ring.go
+++ b/core/collection/ring.go
@@ -1,6 +1,9 @@
 package collection
 
-import "sync"
+import (
+	"math"
+	"sync"
+)
 
 // A Ring can be used as fixed size ring.
 type Ring struct {
@@ -26,7 +29,7 @@ func (r *Ring) Add(v any) {
 	defer r.lock.Unlock()
 
 	r.elements[r.index%len(r.elements)] = v
-	r.index++
+	r.index = (r.index + 1) % math.MaxInt32 // prevent ring index overflow
 }
 
 // Take takes all items from r.


### PR DESCRIPTION
I added these lines to prevent the ring index from overflowing.

```go
// Add adds v into r.
func (r *Ring) Add(v any) {
	r.lock.Lock()
	defer r.lock.Unlock()

	r.elements[r.index%len(r.elements)] = v
	r.index++

	// prevent ring index overflow
	if r.index/len(r.elements) >= 2 {
		r.index = r.index - len(r.elements)
	}
}
```
The issue is from #2627.