### PR TITLE
optimize: change err == xx to errors.Is(err, xx)

### DIFF
--- a/core/iox/textlinescanner.go
+++ b/core/iox/textlinescanner.go
@@ -2,6 +2,7 @@ package iox
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"strings"
 )
@@ -30,7 +31,7 @@ func (scanner *TextLineScanner) Scan() bool {
 
 	line, err := scanner.reader.ReadString('\n')
 	scanner.line = strings.TrimRight(line, "\n")
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		scanner.hasNext = false
 		return true
 	} else if err != nil {

--- a/core/stores/redis/hook.go
+++ b/core/stores/redis/hook.go
@@ -122,7 +122,7 @@ func formatError(err error) string {
 	}
 
 	switch {
-	case err == io.EOF:
+	case errors.Is(err, io.EOF):
 		return "eof"
 	case errors.Is(err, context.DeadlineExceeded):
 		return "context deadline"

--- a/tools/goctl/rpc/generator/genpb.go
+++ b/tools/goctl/rpc/generator/genpb.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -86,7 +87,7 @@ func findPbFile(current string, src string, grpc bool) (string, error) {
 		}
 		return nil
 	})
-	if err == os.ErrExist {
+	if errors.Is(err, os.ErrExist) {
 		return filepath.Dir(filepath.Join(current, ret)), nil
 	}
 	return "", err

--- a/tools/goctl/util/format/format.go
+++ b/tools/goctl/util/format/format.go
@@ -115,7 +115,7 @@ func split(content string) ([]string, error) {
 	for {
 		r, _, err := reader.ReadRune()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				if buffer.Len() > 0 {
 					list = append(list, buffer.String())
 				}

--- a/zrpc/internal/clientinterceptors/tracinginterceptor.go
+++ b/zrpc/internal/clientinterceptors/tracinginterceptor.go
@@ -2,6 +2,7 @@ package clientinterceptors
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	ztrace "github.com/zeromicro/go-zero/core/trace"
@@ -122,7 +123,7 @@ func (w *clientStream) RecvMsg(m any) error {
 	err := w.ClientStream.RecvMsg(m)
 	if err == nil && !w.desc.ServerStreams {
 		w.sendStreamEvent(receiveEndEvent, nil)
-	} else if err == io.EOF {
+	} else if errors.Is(err, io.EOF) {
 		w.sendStreamEvent(receiveEndEvent, nil)
 	} else if err != nil {
 		w.sendStreamEvent(errorEvent, err)


### PR DESCRIPTION
Replace all error comparisons (matching format: err == xx) with errors.Is(err, xx).