### PR TITLE
ci: update workflows to use go.mod instead of specifying go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version-file: go.mod
           check-latest: true
           cache: true
         id: go
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # use 1.20 to guarantee Go 1.20 compatibility
-          go-version: '1.20'
+          go-version-file: go.mod
           check-latest: true
           cache: true
 


### PR DESCRIPTION
use newer syntax to specify go version.