### PR TITLE
fix(goctl): GOPROXY env should set by ourself

### DIFF
--- a/tools/goctl/pkg/golang/install.go
+++ b/tools/goctl/pkg/golang/install.go
@@ -8,7 +8,7 @@ import (
 func Install(git string) error {
 	cmd := exec.Command("go", "install", git)
 	env := os.Environ()
-	env = append(env, "GO111MODULE=on", "GOPROXY=https://goproxy.cn,direct")
+	env = append(env, "GO111MODULE=on")
 	cmd.Env = env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
My GOPROXY env is https://goproxy.io,direct. 

When I use command `goctl env check --install --verbose --force`, always use goproxy.cn. 

goproxy.cn sometimes fails to download.

So I suggest to remove the GOPROXY env