### PR TITLE
(goctl)fix request function parameter error generated by inline struct

### DIFF
--- a/tools/goctl/api/spec/fn.go
+++ b/tools/goctl/api/spec/fn.go
@@ -142,7 +142,7 @@ func (m Member) IsFormMember() bool {
 // IsTagMember returns true if contains given tag
 func (m Member) IsTagMember(tagKey string) bool {
 	if m.IsInline {
-		return true
+		return false
 	}
 
 	tags := m.Tags()

--- a/tools/goctl/api/tsgen/request.ts
+++ b/tools/goctl/api/tsgen/request.ts
@@ -106,7 +106,7 @@ function api<T>(
 }
 
 export const webapi = {
-    get<T>(url: string, req: unknown, config?: unknown): Promise<T> {
+    get<T>(url: string, req?: unknown, config?: unknown): Promise<T> {
         return api<T>('get', url, req, config);
     },
     delete<T>(url: string, req: unknown, config?: unknown): Promise<T> {


### PR DESCRIPTION
reappear example:

test api file
```
syntax = "v1"

type Request {
	Name string `path:"name,options=you|me"`
	Date
}

type Date {
	Foo string `json:"foo"`
}

type Response {
	Message string `json:"message"`
}

service test-api {
	@handler fooHandler
	get /foo/:name (Request) returns (Response)

	@handler barHandler
	get /bar returns (Response)
}
```

result:

test.ts
```
import webapi from "./gocliRequest"
import * as components from "./testComponents"
export * from "./testComponents"

/**
 * @description 
 */
export function bar() {
	return webapi.get<components.Response>(`/bar`)
}

/**
 * @description 
 * @param params
 * @param req
 * @param headers
 */
export function foo(params: components.RequestParams, req: components.Request, headers: components.RequestHeaders, name: string) {
	return webapi.get<components.Response>(`/foo/${name}`, params, req, headers)
}

```
![image](https://github.com/zeromicro/go-zero/assets/16470282/d14bb1b7-0a50-499c-8ffb-7102182c4ae2)

1. foo method has more headers parameters
2. bar method should ignore req


right result: 
```
import webapi from "./gocliRequest"
import * as components from "./testComponents"
export * from "./testComponents"

/**
 * @description 
 */
export function bar() {
	return webapi.get<components.Response>(`/bar`)
}

/**
 * @description 
 * @param params
 * @param req
 */
export function foo(params: components.RequestParams, req: components.Request, name: string) {
	return webapi.get<components.Response>(`/foo/${name}`, params, req)
}
```