### PR TITLE
[dartgen] Add ability to customize format options for dartgen command

### DIFF
--- a/tools/goctl/api/cmd.go
+++ b/tools/goctl/api/cmd.go
@@ -58,6 +58,7 @@ func init() {
 	dartCmdFlags.BoolVar(&dartgen.VarStringLegacy, "legacy")
 	dartCmdFlags.StringVar(&dartgen.VarStringHostname, "hostname")
 	dartCmdFlags.StringVar(&dartgen.VarStringScheme, "scheme")
+	dartCmdFlags.StringVar(&dartgen.VarStringFormatArgs, "format-args")
 
 	docCmdFlags.StringVar(&docgen.VarStringDir, "dir")
 	docCmdFlags.StringVar(&docgen.VarStringOutput, "o")

--- a/tools/goctl/api/dartgen/format.go
+++ b/tools/goctl/api/dartgen/format.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 const dartExec = "dart"
 
-func formatDir(dir string) error {
+func formatDir(dir string, formatArgs string) error {
 	ok, err := dirctoryExists(dir)
 	if err != nil {
 		return err
@@ -24,6 +25,12 @@ func formatDir(dir string) error {
 	cmd := exec.Command(dartExec, "format", dir)
 	cmd.Env = os.Environ()
 	cmd.Stderr = os.Stderr
+
+	// Add additional format arguments to `dart format` command.
+	// Eg: `dart format --line-length=120`
+	if len(formatArgs) > 0 {
+		cmd.Args = append(cmd.Args, strings.Split(formatArgs, " ")...)
+	}
 
 	return cmd.Run()
 }

--- a/tools/goctl/api/dartgen/gen.go
+++ b/tools/goctl/api/dartgen/gen.go
@@ -21,6 +21,8 @@ var (
 	VarStringHostname string
 	// VarStringSchema defines the scheme.
 	VarStringScheme string
+	// VarFormatArgs defines the format arguments, eg: "--line-length=120"
+	VarStringFormatArgs string
 )
 
 // DartCommand create dart network request code
@@ -30,6 +32,7 @@ func DartCommand(_ *cobra.Command, _ []string) error {
 	isLegacy := VarStringLegacy
 	hostname := VarStringHostname
 	scheme := VarStringScheme
+	formatArgs := VarStringFormatArgs
 	if len(apiFile) == 0 {
 		return errors.New("missing -api")
 	}
@@ -43,6 +46,9 @@ func DartCommand(_ *cobra.Command, _ []string) error {
 	if len(scheme) == 0 {
 		fmt.Println("you could use '-scheme' flag to specify your server scheme")
 		scheme = "http"
+	}
+	if len(formatArgs) == 0 {
+		fmt.Println(`you could use '-format-args "--line-length=120"' flag to specify the dart format arguments`)
 	}
 
 	api, err := parser.Parse(apiFile)
@@ -62,7 +68,7 @@ func DartCommand(_ *cobra.Command, _ []string) error {
 	logx.Must(genData(dir+"data/", api, isLegacy))
 	logx.Must(genApi(dir+"api/", api, isLegacy))
 	logx.Must(genVars(dir+"vars/", isLegacy, scheme, hostname))
-	if err := formatDir(dir); err != nil {
+	if err := formatDir(dir, formatArgs); err != nil {
 		logx.Errorf("failed to format, %v", err)
 	}
 	return nil


### PR DESCRIPTION
Currently, when running `goctl api dart ...` to generate dart API files, the **dart formatter** will be triggered automatically. But it always uses the default configurations when formatting the dart files. 

This PR adds a feature to allow users to override the default dart format parameters.

Before:
```Makefile
goctl api dart -api server.api -dir ../app/api

=> `dart format <dir>`
```

After:
```Makefile
goctl api dart -api server.api -dir ../app/api -format-args "--line-length=150"

=> `dart format <dir> --line-length=150`
```