### PR TITLE
feat: add ParallelFnErr and RoutineErrGroup

### DIFF
--- a/core/fx/parallel.go
+++ b/core/fx/parallel.go
@@ -10,3 +10,19 @@ func Parallel(fns ...func()) {
 	}
 	group.Wait()
 }
+
+// ParallelFnErr Execute a set of functions in parallel, each returning the error.
+func ParallelFnErr(fns ...func() error) error {
+	group := threading.NewRoutineErrGroup()
+	group.SetLimit(len(fns))
+
+	for _, fn := range fns {
+		group.RunSafe(fn)
+	}
+
+	if err := group.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/core/fx/parallel_test.go
+++ b/core/fx/parallel_test.go
@@ -48,3 +48,27 @@ func TestParallelFnErr(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "failed to exec #1", "failed to exec #2")
 }
+
+func TestParallelFnErrErrorNil(t *testing.T) {
+	var count int32
+	err := ParallelFnErr(
+		func() error {
+			time.Sleep(time.Millisecond * 100)
+			atomic.AddInt32(&count, 1)
+			return nil
+		},
+		func() error {
+			time.Sleep(time.Millisecond * 100)
+			atomic.AddInt32(&count, 2)
+			return nil
+
+		},
+		func() error {
+			time.Sleep(time.Millisecond * 100)
+			atomic.AddInt32(&count, 3)
+			return nil
+		})
+
+	assert.Equal(t, int32(6), count)
+	assert.NoError(t, err)
+}

--- a/core/threading/routinegroup.go
+++ b/core/threading/routinegroup.go
@@ -1,6 +1,13 @@
 package threading
 
-import "sync"
+import (
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/zeromicro/go-zero/core/errorx"
+	"github.com/zeromicro/go-zero/core/rescue"
+)
 
 // A RoutineGroup is used to group goroutines together and all wait all goroutines to be done.
 type RoutineGroup struct {
@@ -39,4 +46,56 @@ func (g *RoutineGroup) RunSafe(fn func()) {
 // Wait waits all running functions to be done.
 func (g *RoutineGroup) Wait() {
 	g.waitGroup.Wait()
+}
+
+// A RoutineErrGroup is used to group goroutines together and all wait all goroutines to be done.
+// but adds handling of tasks returning errors.
+type RoutineErrGroup struct {
+	errGroup   errgroup.Group
+	batchError errorx.BatchError
+}
+
+// NewRoutineErrGroup returns a RoutineErrGroup.
+func NewRoutineErrGroup() *RoutineErrGroup {
+	return new(RoutineErrGroup)
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
+func (g *RoutineErrGroup) SetLimit(n int) {
+	g.errGroup.SetLimit(n)
+}
+
+// Run Execute the given function in a concurrent error group.
+// If an error occurs during function execution, the error is added to the error batch.
+func (g *RoutineErrGroup) Run(fn func() error) {
+	g.errGroup.Go(func() error {
+		if err := fn(); err != nil {
+			g.batchError.Add(err)
+			return err
+		}
+		return nil
+	})
+}
+
+// RunSafe Executes the given function safely in the group of concurrent errors and avoid panics.
+// If an error occurs during function execution, the error is added to the error batch.
+func (g *RoutineErrGroup) RunSafe(fn func() error) {
+	g.errGroup.Go(func() error {
+		defer rescue.Recover()
+
+		if err := fn(); err != nil {
+			g.batchError.Add(err)
+			return err
+		}
+		return nil
+	})
+}
+
+// Wait waits all running functions to be done.
+func (g *RoutineErrGroup) Wait() error {
+	if err := g.errGroup.Wait(); err != nil {
+		return g.batchError.Err()
+	}
+	return nil
 }

--- a/core/threading/routinegroup_test.go
+++ b/core/threading/routinegroup_test.go
@@ -1,6 +1,7 @@
 package threading
 
 import (
+	"errors"
 	"io"
 	"log"
 	"sync"
@@ -42,4 +43,52 @@ func TestRoutingGroupRunSafe(t *testing.T) {
 	group.Wait()
 
 	assert.Equal(t, int32(2), count)
+}
+
+func TestRoutineErrGroupRun(t *testing.T) {
+	var count int32
+	group := NewRoutineErrGroup()
+	for i := 0; i < 3; i++ {
+		i := i
+		group.Run(func() error {
+			atomic.AddInt32(&count, 1)
+			if i == 1 {
+				return errors.New("error")
+			}
+			return nil
+		})
+	}
+
+	err := group.Wait()
+
+	assert.Equal(t, int32(3), count)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "error")
+}
+
+func TestRoutingErrGroupRunSafe(t *testing.T) {
+	log.SetOutput(io.Discard)
+
+	var count int32
+	group := NewRoutineErrGroup()
+	var once sync.Once
+	for i := 0; i < 3; i++ {
+		i := i
+		group.RunSafe(func() error {
+			once.Do(func() {
+				panic("")
+			})
+			atomic.AddInt32(&count, 1)
+			if i == 1 {
+				return errors.New("error")
+			}
+			return nil
+		})
+	}
+
+	err := group.Wait()
+
+	assert.Equal(t, int32(2), count)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "error")
 }

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	go.uber.org/automaxprocs v1.5.3
 	go.uber.org/goleak v1.2.1
 	golang.org/x/net v0.24.0
+	golang.org/x/sync v0.6.0
 	golang.org/x/sys v0.19.0
 	golang.org/x/time v0.5.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de
@@ -107,7 +108,6 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect
-	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect


### PR DESCRIPTION
suggest to add execute a set of functions in parallel, each returning the error. 
by contrast `ParallelFnErr` the code is cleaner.

example:

Now: `ParallelFnErr`
```go
err := ParallelFnErr(
	func() (err error) {
		_, err = l.svcCtx.xxxRpc.SelectXxx(l.ctx, &Req{})
		return
	},
	func() (err error) {
		_, err = l.svcCtx.xxxRpc.SelectXxx(l.ctx, &Req{})
		return
	},
	...
	...
	...
	func() (err error) {
		_, err = l.svcCtx.xxxRpc.SelectXxx(l.ctx, &Req{})
		return
	},
)

if err != nil { 
	return err 
}
```

Before:  `Parallel` + `batchErr`
```go
fx.Parallel(
	func() {
		_, err := l.svcCtx.xxxRpc.SelectXxx(l.ctx, &Req{})
		if err != nil {
			batchErr.Add(err)
		}
	},
	func() {
		_, err := l.svcCtx.xxxRpc.SelectXxx(l.ctx, &Req{})
		if err != nil {
			batchErr.Add(err)
		}
	},
        ...
        ...
        ...
	func() {
		_, err := l.svcCtx.xxxRpc.SelectXxx(l.ctx, &Req{})
		if err != nil {
			batchErr.Add(err)
		}
	},
)
	
if batchErr.NotNil() {
	return nil, batchErr.Err()
}
```

