### PR TITLE
feat:add redis mset func

### DIFF
--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -1339,6 +1339,30 @@ func (s *Redis) MgetCtx(ctx context.Context, keys ...string) (val []string, err 
 	return
 }
 
+// Mset is the implementation of redis mset command.
+func (s *Redis) Mset(fieldsAndValues ...any) (string, error) {
+	return s.MsetCtx(context.Background(), fieldsAndValues...)
+}
+
+// MsetCtx is the implementation of redis mset command.
+func (s *Redis) MsetCtx(ctx context.Context, fieldsAndValues ...any) (val string, err error) {
+	err = s.brk.DoWithAcceptable(func() error {
+		conn, err := getRedis(s)
+		if err != nil {
+			return err
+		}
+
+		val, err = conn.MSet(ctx, fieldsAndValues...).Result()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, acceptable)
+
+	return
+}
+
 // Persist is the implementation of redis persist command.
 func (s *Redis) Persist(key string) (bool, error) {
 	return s.PersistCtx(context.Background(), key)

--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -663,14 +663,22 @@ func TestRedis_List(t *testing.T) {
 func TestRedis_Mset(t *testing.T) {
 	t.Run("mset", func(t *testing.T) {
 		runOnRedis(t, func(client *Redis) {
-			_, err := client.Mset("key1", "value1", "key2", "value2")
+			// Attempt to Mget with a bad client type, expecting an error.
+			_, err := New(client.Addr, badType()).Mset("key1", "value1")
+			assert.NotNil(t, err)
+
+			// Set multiple key-value pairs using Mset and expect no error.
+			_, err = client.Mset("key1", "value1", "key2", "value2")
 			assert.Nil(t, err)
+
+			// Retrieve the values for the keys set above using Mget and expect no error.
 			vals, err := client.Mget("key1", "key2")
 			assert.Nil(t, err)
 			assert.EqualValues(t, []string{"value1", "value2"}, vals)
 		})
 	})
 
+	// Test case for Mset operation with an incorrect number of arguments, expecting an error.
 	t.Run("mset error", func(t *testing.T) {
 		runOnRedisWithError(t, func(client *Redis) {
 			_, err := client.Mset("key1", "value1", "key2")

--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -660,6 +660,25 @@ func TestRedis_List(t *testing.T) {
 	})
 }
 
+func TestRedis_Mset(t *testing.T) {
+	t.Run("mset", func(t *testing.T) {
+		runOnRedis(t, func(client *Redis) {
+			_, err := client.Mset("key1", "value1", "key2", "value2")
+			assert.Nil(t, err)
+			vals, err := client.Mget("key1", "key2")
+			assert.Nil(t, err)
+			assert.EqualValues(t, []string{"value1", "value2"}, vals)
+		})
+	})
+
+	t.Run("mset error", func(t *testing.T) {
+		runOnRedisWithError(t, func(client *Redis) {
+			_, err := client.Mset("key1", "value1", "key2")
+			assert.Error(t, err)
+		})
+	})
+}
+
 func TestRedis_Mget(t *testing.T) {
 	t.Run("mget", func(t *testing.T) {
 		runOnRedis(t, func(client *Redis) {


### PR DESCRIPTION
The current go-zero Redis library lacks an implementation for the Redis MSET method, and it would be beneficial to add this. Implementing the Redis MSET method will facilitate batch insertion into Redis in the future, reducing network IO.