### PR TITLE
fix: go work duplicate prefix get err

### DIFF
--- a/tools/goctl/util/ctx/gomod.go
+++ b/tools/goctl/util/ctx/gomod.go
@@ -82,7 +82,9 @@ func getRealModule(workDir string, execRun execx.RunFunc) (*Module, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	if workDir[len(workDir)-1] != os.PathSeparator {
+		workDir = workDir + string(os.PathSeparator)
+	}
 	for _, m := range modules {
 		realDir, err := pathx.ReadLink(m.Dir)
 		if err != nil {

--- a/tools/goctl/util/ctx/gomod.go
+++ b/tools/goctl/util/ctx/gomod.go
@@ -88,7 +88,7 @@ func getRealModule(workDir string, execRun execx.RunFunc) (*Module, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read go.mod, dir: %s, error: %w", m.Dir, err)
 		}
-
+		realDir += string(os.PathSeparator)
 		if strings.HasPrefix(workDir, realDir) {
 			return &m, nil
 		}

--- a/tools/goctl/util/ctx/gomod_test.go
+++ b/tools/goctl/util/ctx/gomod_test.go
@@ -98,6 +98,35 @@ func Test_getRealModule(t *testing.T) {
 				GoVersion: "go1.20",
 			},
 		},
+		{
+			name: "go work duplicate prefix",
+			args: args{
+				workDir: "D:\\code\\company\\core-ee\\service",
+				execRun: func(arg, dir string, in ...*bytes.Buffer) (string, error) {
+					return `
+					{
+						"Path": "gitee.com/unitedrhino/core",
+						"Main": true,
+						"Dir": "D:\\code\\company\\core",
+						"GoMod": "D:\\code\\company\\core\\go.mod",
+						"GoVersion": "1.21.4"
+					}
+					{
+						"Path": "gitee.com/unitedrhino/core-ee",
+						"Main": true,
+						"Dir": "D:\\code\\company\\core-ee",
+						"GoMod": "D:\\code\\company\\core-ee\\go.mod",
+						"GoVersion": "1.21.4"
+					}`, nil
+				},
+			},
+			want: &Module{
+				Path:      "gitee.com/unitedrhino/core-ee",
+				Dir:       "D:\\code\\company\\core-ee",
+				GoMod:     "D:\\code\\company\\core-ee\\go.mod",
+				GoVersion: "go1.19",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/goctl/util/ctx/gomod_test.go
+++ b/tools/goctl/util/ctx/gomod_test.go
@@ -106,14 +106,12 @@ func Test_getRealModule(t *testing.T) {
 					return `
 					{
 						"Path": "gitee.com/unitedrhino/core",
-						"Main": true,
 						"Dir": "D:\\code\\company\\core",
 						"GoMod": "D:\\code\\company\\core\\go.mod",
 						"GoVersion": "1.21.4"
 					}
 					{
 						"Path": "gitee.com/unitedrhino/core-ee",
-						"Main": true,
 						"Dir": "D:\\code\\company\\core-ee",
 						"GoMod": "D:\\code\\company\\core-ee\\go.mod",
 						"GoVersion": "1.21.4"
@@ -124,7 +122,34 @@ func Test_getRealModule(t *testing.T) {
 				Path:      "gitee.com/unitedrhino/core-ee",
 				Dir:       "D:\\code\\company\\core-ee",
 				GoMod:     "D:\\code\\company\\core-ee\\go.mod",
-				GoVersion: "go1.19",
+				GoVersion: "1.21.4",
+			},
+		},
+		{
+			name: "go work duplicate prefix2",
+			args: args{
+				workDir: "D:\\code\\company\\core-ee",
+				execRun: func(arg, dir string, in ...*bytes.Buffer) (string, error) {
+					return `
+					{
+						"Path": "gitee.com/unitedrhino/core",
+						"Dir": "D:\\code\\company\\core",
+						"GoMod": "D:\\code\\company\\core\\go.mod",
+						"GoVersion": "1.21.4"
+					}
+					{
+						"Path": "gitee.com/unitedrhino/core-ee",
+						"Dir": "D:\\code\\company\\core-ee",
+						"GoMod": "D:\\code\\company\\core-ee\\go.mod",
+						"GoVersion": "1.21.4"
+					}`, nil
+				},
+			},
+			want: &Module{
+				Path:      "gitee.com/unitedrhino/core-ee",
+				Dir:       "D:\\code\\company\\core-ee",
+				GoMod:     "D:\\code\\company\\core-ee\\go.mod",
+				GoVersion: "1.21.4",
 			},
 		},
 	}


### PR DESCRIPTION
在go work下如果mod名字前缀一样会导致获取的不正确,末尾添加目录分隔符来确保一致