### PR TITLE
fix new writer in logx

### DIFF
--- a/core/logx/writer.go
+++ b/core/logx/writer.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 
 	fatihcolor "github.com/fatih/color"
+
 	"github.com/zeromicro/go-zero/core/color"
 	"github.com/zeromicro/go-zero/core/errorx"
 )
@@ -48,17 +49,15 @@ type (
 	}
 )
 
-// NewWriter creates a new Writer with the given io.Writer.
-func NewWriter(w io.Writer) Writer {
-	lw := newLogWriter(log.New(w, "", flags))
-
+// NewWriter creates a new Writer with the given io.WriteCloser.
+func NewWriter(w io.WriteCloser) Writer {
 	return &concreteWriter{
-		infoLog:   lw,
-		errorLog:  lw,
-		severeLog: lw,
-		slowLog:   lw,
-		statLog:   lw,
-		stackLog:  lw,
+		infoLog:   w,
+		errorLog:  w,
+		severeLog: w,
+		slowLog:   w,
+		statLog:   w,
+		stackLog:  w,
 	}
 }
 


### PR DESCRIPTION
NewWriter 方法用于自定义 logx 的 Writer，例如：
NewWriter method is used to customize logx's Writer, e.g.: 

```go
logx.SetWriter(logx.NewWriter(w))
```

但当前的 logx.NewWriter 使用 log.New 和 logx.newLogWriter 对传入的自定义 writer 进行了包装；
实际调用时，调用路径为，log.Print -> log.output -> writer.Write；
这会导致一系列问题，因为 log 库中是用了 sync.Pool 产生 *[]byte 用于拼接字符串；
如果自定义 writer 是同步写入，则可能不会出现问题；
如果自定义 writer 是异步写入，如使用 chan 来实现并发安全，这时实际传入 writer.Write 的 []byte 可能具有同一地址，造成写入重复内容；
并且 logx.newLogWriter 函数还忽略了自定义 writer 的 Close 方法；
通过修改 logx.NewWriter 方法，直接传入 io.WriteCloser，可以避免这些问题；
在实际测试中也是符合预期的；

When it is actually called, the path is log.Print -> log.output -> writer.Write; 
This will lead to some problems, the std log library uses sync.Pool to generate *[]byte for string splicing; 
If the custom writer writes synchronously, there may not be a problem; 
But if the custom writer writes asynchronously, e.g., using chan for concurrency safety, the []byte that is actually passed to writer.Write may have the same address, resulting in duplicate content being written; 
And logx.newLogWriter function also ignores the Close method of the custom writer; 
These problems can be avoided by modifying the logx.NewWriter method and passing in io.WriteCloser directly; 
It also meets the expectation in the actual test;