### PR TITLE
fix: field head rune

### DIFF
--- a/tools/goctl/util/string.go
+++ b/tools/goctl/util/string.go
@@ -79,7 +79,7 @@ func SafeString(in string) string {
 
 	headRune := rune(data[0])
 	if isNumber(headRune) {
-		return "_" + data
+		return "Z_" + data
 	}
 	return data
 }


### PR DESCRIPTION
CREATE TABLE `user` (
  `id` bigint(10) NOT NULL AUTO_INCREMENT,
  `123user` varchar(50) NOT NULL DEFAULT '' COMMENT '用户',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

当字段以数字开头时，生成的model以下划线开头，会被认为私有，直接执行生成的findOne查询会报错 value not addressable or interfaceable