### PR TITLE
feat:add redis ExistsMany method

### DIFF
--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -467,6 +467,33 @@ func (s *Redis) ExistsCtx(ctx context.Context, key string) (val bool, err error)
 	return
 }
 
+// ExistsMany is the implementation of redis exists command.
+// checks the existence of multiple keys in Redis using the EXISTS command.
+func (s *Redis) ExistsMany(keys ...string) (int64, error) {
+	return s.ExistsManyCtx(context.Background(), keys...)
+}
+
+// ExistsManyCtx is the implementation of redis exists command.
+// checks the existence of multiple keys in Redis using the EXISTS command.
+func (s *Redis) ExistsManyCtx(ctx context.Context, keys ...string) (val int64, err error) {
+	err = s.brk.DoWithAcceptable(func() error {
+		conn, err := getRedis(s)
+		if err != nil {
+			return err
+		}
+
+		v, err := conn.Exists(ctx, keys...).Result()
+		if err != nil {
+			return err
+		}
+
+		val = v
+		return nil
+	}, acceptable)
+
+	return
+}
+
 // Expire is the implementation of redis expire command.
 func (s *Redis) Expire(key string, seconds int) error {
 	return s.ExpireCtx(context.Background(), key, seconds)


### PR DESCRIPTION
  The current `Exists` function in go-zero's Redis only supports a single key, whereas go-redis's `Exists` can query multiple keys. 
  However, directly altering go-zero's Redis implementation would lead to incompatibility between different versions of the method and would affect the implementation of the `Store` interface in `core/stores/kv/store.go`.
  To ensure compatibility between versions, a new method named `ExistsMany` should be added as a transitional solution. A unified upgrade can be planned for a later major version release.
  close #3765
```
// go-zero
// core/stores/redis.go:458
v, err := conn.Exists(ctx, key).Result()

// go-redis
Exists(ctx context.Context, keys ...string) *IntCmd
```