### PR TITLE
bugfix:`SetSlowThreshold` not effective in function `logDetails`

### DIFF
--- a/rest/handler/loghandler.go
+++ b/rest/handler/loghandler.go
@@ -158,7 +158,7 @@ func logDetails(r *http.Request, response *detailLoggedResponseWriter, timer *ut
 	logger := logx.WithContext(r.Context())
 	buf.WriteString(fmt.Sprintf("[HTTP] %s - %d - %s - %s\n=> %s\n",
 		r.Method, code, r.RemoteAddr, timex.ReprOfDuration(duration), dumpRequest(r)))
-	if duration > defaultSlowThreshold {
+	if duration > slowThreshold.Load() {
 		logger.Slowf("[HTTP] %s - %d - %s - slowcall(%s)\n=> %s\n", r.Method, code, r.RemoteAddr,
 			fmt.Sprintf("slowcall(%s)", timex.ReprOfDuration(duration)), dumpRequest(r))
 	}


### PR DESCRIPTION
The `slowThreshold` is not used in the `logDetails` function to judge slow logs, so `SetSlowThreshold` not effective in function `logDetails`