### PR TITLE
fix: zrpc kube resolver builder registers duplicated informer

### DIFF
--- a/zrpc/resolver/internal/kube/eventhandler.go
+++ b/zrpc/resolver/internal/kube/eventhandler.go
@@ -117,6 +117,16 @@ func (h *EventHandler) Update(endpoints *v1.Endpoints) {
 	}
 }
 
+func (h *EventHandler) Targets() []string {
+	targets := make([]string, 0, len(h.endpoints))
+
+	for k := range h.endpoints {
+		targets = append(targets, k)
+	}
+
+	return targets
+}
+
 func (h *EventHandler) notify() {
 	targets := make([]string, 0, len(h.endpoints))
 

--- a/zrpc/resolver/internal/kubebuilder.go
+++ b/zrpc/resolver/internal/kubebuilder.go
@@ -72,7 +72,6 @@ func (b *kubeBuilder) Build(target resolver.Target, cc resolver.ClientConn,
 	}
 
 	if !ok {
-		logx.Debugf("fitst time informer for %s", target)
 		handler = kube.NewEventHandler(updates)
 
 		inf := informers.NewSharedInformerFactoryWithOptions(cs, resyncInterval,
@@ -101,7 +100,6 @@ func (b *kubeBuilder) Build(target resolver.Target, cc resolver.ClientConn,
 		b.handlers[target] = handler
 		b.lock.Unlock()
 	} else {
-		logx.Debugf("existed informer updates for %s", target)
 		updates(handler.Targets())
 	}
 

--- a/zrpc/resolver/internal/resolver.go
+++ b/zrpc/resolver/internal/resolver.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"fmt"
 
+	"github.com/zeromicro/go-zero/zrpc/resolver/internal/kube"
+
 	"google.golang.org/grpc/resolver"
 )
 
@@ -28,7 +30,7 @@ var (
 	directResolverBuilder directBuilder
 	discovResolverBuilder discovBuilder
 	etcdResolverBuilder   etcdBuilder
-	k8sResolverBuilder    kubeBuilder
+	k8sResolverBuilder    kubeBuilder = kubeBuilder{handlers: make(map[resolver.Target]*kube.EventHandler)}
 )
 
 // RegisterResolver registers the direct and discov schemes to the resolver.


### PR DESCRIPTION
Currently zrpc registers a `kube://` scheme for Kubernetes's Service as grpc resolver.

When startup, grpc-go call kubebuilder's `Build` to resolve actual endpoints. In the resolver, it registers a `SharedInformer` for watching changes of Service's Endpoints. But if the client was idle for a very long time, grpc-go will try to resolve the endpoints again. This will be a duplicated registration of `SharedInformers` and cause a goroutine leak.

Therefore, zrpc's `kubeBuilder` should register **only one** `SharedInformer` for same `resolver.Target`. If grpc-go try to resolve the target again, update the `ClientConn`'s state with saved endpoints in `EventHandler`.