### PR TITLE
feat(goctl): support go work (#4332)

### DIFF
--- a/tools/goctl/util/ctx/gomod.go
+++ b/tools/goctl/util/ctx/gomod.go
@@ -51,6 +51,10 @@ func projectFromGoMod(workDir string) (*ProjectContext, error) {
 		return nil, err
 	}
 
+	if err := UpdateGoWorkIfExist(workDir); err != nil {
+		return nil, err
+	}
+
 	m, err := getRealModule(workDir, execx.Run)
 	if err != nil {
 		return nil, err

--- a/tools/goctl/util/ctx/gowork.go
+++ b/tools/goctl/util/ctx/gowork.go
@@ -1,0 +1,33 @@
+package ctx
+
+import (
+	"errors"
+	"os"
+
+	"github.com/zeromicro/go-zero/tools/goctl/rpc/execx"
+)
+
+// UpdateGoWorkIfExist updates go work if workDir is in a go workspace
+func UpdateGoWorkIfExist(workDir string) error {
+	if isGoWork, err := isGoWork(workDir); !isGoWork || err != nil {
+		return err
+	}
+
+	_, err := execx.Run("go work use .", workDir)
+	return err
+}
+
+// isGoWork detect if the workDir is in a go workspace
+func isGoWork(workDir string) (bool, error) {
+	if len(workDir) == 0 {
+		return false, errors.New("the work directory is not found")
+	}
+	if _, err := os.Stat(workDir); err != nil {
+		return false, err
+	}
+	goWorkPath, err := execx.Run("go env GOWORK", workDir)
+	if err != nil {
+		return false, err
+	}
+	return len(goWorkPath) > 0, nil
+}

--- a/tools/goctl/util/ctx/gowork_test.go
+++ b/tools/goctl/util/ctx/gowork_test.go
@@ -1,0 +1,40 @@
+package ctx
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/stringx"
+	"github.com/zeromicro/go-zero/tools/goctl/rpc/execx"
+	"github.com/zeromicro/go-zero/tools/goctl/util/pathx"
+)
+
+func Test_isGoWork(t *testing.T) {
+	dir := filepath.Join("/tmp", stringx.Rand())
+
+	err := pathx.MkdirIfNotExist(dir)
+	assert.Nil(t, err)
+
+	defer os.RemoveAll(dir)
+
+	gowork, err := isGoWork(dir)
+	assert.False(t, gowork)
+	assert.Nil(t, err)
+
+	_, err = execx.Run("go work init", dir)
+	assert.Nil(t, err)
+
+	gowork, err = isGoWork(dir)
+	assert.True(t, gowork)
+	assert.Nil(t, err)
+
+	subDir := filepath.Join(dir, stringx.Rand())
+	err = pathx.MkdirIfNotExist(subDir)
+	assert.Nil(t, err)
+
+	gowork, err = isGoWork(subDir)
+	assert.True(t, gowork)
+	assert.Nil(t, err)
+}

--- a/tools/goctl/util/ctx/modcheck.go
+++ b/tools/goctl/util/ctx/modcheck.go
@@ -7,7 +7,7 @@ import (
 	"github.com/zeromicro/go-zero/tools/goctl/rpc/execx"
 )
 
-// IsGoMod is used to determine whether workDir is a go module project through command `go list -json -m`
+// IsGoMod is used to determine whether workDir is a go module project through command `go env GOMOD`
 func IsGoMod(workDir string) (bool, error) {
 	if len(workDir) == 0 {
 		return false, errors.New("the work directory is not found")
@@ -16,8 +16,8 @@ func IsGoMod(workDir string) (bool, error) {
 		return false, err
 	}
 
-	data, err := execx.Run("go list -m -f '{{.GoMod}}'", workDir)
-	if err != nil || len(data) == 0 {
+	data, err := execx.Run("go env GOMOD", workDir)
+	if err != nil || data == "/dev/null" {
 		return false, nil
 	}
 


### PR DESCRIPTION
this PR fixed the error `no matched module` when using `goctl api` inside of a go workspace.

in go workspace, command `go list -m -f '{{.GoMod}}'` only lists modules declared in go.work, so goctl can't can the go.mod path even it's already initilized if the project is not in go.work.

to fix this, goctl should 

- use `go env GOMOD` to determine whether the project is a go module.
- check if the project is inside of a go workspace, if it does, it will use `go work use .` to add the project to go.work.