### PR TITLE
fix: primary key unique key simultaneously exist cacheIdPrefix duplicate

### DIFF
--- a/tools/goctl/model/sql/parser/parser.go
+++ b/tools/goctl/model/sql/parser/parser.go
@@ -128,6 +128,8 @@ func Parse(filename, database string, strict bool) ([]*Table, error) {
 			return nil, fmt.Errorf("%s: unexpected join primary key", prefix)
 		}
 
+		delete(uniqueKeyMap, indexNameGen(primaryColumn, "idx"))
+		delete(uniqueKeyMap, indexNameGen(primaryColumn, "unique"))
 		primaryKey, fieldM, err := convertColumns(columns, primaryColumn, strict)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
CREATE TABLE `k8s_api_events` (
  `id` int NOT NULL AUTO_INCREMENT,
  `create_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  `status` int DEFAULT '0',
  `operate` int DEFAULT '0',
  PRIMARY KEY (`id`),
  UNIQUE KEY `id_UNIQUE` (`id`),
  KEY `gid_idx` (`gid`),
  KEY `rid_idx` (`rule_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;


goctl model mysql ddl -c
result:

var (
        k8sApiEventsFieldNames          = builder.RawFieldNames(&K8sApiEvents{})
        k8sApiEventsRows                = strings.Join(k8sApiEventsFieldNames, ",")
        k8sApiEventsRowsExpectAutoSet   = strings.Join(stringx.Remove(k8sApiEventsFieldNames, "`id`", "`create_at`", "`create_time`", "`created_at`", "`update_at`", "`update_time`", "`updated_at`"), ",")
        k8sApiEventsRowsWithPlaceHolder = strings.Join(stringx.Remove(k8sApiEventsFieldNames, "`id`", "`create_at`", "`create_time`", "`created_at`", "`update_at`", "`update_time`", "`updated_at`"), "=?,") + "=?"

        cacheK8sApiEventsIdPrefix = "cache:k8sApiEvents:id:"
        cacheK8sApiEventsIdPrefix = "cache:k8sApiEvents:id:"
)

