### PR TITLE
 Add custom log file name date format

### DIFF
--- a/core/logx/config.go
+++ b/core/logx/config.go
@@ -42,4 +42,6 @@ type LogConf struct {
 	// daily: daily rotation.
 	// size: size limited rotation.
 	Rotation string `json:",default=daily,options=[daily,size]"`
+	// FileTimeFormat represents the time format for file name, default is `2006-01-02T15:04:05.000Z07:00`.
+	FileTimeFormat string `json:",optional"`
 }

--- a/core/logx/logs.go
+++ b/core/logx/logs.go
@@ -294,6 +294,10 @@ func SetUp(c LogConf) (err error) {
 			timeFormat = c.TimeFormat
 		}
 
+		if len(c.FileTimeFormat) > 0 {
+			fileTimeFormat = c.FileTimeFormat
+		}
+
 		atomic.StoreUint32(&maxContentLength, c.MaxContentLength)
 
 		switch c.Encoding {

--- a/core/logx/rotatelogger.go
+++ b/core/logx/rotatelogger.go
@@ -19,7 +19,6 @@ import (
 
 const (
 	dateFormat      = "2006-01-02"
-	fileTimeFormat  = time.RFC3339
 	hoursPerDay     = 24
 	bufferSize      = 100
 	defaultDirMode  = 0o755
@@ -28,8 +27,11 @@ const (
 	megaBytes       = 1 << 20
 )
 
-// ErrLogFileClosed is an error that indicates the log file is already closed.
-var ErrLogFileClosed = errors.New("error: log file closed")
+var (
+	// ErrLogFileClosed is an error that indicates the log file is already closed.
+	ErrLogFileClosed = errors.New("error: log file closed")
+	fileTimeFormat   = time.RFC3339
+)
 
 type (
 	// A RotateRule interface is used to define the log rotating rules.


### PR DESCRIPTION
Added a custom log file name date format; when creating a file using the system's default file name date format, the file creation failed on the Windows platform because the file name contained the restriction character ":".