### PR TITLE
mapping Optimized error stack

### DIFF
--- a/core/mapping/fieldoptions.go
+++ b/core/mapping/fieldoptions.go
@@ -1,7 +1,5 @@
 package mapping
 
-import "fmt"
-
 const notSymbol = '!'
 
 type (
@@ -76,13 +74,13 @@ func (o *fieldOptions) toOptionsWithContext(key string, m Valuer, fullName strin
 		} else if dep[0] == notSymbol {
 			dep = dep[1:]
 			if len(dep) == 0 {
-				return nil, fmt.Errorf("wrong optional value for %q in %q", key, fullName)
+				return nil, newError("wrong optional value for %q in %q", key, fullName)
 			}
 
 			_, baseOn := m.Value(dep)
 			_, selfOn := m.Value(key)
 			if baseOn == selfOn {
-				return nil, fmt.Errorf("set value for either %q or %q in %q", dep, key, fullName)
+				return nil, newError("set value for either %q or %q in %q", dep, key, fullName)
 			}
 
 			optional = baseOn
@@ -90,7 +88,7 @@ func (o *fieldOptions) toOptionsWithContext(key string, m Valuer, fullName strin
 			_, baseOn := m.Value(dep)
 			_, selfOn := m.Value(key)
 			if baseOn != selfOn {
-				return nil, fmt.Errorf("values for %q and %q should be both provided or both not in %q",
+				return nil, newError("values for %q and %q should be both provided or both not in %q",
 					dep, key, fullName)
 			}
 

--- a/core/mapping/jsonunmarshaler_test.go
+++ b/core/mapping/jsonunmarshaler_test.go
@@ -856,7 +856,7 @@ func TestUnmarshalBytesError(t *testing.T) {
 	}
 
 	err := UnmarshalJsonBytes([]byte(payload), &v)
-	assert.Equal(t, errTypeMismatch, err)
+	assert.Equal(t, ErrTypeMismatch, err)
 }
 
 func TestUnmarshalReaderError(t *testing.T) {
@@ -866,7 +866,7 @@ func TestUnmarshalReaderError(t *testing.T) {
 		Any string
 	}
 
-	assert.Equal(t, errTypeMismatch, UnmarshalJsonReader(reader, &v))
+	assert.Equal(t, ErrTypeMismatch, UnmarshalJsonReader(reader, &v))
 }
 
 func TestUnmarshalMap(t *testing.T) {

--- a/core/mapping/marshaler.go
+++ b/core/mapping/marshaler.go
@@ -116,11 +116,11 @@ func validateOptional(field reflect.StructField, value reflect.Value) error {
 	switch field.Type.Kind() {
 	case reflect.Ptr:
 		if value.IsNil() {
-			return fmt.Errorf("field %q is nil", field.Name)
+			return newError("field %q is nil", field.Name)
 		}
 	case reflect.Array, reflect.Slice, reflect.Map:
 		if value.IsNil() || value.Len() == 0 {
-			return fmt.Errorf("field %q is empty", field.Name)
+			return newError("field %q is empty", field.Name)
 		}
 	}
 
@@ -137,7 +137,7 @@ func validateOptions(value reflect.Value, opt *fieldOptions) error {
 		}
 	}
 	if !found {
-		return fmt.Errorf("field %q not in options", val)
+		return newError("field %q not in options", val)
 	}
 
 	return nil
@@ -171,7 +171,7 @@ func validateRange(value reflect.Value, opt *fieldOptions) error {
 	case float64:
 		val = v
 	default:
-		return fmt.Errorf("unknown support type for range %q", value.Type().String())
+		return newError("unknown support type for range %q", value.Type().String())
 	}
 
 	// validates [left, right], [left, right), (left, right], (left, right)
@@ -179,7 +179,7 @@ func validateRange(value reflect.Value, opt *fieldOptions) error {
 		(!opt.Range.leftInclude && val == opt.Range.left) ||
 		val > opt.Range.right ||
 		(!opt.Range.rightInclude && val == opt.Range.right) {
-		return fmt.Errorf("%v out of range", value.Interface())
+		return newError("%v out of range", value.Interface())
 	}
 
 	return nil

--- a/core/mapping/marshaler_test.go
+++ b/core/mapping/marshaler_test.go
@@ -277,7 +277,7 @@ func TestMarshal_RangeIllegal(t *testing.T) {
 
 	for _, test := range tests {
 		_, err := Marshal(test)
-		assert.Equal(t, err, errNumberRange)
+		assert.Equal(t, err, ErrNumberRange)
 	}
 }
 
@@ -302,7 +302,7 @@ func TestMarshal_RangeLeftEqualsToRight(t *testing.T) {
 			}{
 				Int: 2,
 			},
-			err: errNumberRange,
+			err: ErrNumberRange,
 		},
 		{
 			name: "left exclusive, right inclusive",
@@ -311,7 +311,7 @@ func TestMarshal_RangeLeftEqualsToRight(t *testing.T) {
 			}{
 				Int: 2,
 			},
-			err: errNumberRange,
+			err: ErrNumberRange,
 		},
 		{
 			name: "left exclusive, right exclusive",
@@ -320,7 +320,7 @@ func TestMarshal_RangeLeftEqualsToRight(t *testing.T) {
 			}{
 				Int: 2,
 			},
-			err: errNumberRange,
+			err: ErrNumberRange,
 		},
 	}
 

--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -3,7 +3,6 @@ package mapping
 import (
 	"encoding"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -25,17 +24,21 @@ const (
 )
 
 var (
-	errTypeMismatch     = errors.New("type mismatch")
-	errValueNotSettable = errors.New("value is not settable")
-	errValueNotStruct   = errors.New("value type is not struct")
-	keyUnmarshaler      = NewUnmarshaler(defaultKeyName)
-	durationType        = reflect.TypeOf(time.Duration(0))
-	cacheKeys           = make(map[string][]string)
-	cacheKeysLock       sync.Mutex
-	defaultCache        = make(map[string]any)
-	defaultCacheLock    sync.Mutex
-	emptyMap            = map[string]any{}
-	emptyValue          = reflect.ValueOf(lang.Placeholder)
+	ErrTypeMismatch     = newError("type mismatch")
+	ErrValueIsNotSet    = newError("is not set")
+	ErrValueNotSettable = newError("value is not settable")
+	ErrValueNotStruct   = newError("value type is not struct")
+)
+
+var (
+	keyUnmarshaler   = NewUnmarshaler(defaultKeyName)
+	durationType     = reflect.TypeOf(time.Duration(0))
+	cacheKeys        = make(map[string][]string)
+	cacheKeysLock    sync.Mutex
+	defaultCache     = make(map[string]any)
+	defaultCacheLock sync.Mutex
+	emptyMap         = map[string]any{}
+	emptyValue       = reflect.ValueOf(lang.Placeholder)
 )
 
 type (
@@ -82,25 +85,25 @@ func (u *Unmarshaler) Unmarshal(i, v any) error {
 func (u *Unmarshaler) unmarshal(i, v any, fullName string) error {
 	valueType := reflect.TypeOf(v)
 	if valueType.Kind() != reflect.Ptr {
-		return errValueNotSettable
+		return ErrValueNotSettable
 	}
 
 	elemType := Deref(valueType)
 	switch iv := i.(type) {
 	case map[string]any:
 		if elemType.Kind() != reflect.Struct {
-			return errTypeMismatch
+			return ErrTypeMismatch
 		}
 
 		return u.unmarshalValuer(mapValuer(iv), v, fullName)
 	case []any:
 		if elemType.Kind() != reflect.Slice {
-			return errTypeMismatch
+			return ErrTypeMismatch
 		}
 
 		return u.fillSlice(elemType, reflect.ValueOf(v).Elem(), iv, fullName)
 	default:
-		return errUnsupportedType
+		return ErrUnsupportedType
 	}
 }
 
@@ -116,7 +119,7 @@ func (u *Unmarshaler) unmarshalValuer(m Valuer, v any, fullName string) error {
 func (u *Unmarshaler) fillMap(fieldType reflect.Type, value reflect.Value,
 	mapValue any, fullName string) error {
 	if !value.CanSet() {
-		return errValueNotSettable
+		return ErrValueNotSettable
 	}
 
 	fieldKeyType := fieldType.Key()
@@ -127,7 +130,7 @@ func (u *Unmarshaler) fillMap(fieldType reflect.Type, value reflect.Value,
 	}
 
 	if !targetValue.Type().AssignableTo(value.Type()) {
-		return errTypeMismatch
+		return ErrTypeMismatch
 	}
 
 	value.Set(targetValue)
@@ -136,7 +139,7 @@ func (u *Unmarshaler) fillMap(fieldType reflect.Type, value reflect.Value,
 
 func (u *Unmarshaler) fillMapFromString(value reflect.Value, mapValue any) error {
 	if !value.CanSet() {
-		return errValueNotSettable
+		return ErrValueNotSettable
 	}
 
 	switch v := mapValue.(type) {
@@ -149,7 +152,7 @@ func (u *Unmarshaler) fillMapFromString(value reflect.Value, mapValue any) error
 			return err
 		}
 	default:
-		return errUnsupportedType
+		return ErrUnsupportedType
 	}
 
 	return nil
@@ -158,7 +161,7 @@ func (u *Unmarshaler) fillMapFromString(value reflect.Value, mapValue any) error
 func (u *Unmarshaler) fillSlice(fieldType reflect.Type, value reflect.Value,
 	mapValue any, fullName string) error {
 	if !value.CanSet() {
-		return errValueNotSettable
+		return ErrValueNotSettable
 	}
 
 	refValue := reflect.ValueOf(mapValue)
@@ -193,7 +196,7 @@ func (u *Unmarshaler) fillSlice(fieldType reflect.Type, value reflect.Value,
 			target := reflect.New(dereffedBaseType)
 			val, ok := ithValue.(map[string]any)
 			if !ok {
-				return errTypeMismatch
+				return ErrTypeMismatch
 			}
 
 			if err := u.unmarshal(val, target.Interface(), sliceFullName); err != nil {
@@ -232,7 +235,7 @@ func (u *Unmarshaler) fillSliceFromString(fieldType reflect.Type, value reflect.
 			return fmt.Errorf("fullName: `%s`, error: `%w`", fullName, err)
 		}
 	default:
-		return errUnsupportedType
+		return ErrUnsupportedType
 	}
 
 	baseFieldType := Deref(fieldType.Elem())
@@ -252,7 +255,7 @@ func (u *Unmarshaler) fillSliceFromString(fieldType reflect.Type, value reflect.
 func (u *Unmarshaler) fillSliceValue(slice reflect.Value, index int,
 	baseKind reflect.Kind, value any, fullName string) error {
 	if value == nil {
-		return errNilSliceElement
+		return ErrNilSliceElement
 	}
 
 	ithVal := slice.Index(index)
@@ -269,7 +272,7 @@ func (u *Unmarshaler) fillSliceValue(slice reflect.Value, index int,
 		if ithVal.Kind() == reflect.Ptr {
 			baseType := Deref(ithVal.Type())
 			if !reflect.TypeOf(value).AssignableTo(baseType) {
-				return errTypeMismatch
+				return ErrTypeMismatch
 			}
 
 			target := reflect.New(baseType).Elem()
@@ -279,7 +282,7 @@ func (u *Unmarshaler) fillSliceValue(slice reflect.Value, index int,
 		}
 
 		if !reflect.TypeOf(value).AssignableTo(ithVal.Type()) {
-			return errTypeMismatch
+			return ErrTypeMismatch
 		}
 
 		ithVal.Set(reflect.ValueOf(value))
@@ -312,7 +315,7 @@ func (u *Unmarshaler) fillSliceWithDefault(derefedType reflect.Type, value refle
 func (u *Unmarshaler) fillUnmarshalerStruct(fieldType reflect.Type,
 	value reflect.Value, targetValue string) error {
 	if !value.CanSet() {
-		return errValueNotSettable
+		return ErrValueNotSettable
 	}
 
 	baseType := Deref(fieldType)
@@ -321,14 +324,14 @@ func (u *Unmarshaler) fillUnmarshalerStruct(fieldType reflect.Type,
 	case jsonTagKey:
 		unmarshaler, ok := target.Interface().(json.Unmarshaler)
 		if !ok {
-			return errUnsupportedType
+			return ErrUnsupportedType
 		}
 
 		if err := unmarshaler.UnmarshalJSON([]byte(targetValue)); err != nil {
 			return err
 		}
 	default:
-		return errUnsupportedType
+		return ErrUnsupportedType
 	}
 
 	value.Set(target)
@@ -344,7 +347,7 @@ func (u *Unmarshaler) generateMap(keyType, elemType reflect.Type, mapValue any,
 	}
 
 	if keyType != valueType.Key() {
-		return emptyValue, errTypeMismatch
+		return emptyValue, ErrTypeMismatch
 	}
 
 	refValue := reflect.ValueOf(mapValue)
@@ -368,7 +371,7 @@ func (u *Unmarshaler) generateMap(keyType, elemType reflect.Type, mapValue any,
 		case reflect.Struct:
 			keythMap, ok := keythData.(map[string]any)
 			if !ok {
-				return emptyValue, errTypeMismatch
+				return emptyValue, ErrTypeMismatch
 			}
 
 			target := reflect.New(dereffedElemType)
@@ -380,7 +383,7 @@ func (u *Unmarshaler) generateMap(keyType, elemType reflect.Type, mapValue any,
 		case reflect.Map:
 			keythMap, ok := keythData.(map[string]any)
 			if !ok {
-				return emptyValue, errTypeMismatch
+				return emptyValue, ErrTypeMismatch
 			}
 
 			innerValue, err := u.generateMap(elemType.Key(), elemType.Elem(), keythMap, mapFullName)
@@ -393,18 +396,18 @@ func (u *Unmarshaler) generateMap(keyType, elemType reflect.Type, mapValue any,
 			switch v := keythData.(type) {
 			case bool:
 				if dereffedElemKind != reflect.Bool {
-					return emptyValue, errTypeMismatch
+					return emptyValue, ErrTypeMismatch
 				}
 
 				targetValue.SetMapIndex(key, reflect.ValueOf(v))
 			case string:
 				if dereffedElemKind != reflect.String {
-					return emptyValue, errTypeMismatch
+					return emptyValue, ErrTypeMismatch
 				}
 
 				val := reflect.ValueOf(v)
 				if !val.Type().AssignableTo(dereffedElemType) {
-					return emptyValue, errTypeMismatch
+					return emptyValue, ErrTypeMismatch
 				}
 
 				targetValue.SetMapIndex(key, val)
@@ -417,7 +420,7 @@ func (u *Unmarshaler) generateMap(keyType, elemType reflect.Type, mapValue any,
 				targetValue.SetMapIndex(key, target.Elem())
 			default:
 				if dereffedElemKind != keythValue.Kind() {
-					return emptyValue, errTypeMismatch
+					return emptyValue, ErrTypeMismatch
 				}
 
 				targetValue.SetMapIndex(key, keythValue)
@@ -567,7 +570,7 @@ func (u *Unmarshaler) processAnonymousStructFieldOptional(fieldType reflect.Type
 	}
 
 	if filled && required != requiredFilled {
-		return fmt.Errorf("%q is not fully set", key)
+		return newError("%q is not fully set", key)
 	}
 
 	return nil
@@ -597,7 +600,7 @@ func (u *Unmarshaler) processFieldNotFromString(fieldType reflect.Type, value re
 	case valueKind == reflect.Map && typeKind == reflect.Struct:
 		mv, ok := mapValue.(map[string]any)
 		if !ok {
-			return errTypeMismatch
+			return ErrTypeMismatch
 		}
 
 		return u.processFieldStruct(fieldType, value, &simpleValuer{
@@ -675,7 +678,7 @@ func (u *Unmarshaler) processFieldPrimitiveWithJSONNumber(fieldType reflect.Type
 			derefedValue = derefedValue.Elem()
 		}
 		if derefedValue.CanFloat() && derefedValue.OverflowFloat(fValue) {
-			return fmt.Errorf("parsing %q as float32: value out of range", v.String())
+			return newError("parsing %q as float32: value out of range", v.String())
 		}
 
 		target.SetFloat(fValue)
@@ -804,7 +807,7 @@ func (u *Unmarshaler) processNamedField(field reflect.StructField, value reflect
 	// When fillDefault is used, m is a null value, hasValue must be false, all priority judgments fillDefault.
 	if u.opts.fillDefault {
 		if !value.IsZero() {
-			return fmt.Errorf("set the default value, %q must be zero", fullName)
+			return newError("set the default value, %q must be zero", fullName)
 		}
 		return u.processNamedFieldWithoutValue(field.Type, value, opts, fullName)
 	} else if !hasValue {
@@ -825,11 +828,11 @@ func (u *Unmarshaler) processNamedFieldWithValue(fieldType reflect.Type, value r
 			return nil
 		}
 
-		return fmt.Errorf("field %q mustn't be nil", key)
+		return newError("field %q mustn't be nil", key)
 	}
 
 	if !value.CanSet() {
-		return fmt.Errorf("field %q is not settable", key)
+		return fmt.Errorf("field %q %w", key, ErrValueNotSettable)
 	}
 
 	maybeNewValue(fieldType, value)
@@ -856,7 +859,7 @@ func (u *Unmarshaler) processNamedFieldWithValueFromString(fieldType reflect.Typ
 	mapValue any, key string, opts *fieldOptionsWithContext, fullName string) error {
 	valueKind := reflect.TypeOf(mapValue).Kind()
 	if valueKind != reflect.String {
-		return fmt.Errorf("the value in map is not string, but %s", valueKind)
+		return newError("the value in map is not string, but %s", valueKind)
 	}
 
 	options := opts.options()
@@ -868,12 +871,12 @@ func (u *Unmarshaler) processNamedFieldWithValueFromString(fieldType reflect.Typ
 		case fmt.Stringer:
 			checkValue = mt.String()
 		default:
-			return fmt.Errorf("the value in map is not string or json.Number, but %s",
+			return newError("the value in map is not string or json.Number, but %s",
 				valueKind.String())
 		}
 
 		if !stringx.Contains(options, checkValue) {
-			return fmt.Errorf(`value "%s" for field %q is not defined in options "%v"`,
+			return newError(`value "%s" for field %q is not defined in options "%v"`,
 				mapValue, key, options)
 		}
 	}
@@ -922,7 +925,7 @@ func (u *Unmarshaler) processNamedFieldWithoutValue(fieldType reflect.Type, valu
 			}
 
 			if required {
-				return fmt.Errorf("%q is not set", fullName)
+				return fmt.Errorf("%q %w", fullName, ErrValueIsNotSet)
 			}
 
 			return u.processFieldNotFromString(fieldType, value, valueWithParent{
@@ -947,7 +950,7 @@ func (u *Unmarshaler) unmarshalWithFullName(m valuerWithParent, v any, fullName 
 	valueType := reflect.TypeOf(v)
 	baseType := Deref(valueType)
 	if baseType.Kind() != reflect.Struct {
-		return errValueNotStruct
+		return ErrValueNotStruct
 	}
 
 	valElem := rv.Elem()
@@ -1026,7 +1029,7 @@ func fillDurationValue(fieldType reflect.Type, value reflect.Value, dur string) 
 func fillPrimitive(fieldType reflect.Type, value reflect.Value, mapValue any,
 	opts *fieldOptionsWithContext, fullName string) error {
 	if !value.CanSet() {
-		return errValueNotSettable
+		return ErrValueNotSettable
 	}
 
 	baseType := Deref(fieldType)
@@ -1055,7 +1058,7 @@ func fillPrimitive(fieldType reflect.Type, value reflect.Value, mapValue any,
 func fillWithSameType(fieldType reflect.Type, value reflect.Value, mapValue any,
 	opts *fieldOptionsWithContext) error {
 	if !value.CanSet() {
-		return errValueNotSettable
+		return ErrValueNotSettable
 	}
 
 	if err := validateValueRange(mapValue, opts); err != nil {
@@ -1123,16 +1126,16 @@ func join(elem ...string) string {
 }
 
 func newInitError(name string) error {
-	return fmt.Errorf("field %q is not set", name)
+	return fmt.Errorf("field %q %w", name, ErrValueIsNotSet)
 }
 
 func newTypeMismatchError(name string) error {
-	return fmt.Errorf("type mismatch for field %q", name)
+	return fmt.Errorf("%w for field %q", ErrTypeMismatch, name)
 }
 
 func newTypeMismatchErrorWithHint(name, expectType, actualType string) error {
-	return fmt.Errorf("type mismatch for field %q, expect %q, actual %q",
-		name, expectType, actualType)
+	return fmt.Errorf("%w for field %q, expect %q, actual %q",
+		ErrTypeMismatch, name, expectType, actualType)
 }
 
 func readKeys(key string, opaque bool) []string {

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -24,14 +24,14 @@ func TestUnmarshalWithFullNameNotStruct(t *testing.T) {
 	var s map[string]any
 	content := []byte(`{"name":"xiaoming"}`)
 	err := UnmarshalJsonBytes(content, &s)
-	assert.Equal(t, errTypeMismatch, err)
+	assert.Equal(t, ErrTypeMismatch, err)
 }
 
 func TestUnmarshalValueNotSettable(t *testing.T) {
 	var s map[string]any
 	content := []byte(`{"name":"xiaoming"}`)
 	err := UnmarshalJsonBytes(content, s)
-	assert.Equal(t, errValueNotSettable, err)
+	assert.Equal(t, ErrValueNotSettable, err)
 }
 
 func TestUnmarshalWithoutTagName(t *testing.T) {
@@ -419,7 +419,7 @@ func TestUnmarshalIntWithString(t *testing.T) {
 		}
 
 		var in inner
-		assert.ErrorIs(t, UnmarshalKey(m, &in), errNumberRange)
+		assert.ErrorIs(t, UnmarshalKey(m, &in), ErrNumberRange)
 	})
 
 	t.Run("int with wrong type", func(t *testing.T) {
@@ -1340,7 +1340,7 @@ func TestUnmarshalNullableSlice(t *testing.T) {
 		"slice": `[null,2]`,
 	}
 
-	assert.New(t).Equal(UnmarshalKey(m, &v), errNilSliceElement)
+	assert.New(t).Equal(UnmarshalKey(m, &v), ErrNilSliceElement)
 }
 
 func TestUnmarshalWithFloatPtr(t *testing.T) {
@@ -3698,16 +3698,16 @@ func TestUnmarshalNumberRangeIntOutOfRange(t *testing.T) {
 	}
 
 	var in1 inner1
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": int64(1),
 	}, &in1))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": int64(0),
 	}, &in1))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": int64(5),
 	}, &in1))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": json.Number("6"),
 	}, &in1))
 
@@ -3716,10 +3716,10 @@ func TestUnmarshalNumberRangeIntOutOfRange(t *testing.T) {
 	}
 
 	var in2 inner2
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": int64(0),
 	}, &in2))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": int64(5),
 	}, &in2))
 
@@ -3728,10 +3728,10 @@ func TestUnmarshalNumberRangeIntOutOfRange(t *testing.T) {
 	}
 
 	var in3 inner3
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": int64(1),
 	}, &in3))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": int64(6),
 	}, &in3))
 
@@ -3740,10 +3740,10 @@ func TestUnmarshalNumberRangeIntOutOfRange(t *testing.T) {
 	}
 
 	var in4 inner4
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": int64(0),
 	}, &in4))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": int64(6),
 	}, &in4))
 }
@@ -3874,16 +3874,16 @@ func TestUnmarshalNumberRangeFloatOutOfRange(t *testing.T) {
 	}
 
 	var in1 inner1
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": float64(1),
 	}, &in1))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": float64(0),
 	}, &in1))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": float64(5),
 	}, &in1))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": json.Number("6"),
 	}, &in1))
 
@@ -3892,10 +3892,10 @@ func TestUnmarshalNumberRangeFloatOutOfRange(t *testing.T) {
 	}
 
 	var in2 inner2
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": float64(0),
 	}, &in2))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": float64(5),
 	}, &in2))
 
@@ -3904,10 +3904,10 @@ func TestUnmarshalNumberRangeFloatOutOfRange(t *testing.T) {
 	}
 
 	var in3 inner3
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": float64(1),
 	}, &in3))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": float64(6),
 	}, &in3))
 
@@ -3916,10 +3916,10 @@ func TestUnmarshalNumberRangeFloatOutOfRange(t *testing.T) {
 	}
 
 	var in4 inner4
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": float64(0),
 	}, &in4))
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"value": float64(6),
 	}, &in4))
 }
@@ -3929,7 +3929,7 @@ func TestUnmarshalRangeError(t *testing.T) {
 		Value int `key:",range="`
 	}
 	var in1 inner1
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"Value": 1,
 	}, &in1))
 
@@ -3937,7 +3937,7 @@ func TestUnmarshalRangeError(t *testing.T) {
 		Value int `key:",range=["`
 	}
 	var in2 inner2
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"Value": 1,
 	}, &in2))
 
@@ -3945,7 +3945,7 @@ func TestUnmarshalRangeError(t *testing.T) {
 		Value int `key:",range=[:"`
 	}
 	var in3 inner3
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"Value": 1,
 	}, &in3))
 
@@ -3953,7 +3953,7 @@ func TestUnmarshalRangeError(t *testing.T) {
 		Value int `key:",range=[:]"`
 	}
 	var in4 inner4
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"Value": 1,
 	}, &in4))
 
@@ -3961,7 +3961,7 @@ func TestUnmarshalRangeError(t *testing.T) {
 		Value int `key:",range={:]"`
 	}
 	var in5 inner5
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"Value": 1,
 	}, &in5))
 
@@ -3969,7 +3969,7 @@ func TestUnmarshalRangeError(t *testing.T) {
 		Value int `key:",range=[:}"`
 	}
 	var in6 inner6
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"Value": 1,
 	}, &in6))
 
@@ -3977,7 +3977,7 @@ func TestUnmarshalRangeError(t *testing.T) {
 		Value int `key:",range=[]"`
 	}
 	var in7 inner7
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"Value": 1,
 	}, &in7))
 
@@ -4009,7 +4009,7 @@ func TestUnmarshalRangeError(t *testing.T) {
 		Value int `key:",range=[1,2]"`
 	}
 	var in11 inner11
-	assert.Equal(t, errNumberRange, UnmarshalKey(map[string]any{
+	assert.Equal(t, ErrNumberRange, UnmarshalKey(map[string]any{
 		"Value": "a",
 	}, &in11))
 }
@@ -5016,7 +5016,7 @@ func TestUnmarshalJsonReaderWithTypeMismatchBool(t *testing.T) {
 		Params map[string]bool `json:"params"`
 	}
 	body := `{"params":{"a":"123"}}`
-	assert.Equal(t, errTypeMismatch, UnmarshalJsonReader(strings.NewReader(body), &req))
+	assert.Equal(t, ErrTypeMismatch, UnmarshalJsonReader(strings.NewReader(body), &req))
 }
 
 func TestUnmarshalJsonReaderWithTypeString(t *testing.T) {
@@ -5035,7 +5035,7 @@ func TestUnmarshalJsonReaderWithTypeString(t *testing.T) {
 			Params map[string]string `json:"params"`
 		}
 		body := `{"params":{"a":{"a":123}}}`
-		assert.Equal(t, errTypeMismatch, UnmarshalJsonReader(strings.NewReader(body), &req))
+		assert.Equal(t, ErrTypeMismatch, UnmarshalJsonReader(strings.NewReader(body), &req))
 	})
 
 	t.Run("customized string type", func(t *testing.T) {
@@ -5045,7 +5045,7 @@ func TestUnmarshalJsonReaderWithTypeString(t *testing.T) {
 			Params map[string]myString `json:"params"`
 		}
 		body := `{"params":{"a":"b"}}`
-		assert.Equal(t, errTypeMismatch, UnmarshalJsonReader(strings.NewReader(body), &req))
+		assert.Equal(t, ErrTypeMismatch, UnmarshalJsonReader(strings.NewReader(body), &req))
 	})
 }
 
@@ -5056,7 +5056,7 @@ func TestUnmarshalJsonReaderWithMismatchType(t *testing.T) {
 
 	var req Req
 	body := `{"params":{"a":{"a":123}}}`
-	assert.Equal(t, errTypeMismatch, UnmarshalJsonReader(strings.NewReader(body), &req))
+	assert.Equal(t, ErrTypeMismatch, UnmarshalJsonReader(strings.NewReader(body), &req))
 }
 
 func TestUnmarshalJsonReaderWithTypeBool(t *testing.T) {
@@ -5116,7 +5116,7 @@ func TestUnmarshalJsonReaderWithTypeBool(t *testing.T) {
 			test := test
 			t.Run(test.name, func(t *testing.T) {
 				var req Req
-				assert.Equal(t, errTypeMismatch, UnmarshalJsonReader(strings.NewReader(test.input), &req))
+				assert.Equal(t, ErrTypeMismatch, UnmarshalJsonReader(strings.NewReader(test.input), &req))
 			})
 		}
 	})
@@ -5142,7 +5142,7 @@ func TestUnmarshalJsonReaderWithTypeBoolMap(t *testing.T) {
 		var req struct {
 			Params map[string]string `json:"params"`
 		}
-		assert.Equal(t, errTypeMismatch, UnmarshalJsonMap(map[string]any{
+		assert.Equal(t, ErrTypeMismatch, UnmarshalJsonMap(map[string]any{
 			"params": map[string]any{
 				"a": true,
 			},
@@ -5470,7 +5470,7 @@ func Test_UnmarshalMap(t *testing.T) {
 		}
 
 		var customer Customer
-		assert.ErrorIs(t, UnmarshalKey(input, &customer), errTypeMismatch)
+		assert.ErrorIs(t, UnmarshalKey(input, &customer), ErrTypeMismatch)
 	})
 
 	t.Run("map type mismatch", func(t *testing.T) {
@@ -5487,7 +5487,7 @@ func Test_UnmarshalMap(t *testing.T) {
 		}
 
 		var customer Customer
-		assert.ErrorIs(t, UnmarshalKey(input, &customer), errTypeMismatch)
+		assert.ErrorIs(t, UnmarshalKey(input, &customer), ErrTypeMismatch)
 	})
 
 	t.Run("map from string", func(t *testing.T) {

--- a/core/mapping/utils_test.go
+++ b/core/mapping/utils_test.go
@@ -296,7 +296,7 @@ func TestSetValueFormatErrors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.kind.String(), func(t *testing.T) {
 			err := setValueFromString(test.kind, test.target, test.value)
-			assert.NotEqual(t, errValueNotSettable, err)
+			assert.NotEqual(t, ErrValueNotSettable, err)
 			assert.NotNil(t, err)
 		})
 	}


### PR DESCRIPTION
Optimize error returns to allow external parties to better judge errors

I can set an error handler to accurately handle error parameters with a single judgment.
```golang
httpx.SetErrorHandler(func(err error) (int, any) {
      if errors.Is(err, mapping.ErrMappingErrors) {
	      return http.StatusBadRequest, nil
      }
      
      return http.StatusInternalServerError, nil
})


```