### PR TITLE
rest.Route add AtDoc field for struct

### DIFF
--- a/rest/server.go
+++ b/rest/server.go
@@ -234,6 +234,7 @@ func WithMiddleware(middleware Middleware, rs ...Route) []Route {
 	for i := range rs {
 		route := rs[i]
 		routes[i] = Route{
+			AtDoc:   route.AtDoc,
 			Method:  route.Method,
 			Path:    route.Path,
 			Handler: middleware(route.Handler),
@@ -265,6 +266,7 @@ func WithPrefix(group string) RouteOption {
 		for _, rt := range r.routes {
 			p := path.Join(group, rt.Path)
 			routes = append(routes, Route{
+				AtDoc:   rt.AtDoc,
 				Method:  rt.Method,
 				Path:    p,
 				Handler: rt.Handler,

--- a/rest/types.go
+++ b/rest/types.go
@@ -11,6 +11,7 @@ type (
 
 	// A Route is a http route.
 	Route struct {
+		AtDoc   map[string]string
 		Method  string
 		Path    string
 		Handler http.HandlerFunc

--- a/tools/goctl/api/gogen/genroutes.go
+++ b/tools/goctl/api/gogen/genroutes.go
@@ -75,6 +75,7 @@ type (
 		path    string
 		handler string
 		doc     string
+		atDoc   map[string]string
 	}
 )
 
@@ -97,14 +98,15 @@ func genRoutes(dir, rootPkg string, cfg *config.Config, api *spec.ApiSpec) error
 		gbuilder.WriteString("[]rest.Route{")
 		for _, r := range g.routes {
 			var routeString string
-			if len(r.doc) > 0 {
+			if len(r.doc) > 0 || len(r.atDoc) > 0 {
 				routeString = fmt.Sprintf(`
 					{
+						%s
 						%s
 						Method:  %s,
 						Path:    "%s",
 						Handler: %s,
-					},`, getDoc(r.doc), r.method, r.path, r.handler)
+					},`, getDoc(r.doc), getAtDoc(r.atDoc), r.method, r.path, r.handler)
 			} else {
 				routeString = fmt.Sprintf(`
 					{
@@ -261,6 +263,7 @@ func getRoutes(api *spec.ApiSpec) ([]group, error) {
 				path:    r.Path,
 				handler: handler,
 				doc:     r.JoinedDoc(),
+				atDoc:   r.JoinedAtDoc(),
 			})
 		}
 

--- a/tools/goctl/api/gogen/util.go
+++ b/tools/goctl/api/gogen/util.go
@@ -232,3 +232,22 @@ func getDoc(doc string) string {
 
 	return "// " + strings.Trim(doc, "\"")
 }
+
+func getAtDoc(m map[string]string) string {
+	if len(m) <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(`
+	AtDoc: map[string]string{
+			%s
+		},
+	`, getKv(m))
+}
+
+func getKv(m map[string]string) string {
+	kv := ""
+	for k, v := range m {
+		kv += fmt.Sprintf("\"%s\": \"%s\",\n", k, v)
+	}
+	return kv
+}

--- a/tools/goctl/api/spec/fn.go
+++ b/tools/goctl/api/spec/fn.go
@@ -229,6 +229,17 @@ func (r Route) JoinedDoc() string {
 	return strings.TrimSpace(doc)
 }
 
+func (r Route) JoinedAtDoc() map[string]string {
+	properties := r.AtDoc.Properties
+
+	if properties != nil {
+		return properties
+	}
+	m := make(map[string]string)
+	m["atDoc"] = r.AtDoc.Text
+	return m
+}
+
 // GetAnnotation returns the value by specified key from @server
 func (r Route) GetAnnotation(key string) string {
 	if r.AtServerAnnotation.Properties == nil {

--- a/tools/goctl/api/spec/fn.go
+++ b/tools/goctl/api/spec/fn.go
@@ -235,6 +235,9 @@ func (r Route) JoinedAtDoc() map[string]string {
 	if properties != nil {
 		return properties
 	}
+	if len(r.AtDoc.Text) <= 0 {
+		return nil
+	}
 	m := make(map[string]string)
 	m["atDoc"] = r.AtDoc.Text
 	return m


### PR DESCRIPTION
rest.Route add AtDoc field for struct

给rest.Route{}结构体添加一个 AtDoc 的map[string]string 属性字段，goctl 生成代码时，会给这个字段赋值。
这样可以根据给定的注释开发出更多复杂的关于路由的功能
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8c070382-e529-492d-9e94-f33cb1ae3f26" />

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ca85007a-f51e-4ba5-bfb9-6c1e85b17e69" />
