### PR TITLE
fix: goctl compile error on windows

### DIFF
--- a/core/proc/shutdown+polyfill.go
+++ b/core/proc/shutdown+polyfill.go
@@ -5,7 +5,7 @@ package proc
 import "time"
 
 // ShutdownConf is empty on windows.
-type ShutdownConf struct {}
+type ShutdownConf struct{}
 
 // AddShutdownListener returns fn itself on windows, lets callers call fn on their own.
 func AddShutdownListener(fn func()) func() {
@@ -22,7 +22,7 @@ func SetTimeToForceQuit(duration time.Duration) {
 }
 
 // Setup does nothing on windows.
-func Setup() {
+func Setup(conf ShutdownConf) {
 }
 
 // Shutdown does nothing on windows.

--- a/tools/goctl/internal/version/version.go
+++ b/tools/goctl/internal/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // BuildVersion is the version of goctl.
-const BuildVersion = "1.7.4"
+const BuildVersion = "1.7.5"
 
 var tag = map[string]int{"pre-alpha": 0, "alpha": 1, "pre-bata": 2, "beta": 3, "released": 4, "": 5}
 


### PR DESCRIPTION
fix #4536 

But we need to finish it in 2 PRs. This one will fix service problem, the next one will use the latest release and fix the goctl windows problem.