### PR TITLE
fix:  wrong way of Unmarshal

### DIFF
--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/zeromicro/go-zero/core/jsonx"
 	"reflect"
 	"strconv"
 	"strings"
@@ -4868,14 +4869,27 @@ func TestUnmarshal_EnvWithOptionsWrongValueString(t *testing.T) {
 
 func TestUnmarshalJsonReaderMultiArray(t *testing.T) {
 	t.Run("reader multi array", func(t *testing.T) {
-		var res struct {
+		type testRes struct {
 			A string     `json:"a"`
 			B [][]string `json:"b"`
+			C []byte     `json:"c"`
 		}
-		payload := `{"a": "133", "b": [["add", "cccd"], ["eeee"]]}`
+		var res testRes
+		marshal := testRes{
+			A: "133",
+			B: [][]string{
+				{"add", "cccd"},
+				{"eeee"},
+			},
+			C: []byte("11122344wsss"),
+		}
+		bytes, err := jsonx.Marshal(marshal)
+		assert.NoError(t, err)
+		payload := string(bytes)
 		reader := strings.NewReader(payload)
 		if assert.NoError(t, UnmarshalJsonReader(reader, &res)) {
 			assert.Equal(t, 2, len(res.B))
+			assert.Equal(t, string(marshal.C), string(res.C))
 		}
 	})
 


### PR DESCRIPTION
I faced a minor problem when I used it.
for examlpe:
```api
type request {
	Bytes []byte `json:"bytes"`
	Name  string `json:"name"`
}

type response {}

service template {
	@handler postDataTest
	post /test (request) returns (response)

	@handler getJsonData
	get /get returns (request)
}
```
and `get` returns

```go
&types.Request{
		Bytes: []byte("11122344wsss"),
		Name:  "test",
	}
```
It's ok when I visit `/get` api ,but when I put `/get` response (the json data of `request`) into `/test` error happend:

```log
fullName: `bytes`, error: `string: `MTExMjIzNDR3c3Nz`, error: `invalid character 'M' looking for beginning of value``
```
and I notice that ,there use json.Marshal() to make the response but use slef custom mapping.UnmarshalJsonReader to Unmarshal json data

so I just fix it (core in mapping.processFieldNotFromString).

You can see test in TestUnmarshalJsonReaderMultiArray
