### PR TITLE
fix:  negative float32 overflow when unmarshalling

### DIFF
--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -622,7 +621,7 @@ func (u *Unmarshaler) processFieldPrimitiveWithJSONNumber(fieldType reflect.Type
 			return err
 		}
 
-		if fValue > math.MaxFloat32 {
+		if value.OverflowFloat(fValue) {
 			return fmt.Errorf("parsing %q as float32: value out of range", v.String())
 		}
 

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -976,6 +976,19 @@ func TestUnmarshalFloat32WithOverflow(t *testing.T) {
 		assert.Error(t, UnmarshalKey(m, &in))
 	})
 
+	t.Run("float32 from string less than float32", func(t *testing.T) {
+		type inner struct {
+			Value float32 `key:"float, string"`
+		}
+
+		m := map[string]any{
+			"float": "-1.79769313486231570814527423731704356798070e+300", // overflow
+		}
+
+		var in inner
+		assert.Error(t, UnmarshalKey(m, &in))
+	})
+
 	t.Run("float32 from json.Number greater than float64", func(t *testing.T) {
 		type inner struct {
 			Value float32 `key:"float"`
@@ -996,6 +1009,19 @@ func TestUnmarshalFloat32WithOverflow(t *testing.T) {
 
 		m := map[string]any{
 			"float": json.Number("1.79769313486231570814527423731704356798070e+300"), // overflow
+		}
+
+		var in inner
+		assert.Error(t, UnmarshalKey(m, &in))
+	})
+
+	t.Run("float32 from json number less than float32", func(t *testing.T) {
+		type inner struct {
+			Value float32 `key:"float"`
+		}
+
+		m := map[string]any{
+			"float": json.Number("-1.79769313486231570814527423731704356798070e+300"), // overflow
 		}
 
 		var in inner


### PR DESCRIPTION
When unmarshalling, if a negative float32 number is out of range,  the error  "out of range" would be returned.