### PR TITLE
fix: BatchError.Add() non thread safe

### DIFF
--- a/core/errorx/batcherror.go
+++ b/core/errorx/batcherror.go
@@ -1,10 +1,14 @@
 package errorx
 
-import "bytes"
+import (
+	"bytes"
+	"sync"
+)
 
 type (
 	// A BatchError is an error that can hold multiple errors.
 	BatchError struct {
+		mu   sync.Mutex
 		errs errorArray
 	}
 
@@ -13,6 +17,9 @@ type (
 
 // Add adds errs to be, nil errors are ignored.
 func (be *BatchError) Add(errs ...error) {
+	be.mu.Lock()
+	defer be.mu.Unlock()
+
 	for _, err := range errs {
 		if err != nil {
 			be.errs = append(be.errs, err)

--- a/core/errorx/batcherror_test.go
+++ b/core/errorx/batcherror_test.go
@@ -3,6 +3,7 @@ package errorx
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,4 +46,22 @@ func TestBatchErrorWithErrors(t *testing.T) {
 	assert.NotNil(t, batch)
 	assert.Equal(t, fmt.Sprintf("%s\n%s", err1, err2), batch.Err().Error())
 	assert.True(t, batch.NotNil())
+}
+
+func TestBatchErrorConcurrentAdd(t *testing.T) {
+	const count = 10000
+	var batch BatchError
+	var wg sync.WaitGroup
+
+	wg.Add(count)
+	for i := 0; i < count; i++ {
+		go func() {
+			batch.Add(errors.New(err1))
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, count, len(batch.errs))
+
 }

--- a/core/errorx/batcherror_test.go
+++ b/core/errorx/batcherror_test.go
@@ -34,7 +34,7 @@ func TestBatchErrorNilFromFunc(t *testing.T) {
 func TestBatchErrorOneError(t *testing.T) {
 	var batch BatchError
 	batch.Add(errors.New(err1))
-	assert.NotNil(t, batch)
+	assert.NotNil(t, batch.Err())
 	assert.Equal(t, err1, batch.Err().Error())
 	assert.True(t, batch.NotNil())
 }
@@ -43,7 +43,7 @@ func TestBatchErrorWithErrors(t *testing.T) {
 	var batch BatchError
 	batch.Add(errors.New(err1))
 	batch.Add(errors.New(err2))
-	assert.NotNil(t, batch)
+	assert.NotNil(t, batch.Err())
 	assert.Equal(t, fmt.Sprintf("%s\n%s", err1, err2), batch.Err().Error())
 	assert.True(t, batch.NotNil())
 }
@@ -56,12 +56,13 @@ func TestBatchErrorConcurrentAdd(t *testing.T) {
 	wg.Add(count)
 	for i := 0; i < count; i++ {
 		go func() {
+			defer wg.Done()
 			batch.Add(errors.New(err1))
-			wg.Done()
 		}()
 	}
 	wg.Wait()
 
+	assert.NotNil(t, batch.Err())
 	assert.Equal(t, count, len(batch.errs))
-
+	assert.True(t, batch.NotNil())
 }


### PR DESCRIPTION
BatchError.Add()  non thread safe,  `append` operation need  locked.

help to review it. thank!

@kevwan @kesonan 