### PR TITLE
feat: support query value list/array as url parameter

### DIFF
--- a/rest/httpx/util.go
+++ b/rest/httpx/util.go
@@ -21,8 +21,10 @@ func GetFormValues(r *http.Request) (map[string]any, error) {
 
 	params := make(map[string]any, len(r.Form))
 	for name := range r.Form {
-		formValue := r.Form.Get(name)
-		if len(formValue) > 0 {
+		formValue := r.Form[name] // to access multiple values, use the map
+		if len(formValue) == 1 && len(formValue[0]) > 0 {
+			params[name] = formValue[0]
+		} else if len(formValue) > 1 {
 			params[name] = formValue
 		}
 	}

--- a/rest/httpx/util_test.go
+++ b/rest/httpx/util_test.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -22,4 +23,64 @@ func TestGetRemoteAddrNoHeader(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.True(t, len(GetRemoteAddr(r)) == 0)
+}
+
+type User struct {
+	UserId   []int  `form:"userId"`
+	Username string `form:"username"`
+	Password string `form:"password,optional"`
+}
+
+func TestQueryURLArrayParameterFormValues(t *testing.T) {
+	u := User{
+		UserId:   []int{1, 2},
+		Username: "admin",
+	}
+
+	// Unit 1
+	r, err := http.NewRequest(http.MethodGet, "/test/?userId=1&userId=2&username=admin&password=", nil)
+	assert.Nil(t, err)
+
+	params, err := GetFormValues(r)
+	assert.Nil(t, err)
+
+	var u1 User
+	assert.Nil(t, formUnmarshaler.Unmarshal(params, &u1))
+	assert.Equal(t, u, u1)
+
+	// Unit 2
+	r, err = http.NewRequest(http.MethodGet, "/test/?userId=[1,2]&username=admin", nil)
+	assert.Nil(t, err)
+
+	params, err = GetFormValues(r)
+	assert.Nil(t, err)
+
+	var u2 User
+	assert.Nil(t, formUnmarshaler.Unmarshal(params, &u2))
+	assert.Equal(t, u, u2)
+}
+
+func TestPostFormValues(t *testing.T) {
+	u := User{
+		UserId:   []int{1, 2},
+		Username: "admin",
+	}
+
+	formData := url.Values{
+		"userId":   {"1", "2"},
+		"username": {"admin"},
+	}
+
+	r, err := http.NewRequest(http.MethodPost, "/test", strings.NewReader(formData.Encode()))
+	assert.Nil(t, err)
+
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	params, err := GetFormValues(r)
+	assert.Nil(t, err)
+
+	var u1 User
+	assert.Nil(t, formUnmarshaler.Unmarshal(params, &u1))
+	assert.Equal(t, u, u1)
+
 }


### PR DESCRIPTION
Sending via URL:
List of values can be passed via URL like this:

`http://localhost:8080/test/?userId=1&userId=2&username=admin&password=`

OR

`http://localhost:8080/test/?userId=[1,2]&username=admin`

help to review it. thank! @kevwan @kesonan
