### PR TITLE
feat(api): export GenRoutesString function

### DIFF
--- a/tools/goctl/api/gogen/genroutes_test.go
+++ b/tools/goctl/api/gogen/genroutes_test.go
@@ -1,0 +1,22 @@
+package gogen
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/tools/goctl/config"
+	"github.com/zeromicro/go-zero/tools/goctl/pkg/parser/api/parser"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenRoutesString(t *testing.T) {
+	parse, err := parser.Parse(filepath.Join("testdata", "example.api"), nil)
+	assert.Nil(t, err)
+
+	routesString, err := GenRoutesString("example", &config.Config{
+		NamingFormat: "gozero",
+	}, parse)
+	assert.NotNil(t, routesString)
+	assert.Nil(t, err)
+	fmt.Println(routesString)
+}

--- a/tools/goctl/api/gogen/util.go
+++ b/tools/goctl/api/gogen/util.go
@@ -57,6 +57,31 @@ func genFile(c fileGenConfig) error {
 	return err
 }
 
+func genFileString(c fileGenConfig) (string, error) {
+	var (
+		text string
+		err  error
+	)
+	if len(c.category) == 0 || len(c.templateFile) == 0 {
+		text = c.builtinTemplate
+	} else {
+		text, err = pathx.LoadTemplate(c.category, c.templateFile, c.builtinTemplate)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	t := template.Must(template.New(c.templateName).Parse(text))
+	buffer := new(bytes.Buffer)
+	err = t.Execute(buffer, c.data)
+	if err != nil {
+		return "", err
+	}
+
+	code := golang.FormatCode(buffer.String())
+	return code, nil
+}
+
 func writeProperty(writer io.Writer, name, tag, comment string, tp spec.Type, indent int) error {
 	util.WriteIndent(writer, indent)
 	var (


### PR DESCRIPTION
I generate an api file in my scaffolding, but it will cause the routes.go file to be constantly overwritten. There is already a method to generate types.go files, but there is no routes.go file, so I want to add a method to generate based on api.Spec