### PR TITLE
fix: quickstart dont work

### DIFF
--- a/readme-cn.md
+++ b/readme-cn.md
@@ -133,10 +133,12 @@ GO111MODULE=on GOPROXY=https://goproxy.cn/,direct go get -u github.com/zeromicro
 2. 快速生成 api 服务
 
     ```shell
+    mkdir quickstart
+    cd quickstart
+    go mod init go-zero-quickstart
     goctl api new greet
-    cd greet
-    go mod init
     go mod tidy
+    cd greet
     go run greet.go -f etc/greet-api.yaml
     ```
 

--- a/readme.md
+++ b/readme.md
@@ -193,9 +193,12 @@ go get -u github.com/zeromicro/go-zero
    the generated code can be run directly:
 
    ```shell
-   cd greet
-   go mod init
+   mkdir quickstart
+   cd quickstart
+   go mod init go-zero-quickstart
+   goctl api new greet
    go mod tidy
+   cd greet
    go run greet.go -f etc/greet-api.yaml
    ```
 


### PR DESCRIPTION
the default quickstart section do not work for the command order 
this would failed beginner<me and others> and prevent their going on learning, so after i fingered out the fixing, i just want to contributed it back 
to you