### PR TITLE
fix the source code directory after the soft link

### DIFF
--- a/tools/goctl/rpc/generator/genpb.go
+++ b/tools/goctl/rpc/generator/genpb.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/zeromicro/go-zero/tools/goctl/rpc/execx"
+	"github.com/zeromicro/go-zero/tools/goctl/util/pathx"
 )
 
 // GenPb generates the pb.go file, which is a layer of packaging for protoc to generate gprc,

--- a/tools/goctl/rpc/generator/genpb.go
+++ b/tools/goctl/rpc/generator/genpb.go
@@ -88,7 +88,7 @@ func findPbFile(current string, src string, grpc bool) (string, error) {
 		return nil
 	})
 	if errors.Is(err, os.ErrExist) {
-		return filepath.Dir(filepath.Join(current, ret)), nil
+		return pathx.ReadLink(filepath.Dir(filepath.Join(current, ret)))
 	}
 	return "", err
 }


### PR DESCRIPTION
To solve the problem of the disk full of code, I used soft links to move the directory where the code is saved, but the import path of the code generated by goctl is wrong

The problem occurs in tools/goctl/rpc/generator/mkdir.go SetPbDir()

d.ctx.Dir calculates the absolute path
pbDir does not calculate the absolute path
strings.TrimPrefix tries to remove d.ctx.Dir from pbDir but does not get a match