### PR TITLE
disable nested struct for array and map type

### DIFF
--- a/tools/goctl/pkg/parser/api/parser/testdata/invalid.api
+++ b/tools/goctl/pkg/parser/api/parser/testdata/invalid.api
@@ -124,6 +124,70 @@ type Foo {
 }
 
 -----
+// test case:  invalid map key
+syntax = "v1"
+type Foo {
+  M map[{}]string `json:"m"`
+}
+
+-----
+// test case:  invalid map key
+syntax = "v1"
+type Foo {
+M map[{
+  Foo string `json:"foo"`
+}]string `json:"m"`
+}
+
+-----
+// test case:  invalid map value
+syntax = "v1"
+type Foo {
+M map[int]{} `json:"m"`
+}
+
+-----
+// test case:  invalid map value
+syntax = "v1"
+type Foo {
+M map[int]{
+  Foo int `json:"foo"`
+} `json:"m"`
+}
+
+-----
+// test case:  invalid array element
+syntax = "v1"
+type Foo {
+  Array [3]{} `json:"array"`
+}
+
+-----
+// test case:  invalid array element
+syntax = "v1"
+type Foo {
+Array [3]{
+Foo int `json:"foo"`
+} `json:"array"`
+}
+
+-----
+// test case:  invalid array element
+syntax = "v1"
+type Foo {
+Array []{} `json:"array"`
+}
+
+-----
+// test case:  invalid slice element
+syntax = "v1"
+type Foo {
+Array []{
+Foo int `json:"foo"`
+} `json:"array"`
+}
+
+-----
 // test case:  unresolved type
 syntax = "v1"
 service example {


### PR DESCRIPTION
1. disable nested struct for array and map type, the follow types all are invalid:

```go
type Demo {
  Foo {} `json:"foo"` // invalid types: unsupported empty nestedt struct
  Bar []{} `json:"foo"` // invalid types: slice elements unsupported nested struct
  Bar [2]{} `json:"foo"` // invalid types: array elements unsupported nested struct
  Bar map[{}]string `json:"foo"` // invalid types: map key elements unsupported nested struct
  Bar map[int]{} `json:"foo"` // invalid types: map value elements unsupported nested struct
}
```