### PR TITLE
fix: make: command: Command not found

### DIFF
--- a/tools/goctl/Makefile
+++ b/tools/goctl/Makefile
@@ -1,18 +1,18 @@
 build:
 	go build -ldflags="-s -w" goctl.go
-	$(if $(shell command -v upx), upx goctl)
+	$(if $(shell which upx), upx goctl)
 
 mac:
 	GOOS=darwin go build -ldflags="-s -w" -o goctl-darwin goctl.go
-	$(if $(shell command -v upx), upx goctl-darwin)
+	$(if $(shell which upx), upx goctl-darwin)
 
 win:
 	GOOS=windows go build -ldflags="-s -w" -o goctl.exe goctl.go
-	$(if $(shell command -v upx), upx goctl.exe)
+	$(if $(shell which upx), upx goctl.exe)
 
 linux:
 	GOOS=linux go build -ldflags="-s -w" -o goctl-linux goctl.go
-	$(if $(shell command -v upx), upx goctl-linux)
+	$(if $(shell which upx), upx goctl-linux)
 
 image:
 	docker build --rm --platform linux/amd64 -t kevinwan/goctl:$(version) .


### PR DESCRIPTION
 make build error:
make: command: Command not found
go build -ldflags="-s -w" goctl.go