### PR TITLE
fix: global fields apply to Third-party log module

### DIFF
--- a/core/logx/logs.go
+++ b/core/logx/logs.go
@@ -560,7 +560,7 @@ func shallLogStat() bool {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeDebug(val any, fields ...LogField) {
-	getWriter().Debug(val, addCaller(fields...)...)
+	getWriter().Debug(val, combineGlobalFields(addCaller(fields...))...)
 }
 
 // writeError writes v into the error log.
@@ -568,7 +568,7 @@ func writeDebug(val any, fields ...LogField) {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeError(val any, fields ...LogField) {
-	getWriter().Error(val, addCaller(fields...)...)
+	getWriter().Error(val, combineGlobalFields(addCaller(fields...))...)
 }
 
 // writeInfo writes v into info log.
@@ -576,7 +576,7 @@ func writeError(val any, fields ...LogField) {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeInfo(val any, fields ...LogField) {
-	getWriter().Info(val, addCaller(fields...)...)
+	getWriter().Info(val, combineGlobalFields(addCaller(fields...))...)
 }
 
 // writeSevere writes v into severe log.
@@ -592,7 +592,7 @@ func writeSevere(msg string) {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeSlow(val any, fields ...LogField) {
-	getWriter().Slow(val, addCaller(fields...)...)
+	getWriter().Slow(val, combineGlobalFields(addCaller(fields...))...)
 }
 
 // writeStack writes v into stack log.
@@ -608,5 +608,5 @@ func writeStack(msg string) {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeStat(msg string) {
-	getWriter().Stat(msg, addCaller()...)
+	getWriter().Stat(msg, combineGlobalFields(addCaller())...)
 }

--- a/core/logx/richlogger.go
+++ b/core/logx/richlogger.go
@@ -207,6 +207,7 @@ func (l *richLogger) WithFields(fields ...LogField) Logger {
 func (l *richLogger) buildFields(fields ...LogField) []LogField {
 	fields = append(l.fields, fields...)
 	fields = append(fields, Field(callerKey, getCaller(callerDepth+l.callerSkip)))
+	fields = combineGlobalFields(fields)
 
 	if l.ctx == nil {
 		return fields
@@ -234,7 +235,7 @@ func (l *richLogger) buildFields(fields ...LogField) []LogField {
 
 func (l *richLogger) debug(v any, fields ...LogField) {
 	if shallLog(DebugLevel) {
-		getWriter().Debug(v, l.buildFields(fields...)...)
+		getWriter().Debug(v, (l.buildFields(fields...))...)
 	}
 }
 

--- a/core/logx/writer.go
+++ b/core/logx/writer.go
@@ -362,7 +362,6 @@ func output(writer io.Writer, level string, val any, fields ...LogField) {
 		}
 	}
 
-	fields = combineGlobalFields(fields)
 	// +3 for timestamp, level and content
 	entry := make(logEntry, len(fields)+3)
 	for _, field := range fields {


### PR DESCRIPTION
fix #4398 