### PR TITLE
feat:  add StartWithListener method  to api and rpc server

### DIFF
--- a/rest/internal/starter.go
+++ b/rest/internal/starter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/zeromicro/go-zero/core/logx"
@@ -23,12 +24,28 @@ func StartHttp(host string, port int, handler http.Handler, opts ...StartOption)
 	}, opts...)
 }
 
+// StartHttpWithListener starts a http server with listener.
+func StartHttpWithListener(listener net.Listener, handler http.Handler, opts ...StartOption) error {
+	return startWithListener(listener, handler, func(svr *http.Server) error {
+		return svr.Serve(listener)
+	}, opts...)
+}
+
 // StartHttps starts a https server.
 func StartHttps(host string, port int, certFile, keyFile string, handler http.Handler,
 	opts ...StartOption) error {
 	return start(host, port, handler, func(svr *http.Server) error {
 		// certFile and keyFile are set in buildHttpsServer
 		return svr.ListenAndServeTLS(certFile, keyFile)
+	}, opts...)
+}
+
+// StartHttpsWithListener starts a https server with listener.
+func StartHttpsWithListener(listener net.Listener, certFile, keyFile string, handler http.Handler,
+	opts ...StartOption) error {
+	return startWithListener(listener, handler, func(svr *http.Server) error {
+		// certFile and keyFile are set in buildHttpsServer
+		return svr.ServeTLS(listener, certFile, keyFile)
 	}, opts...)
 }
 
@@ -43,6 +60,35 @@ func start(host string, port int, handler http.Handler, run func(svr *http.Serve
 	}
 	healthManager := health.NewHealthManager(fmt.Sprintf("%s-%s:%d", probeNamePrefix, host, port))
 
+	waitForCalled := proc.AddShutdownListener(func() {
+		healthManager.MarkNotReady()
+		if e := server.Shutdown(context.Background()); e != nil {
+			logx.Error(e)
+		}
+	})
+	defer func() {
+		if errors.Is(err, http.ErrServerClosed) {
+			waitForCalled()
+		}
+	}()
+
+	healthManager.MarkReady()
+	health.AddProbe(healthManager)
+	return run(server)
+}
+
+func startWithListener(listener net.Listener, handler http.Handler, run func(svr *http.Server) error,
+	opts ...StartOption) (err error) {
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf("%s", listener.Addr().String()),
+		Handler: handler,
+	}
+	for _, opt := range opts {
+		opt(server)
+	}
+
+	healthManager := health.NewHealthManager(fmt.Sprintf("%s-%s", probeNamePrefix, listener.Addr().String()))
 	waitForCalled := proc.AddShutdownListener(func() {
 		healthManager.MarkNotReady()
 		if e := server.Shutdown(context.Background()); e != nil {

--- a/rest/internal/starter_test.go
+++ b/rest/internal/starter_test.go
@@ -34,3 +34,12 @@ func TestStartHttps(t *testing.T) {
 	assert.NotNil(t, err)
 	proc.WrapUp()
 }
+
+func TestStartHttpsWithListener(t *testing.T) {
+	svr := httptest.NewUnstartedServer(http.NotFoundHandler())
+	err := StartHttpsWithListener(svr.Listener, "", "", http.NotFoundHandler(), func(svr *http.Server) {
+		svr.IdleTimeout = 0
+	})
+	assert.NotNil(t, err)
+	proc.WrapUp()
+}

--- a/rest/server.go
+++ b/rest/server.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"crypto/tls"
 	"errors"
+	"net"
 	"net/http"
 	"path"
 	"time"
@@ -119,6 +120,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Use proc.SetTimeToForceQuit to customize the graceful shutdown period.
 func (s *Server) Start() {
 	handleError(s.ngin.start(s.router))
+}
+
+// StartWithListener starts the Server with listener
+// Graceful shutdown is enabled by default.
+// Use proc.SetTimeToForceQuit to customize the graceful shutdown period.
+func (s *Server) StartWithListener(listener net.Listener) {
+	handleError(s.ngin.startWithListener(listener, s.router))
 }
 
 // StartWithOpts starts the Server.

--- a/rest/server_test.go
+++ b/rest/server_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -122,6 +123,24 @@ Port: 0
 			svr.StartWithOpts(func(svr *http.Server) {
 				svr.RegisterOnShutdown(func() {})
 			})
+			svr.Stop()
+		}()
+
+		func() {
+			defer func() {
+				p := recover()
+				switch v := p.(type) {
+				case error:
+					assert.Equal(t, "foo", v.Error())
+				default:
+					t.Fail()
+				}
+			}()
+
+			address := fmt.Sprintf("%s:%d", cnf.Host, cnf.Port)
+			listener, err := net.Listen("tcp", address)
+			assert.Nil(t, err)
+			svr.StartWithListener(listener)
 			svr.Stop()
 		}()
 	}

--- a/zrpc/internal/server.go
+++ b/zrpc/internal/server.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"net"
 	"time"
 
 	"google.golang.org/grpc"
@@ -21,6 +22,7 @@ type (
 		AddUnaryInterceptors(interceptors ...grpc.UnaryServerInterceptor)
 		SetName(string)
 		Start(register RegisterFn) error
+		StartWithListener(listener net.Listener, register RegisterFn) error
 	}
 
 	baseRpcServer struct {

--- a/zrpc/server.go
+++ b/zrpc/server.go
@@ -1,6 +1,7 @@
 package zrpc
 
 import (
+	"net"
 	"time"
 
 	"github.com/zeromicro/go-zero/core/load"
@@ -87,6 +88,16 @@ func (rs *RpcServer) AddUnaryInterceptors(interceptors ...grpc.UnaryServerInterc
 // Use proc.SetTimeToForceQuit to customize the graceful shutdown period.
 func (rs *RpcServer) Start() {
 	if err := rs.server.Start(rs.register); err != nil {
+		logx.Error(err)
+		panic(err)
+	}
+}
+
+// StartWithListener starts the RpcServer with listener.
+// Graceful shutdown is enabled by default.
+// Use proc.SetTimeToForceQuit to customize the graceful shutdown period.
+func (rs *RpcServer) StartWithListener(listener net.Listener) {
+	if err := rs.server.StartWithListener(listener, rs.register); err != nil {
 		logx.Error(err)
 		panic(err)
 	}


### PR DESCRIPTION
add StartWithListener method  to api and rpc server
more friendly support for third-party packages such as
https://github.com/fvbock/endless
https://github.com/jpillora/overseer
https://github.com/cloudflare/tableflip


