### PR TITLE
Add: export the Gateway/internal. methods 

### DIFF
--- a/gateway/internal/descriptorsource.go
+++ b/gateway/internal/descriptorsource.go
@@ -18,13 +18,12 @@ type Method struct {
 }
 
 // GetMethods returns all methods of the given grpcurl.DescriptorSource.
-func GetMethods(source grpcurl.DescriptorSource) ([]Method, error) {
+func GetMethods(source grpcurl.DescriptorSource,methods []Method) ([]Method, error) {
 	svcs, err := source.ListServices()
 	if err != nil {
 		return nil, err
 	}
 
-	var methods []Method
 	for _, svc := range svcs {
 		d, err := source.FindSymbol(svc)
 		if err != nil {
@@ -45,7 +44,6 @@ func GetMethods(source grpcurl.DescriptorSource) ([]Method, error) {
 						})
 						continue
 					}
-
 					switch httpRule := rule.GetPattern().(type) {
 					case *annotations.HttpRule_Get:
 						methods = append(methods, Method{
@@ -90,7 +88,6 @@ func GetMethods(source grpcurl.DescriptorSource) ([]Method, error) {
 			}
 		}
 	}
-
 	return methods, nil
 }
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -31,6 +31,18 @@ type (
 	Option func(svr *Server)
 )
 
+var Methods []internal.Method
+
+type Method internal.Method
+
+func MethodConver(method Method) internal.Method {
+	return internal.Method{
+		HttpMethod: method.HttpMethod,
+		HttpPath:   method.HttpPath,
+		RpcPath:    method.RpcPath,
+	}
+}
+
 // MustNewServer creates a new gateway server.
 func MustNewServer(c GatewayConf, opts ...Option) *Server {
 	svr := &Server{
@@ -78,7 +90,8 @@ func (s *Server) build() error {
 			return
 		}
 
-		methods, err := internal.GetMethods(source)
+		methods, err := internal.GetMethods(source, Methods)
+
 		if err != nil {
 			cancel(fmt.Errorf("%s: %w", up.Name, err))
 			return


### PR DESCRIPTION
export the methods to avoid  proto.GetExtension can't get any thing from rpc server,export the methods means  i can add the methods in gateway/main.go like 
`package main

import (
	"flag"
	"github.com/zeromicro/go-zero/core/conf"
	"github.com/zeromicro/go-zero/gateway"
	"gopkg.in/yaml.v2"
	"log"
	"os"
	"strings"
)

var file = "etc/route.yaml"
var configFile = flag.String("f", "etc/versionApi.yaml", "config file")

type RouteMapping struct {
	Method  string `yaml:"Method"`
	Path    string `yaml:"Path"`
	RpcPath string `yaml:"RpcPath"`
}

type Mappings struct {
	Mappings []RouteMapping `yaml:"Mappings"`
}

func main() {
	flag.Parse()
	var c gateway.GatewayConf
	conf.MustLoad(*configFile, &c)
	addMapping()
	gw := gateway.MustNewServer(c)
	defer gw.Stop()
	gw.Start()
}

func addMapping() {
	data, err := os.ReadFile(file)
	if err != nil {
		log.Fatalf("无法读取 YAML 文件：%v", err)
	}
	var config Mappings
	err = yaml.Unmarshal(data, &config)
	if err != nil {
		log.Fatalf("无法解析 YAML 数据：%v", err)
	}
	for _, mapping := range config.Mappings {
		gateway.Methods = append(gateway.Methods, gateway.MethodConver(gateway.Method{
			HttpMethod: mapping.Method,
			HttpPath:   adjustHttpPath(mapping.Path),
			RpcPath:    mapping.RpcPath,
		}))
	}
}

func adjustHttpPath(path string) string {
	path = strings.ReplaceAll(path, "{", ":")
	path = strings.ReplaceAll(path, "}", "")
	return path
}
`