### PR TITLE
fix: coredump: goctl model mysql ddl --src user_base.sql --dir . area…

### DIFF
--- a/tools/goctl/model/sql/parser/parser.go
+++ b/tools/goctl/model/sql/parser/parser.go
@@ -149,6 +149,9 @@ func Parse(filename, database string, strict bool) ([]*Table, error) {
 
 		for indexName, each := range uniqueKeyMap {
 			for _, columnName := range each {
+				if fieldM[columnName] == nil {
+					return nil, fmt.Errorf("table %s: unique key with error column name[%s]", e.Name, columnName)
+				}
 				uniqueIndex[indexName] = append(uniqueIndex[indexName], fieldM[columnName])
 			}
 		}

--- a/tools/goctl/model/sql/parser/parser.go
+++ b/tools/goctl/model/sql/parser/parser.go
@@ -144,7 +144,7 @@ func Parse(filename, database string, strict bool) ([]*Table, error) {
 			}
 		}
 
-    uniqueIndex := make(map[string][]*Field)
+		uniqueIndex := make(map[string][]*Field)
 
 		for indexName, each := range uniqueKeyMap {
 			for _, columnName := range each {


### PR DESCRIPTION
…/goctl #3766

Root cause:
when column name is not valid in UNIQUE KEY, element in uniqueIndex is nil in function checkDuplicateUniqueIndex() of parser.go file and crash happens

What is fixed
We don't add element to uniqueIndex when the column name of UNIQUE KEY is invalid. 
When run command as following,
goctl model mysql ddl --src user_base.sql --dir .

and output below message and exit
"table %s: unique key with error column name[%s]"