### PR TITLE
fix the usage datasource url of postgresql (#4029)

### DIFF
--- a/tools/goctl/internal/flags/default_en.json
+++ b/tools/goctl/internal/flags/default_en.json
@@ -178,7 +178,7 @@
         "short": "Generate postgresql model",
         "datasource": {
           "short": "Generate model from datasource",
-          "url": "The data source of database,like \"root:password@tcp(127.0.0.1:3306)/database",
+          "url": "The data source of database,like \"postgres://root:password@127.0.0.1:5432/database?sslmode=disable\"",
           "table": "The table or table globbing patterns in the database",
           "schema": "The schema or schema globbing patterns in the database",
           "cache": "Generate code with cache [optional]",


### PR DESCRIPTION
The demo url of posrgres from goctl tools usage is not correct. like this

The data source of database,like "root:password@tcp(127.0.0.1:3306)/database
seems copy from mysql side.