### PR TITLE
fix: prevent a crash if there is a unique key constraint with a nil field.

### DIFF
--- a/tools/goctl/model/sql/parser/parser.go
+++ b/tools/goctl/model/sql/parser/parser.go
@@ -149,6 +149,10 @@ func Parse(filename, database string, strict bool) ([]*Table, error) {
 
 		for indexName, each := range uniqueKeyMap {
 			for _, columnName := range each {
+				// Prevent a crash if there is a unique key constraint with a nil field.
+				if fieldM[columnName] == nil {
+					return nil, fmt.Errorf("table %s: unique key with error column name[%s]", e.Name, columnName)
+				}
 				uniqueIndex[indexName] = append(uniqueIndex[indexName], fieldM[columnName])
 			}
 		}

--- a/tools/goctl/model/sql/parser/parser.go
+++ b/tools/goctl/model/sql/parser/parser.go
@@ -83,8 +83,9 @@ func Parse(filename, database string, strict bool) ([]*Table, error) {
 			primaryColumn    string
 			primaryColumnSet = collection.NewSet()
 			uniqueKeyMap     = make(map[string][]string)
-			normalKeyMap     = make(map[string][]string)
-			columns          = e.Columns
+			// Unused local variable
+			// normalKeyMap     = make(map[string][]string)
+			columns = e.Columns
 		)
 
 		for _, column := range columns {
@@ -144,7 +145,8 @@ func Parse(filename, database string, strict bool) ([]*Table, error) {
 
 		var (
 			uniqueIndex = make(map[string][]*Field)
-			normalIndex = make(map[string][]*Field)
+			// Unused local variable
+			// normalIndex = make(map[string][]*Field)
 		)
 
 		for indexName, each := range uniqueKeyMap {
@@ -157,11 +159,12 @@ func Parse(filename, database string, strict bool) ([]*Table, error) {
 			}
 		}
 
-		for indexName, each := range normalKeyMap {
-			for _, columnName := range each {
-				normalIndex[indexName] = append(normalIndex[indexName], fieldM[columnName])
-			}
-		}
+		// Unused local variable
+		// for indexName, each := range normalKeyMap {
+		// 	for _, columnName := range each {
+		// 		normalIndex[indexName] = append(normalIndex[indexName], fieldM[columnName])
+		// 	}
+		// }
 
 		checkDuplicateUniqueIndex(uniqueIndex, e.Name)
 


### PR DESCRIPTION
Issue #3766.

```bash
goctl model mysql ddl --src user_base.sql --dir .
```
```sql
# cat user_base.sql 
CREATE TABLE `t_user_base` (
  `f_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
  `f_uname` VARCHAR(16),
  `f_phone` VARCHAR(20),
  `f_email` VARCHAR(32),
  `f_stop_time` DATETIME NOT NULL,
  `f_create_time` DATETIME NOT NULL,
  PRIMARY KEY (`f_id`),
  UNIQUE KEY (`f_phone_number`) // error field
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
```
There is a case where the unique key `'f_phone_number'` does not match the `'f_phone'` field, which can cause a crash without displaying an error message.


And I found that there is a local variable that is not being used, but it will be processed in `Parse()`.
Do I need to mark it as a comment?

<img width="1207" alt="截圖 2023-12-11 上午2 18 42" src="https://github.com/zeromicro/go-zero/assets/38785340/d858d603-6845-4143-aff5-b7f2db509db4">
