### PR TITLE
feat[redis]: add an option for specifying acceptable function

### DIFF
--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -2080,3 +2080,18 @@ func (n mockedNode) BLPop(_ context.Context, _ time.Duration, _ ...string) *red.
 
 	return cmd
 }
+
+func TestWithAcceptable(t *testing.T) {
+	c := RedisConf{
+		Host:     "host",
+		Type:     "node",
+		NonBlock: true,
+	}
+	e := errors.New("test error")
+	rds := MustNewRedis(c, WithAcceptable(func(err error) bool {
+		return e == err
+	}))
+	assert.True(t, rds.acceptable(e))
+	// don't hide default acceptable function
+	assert.True(t, rds.acceptable(nil))
+}


### PR DESCRIPTION
Which module can we specify an acceptable function?
**zrpc**: It is a bit difficult to specify different options for each client and server, more discussion is required.
**mongo**: can not be implemented on current interface
**sqlx**: already supported
**redis**: supported in this pr
**rest**: There is no need to do it.