### PR TITLE
feat:add db url shortname

### DIFF
--- a/tools/goctl/model/cmd.go
+++ b/tools/goctl/model/cmd.go
@@ -35,7 +35,7 @@ func init() {
 	ddlCmdFlags.StringVar(&command.VarStringRemote, "remote")
 	ddlCmdFlags.StringVar(&command.VarStringBranch, "branch")
 
-	datasourceCmdFlags.StringVar(&command.VarStringURL, "url")
+	datasourceCmdFlags.StringVarP(&command.VarStringURL, "url", "u")
 	datasourceCmdFlags.StringSliceVarP(&command.VarStringSliceTable, "table", "t")
 	datasourceCmdFlags.BoolVarP(&command.VarBoolCache, "cache", "c")
 	datasourceCmdFlags.StringVarP(&command.VarStringDir, "dir", "d")
@@ -45,7 +45,7 @@ func init() {
 	datasourceCmdFlags.StringVar(&command.VarStringRemote, "remote")
 	datasourceCmdFlags.StringVar(&command.VarStringBranch, "branch")
 
-	pgDatasourceCmdFlags.StringVar(&command.VarStringURL, "url")
+	pgDatasourceCmdFlags.StringVarP(&command.VarStringURL, "url", "u")
 	pgDatasourceCmdFlags.StringSliceVarP(&command.VarStringSliceTable, "table", "t")
 	pgDatasourceCmdFlags.StringVarPWithDefaultValue(&command.VarStringSchema, "schema", "s", "public")
 	pgDatasourceCmdFlags.BoolVarP(&command.VarBoolCache, "cache", "c")

--- a/tools/goctl/model/sql/README.MD
+++ b/tools/goctl/model/sql/README.MD
@@ -283,7 +283,7 @@ OPTIONS:
        goctl model mysql datasource [command options] [arguments...]
     
     OPTIONS:
-       --url value              the data source of database,like "root:password@tcp(127.0.0.1:3306)/database
+       --url value, -u url      the data source of database,like "root:password@tcp(127.0.0.1:3306)/database
        --table value, -t value  the table or table globbing patterns in the database
        --cache, -c              generate code with cache [optional]
        --dir value, -d value    the target dir


### PR DESCRIPTION
Goctl generates models code, adds abbreviations for URLs.
This change is targeted at MySQL and Postgres
from
`
goctl model pg datasource  --url postgres://xxx:xxx@xxx:5432/ecommerce -t books
`
to
`
goctl model pg datasource  -u postgres://xxx:xxx@xxx:5432/ecommerce -t books
`