### PR TITLE
fix: only add log middleware to not found handler when enabled

### DIFF
--- a/rest/engine.go
+++ b/rest/engine.go
@@ -217,8 +217,11 @@ func (ng *engine) notFoundHandler(next http.Handler) http.Handler {
 			handler.TraceHandler(ng.conf.Name,
 				"",
 				handler.WithTraceIgnorePaths(ng.conf.TraceIgnorePaths)),
-			ng.getLogHandler(),
 		)
+
+		if ng.conf.Middlewares.Log {
+			chn = chn.Append(ng.getLogHandler())
+		}
 
 		var h http.Handler
 		if next != nil {


### PR DESCRIPTION
The `notFoundHandler()` function builds its own chain, that will always contain the log middleware, even when `Middlewares.Log = false`.

This change ensures the log handler is only added to this chain conditionally.