### PR TITLE
feat: add nocgroup build tag for systems without cgroup

### DIFF
--- a/core/stat/internal/cpu_linux.go
+++ b/core/stat/internal/cpu_linux.go
@@ -1,3 +1,5 @@
+//go:build !nocgroup
+
 package internal
 
 import (

--- a/core/stat/internal/cpu_other.go
+++ b/core/stat/internal/cpu_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux || nocgroup
 
 package internal
 


### PR DESCRIPTION
In restricted environments, for example some PaaS, there is limited/no access to Linux cgroups. This can cause the following panic:

```
[2024-02-29 21:10:43] {"@timestamp":"2024-02-29T21:10:43.134Z","content":"cannot statfs cgroup root: no such file or directory
goroutine 4 [running]:
runtime/debug.Stack()
    /layers/heroku_go/shim/go1.21.6/go/src/runtime/debug/stack.go:24 +0x5e
github.com/zeromicro/go-zero/core/logx.writeStack({0xc00012c4c0, 0x34})
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/logx/logs.go:521 +0x34
github.com/zeromicro/go-zero/core/logx.ErrorStack({0xc000080b80?, 0xc000080c60?, 0xc000080c28?})
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/logx/logs.go:126 +0x2a
github.com/zeromicro/go-zero/core/rescue.Recover({0x0, 0x0, 0x8?})
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/rescue/recover.go:20 +0x76
panic({0x11bda20?, 0xc0002b0070?})
    /layers/heroku_go/shim/go1.21.6/go/src/runtime/panic.go:914 +0x21f
github.com/zeromicro/go-zero/core/stat/internal.isCgroup2UnifiedMode.func1()
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/stat/internal/cgroup_linux.go:231 +0x119
sync.(*Once).doSlow(0x0?, 0xc00006bf20?)
    /layers/heroku_go/shim/go1.21.6/go/src/sync/once.go:74 +0xbf
sync.(*Once).Do(...)
    /layers/heroku_go/shim/go1.21.6/go/src/sync/once.go:65
github.com/zeromicro/go-zero/core/stat/internal.isCgroup2UnifiedMode()
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/stat/internal/cgroup_linux.go:222 +0x2c
github.com/zeromicro/go-zero/core/stat/internal.currentCgroup()
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/stat/internal/cgroup_linux.go:41 +0xf
github.com/zeromicro/go-zero/core/stat/internal.effectiveCpus()
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/stat/internal/cpu_linux.go:107 +0x13
github.com/zeromicro/go-zero/core/stat/internal.initialize()
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/stat/internal/cpu_linux.go:31 +0x17
sync.(*Once).doSlow(0xc00031e0c0?, 0xc00031e120?)
    /layers/heroku_go/shim/go1.21.6/go/src/sync/once.go:74 +0xbf
sync.(*Once).Do(...)
    /layers/heroku_go/shim/go1.21.6/go/src/sync/once.go:65
github.com/zeromicro/go-zero/core/stat/internal.RefreshCpu()
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/stat/internal/cpu_linux.go:61 +0x30
github.com/zeromicro/go-zero/core/stat.init.1.func1.1()
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/stat/usage.go:34 +0xf
github.com/zeromicro/go-zero/core/threading.RunSafe(0xc00006bfa0?)
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/threading/routines.go:38 +0x33
github.com/zeromicro/go-zero/core/stat.init.1.func1()
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/stat/usage.go:33 +0x113
created by github.com/zeromicro/go-zero/core/stat.init.1 in goroutine 1
    /layers/heroku_go/shim/go-path/pkg/mod/github.com/zeromicro/go-zero@v1.6.2/core/stat/usage.go:24
```

To prevent this panic, this contribution adds support for a new go build tag `nocgroup` which will build `core/stat/internal/cpu_other.go` instead of `core/stat/internal/cpu_linux.go`.

Example usage:
```shell
go build -tags nocgroup ...
```