### PR TITLE
Potential fix for code scanning alert no. 57: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/tools/goctl/util/zipx/zipx.go
+++ b/tools/goctl/util/zipx/zipx.go
@@ -2,9 +2,11 @@ package zipx
 
 import (
 	"archive/zip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/zeromicro/go-zero/tools/goctl/util/pathx"
 )
@@ -39,13 +41,22 @@ func fileCopy(file *zip.File, destPath string) error {
 		return err
 	}
 	defer rc.Close()
-	abs, err := filepath.Abs(file.Name)
+	// Ensure the file path does not contain directory traversal elements
+	if strings.Contains(file.Name, "..") {
+		return fmt.Errorf("invalid file path: %s", file.Name)
+	}
+
+	abs, err := filepath.Abs(filepath.Join(destPath, file.Name))
 	if err != nil {
 		return err
 	}
 
-	filename := filepath.Join(destPath, filepath.Base(abs))
-	dir := filepath.Dir(filename)
+	// Ensure the destination path is within the intended directory
+	if !strings.HasPrefix(abs, destPath) {
+		return fmt.Errorf("file path is outside the destination directory: %s", abs)
+	}
+
+	dir := filepath.Dir(abs)
 	err = pathx.MkdirIfNotExist(dir)
 	if err != nil {
 		return err

--- a/tools/goctl/util/zipx/zipx.go
+++ b/tools/goctl/util/zipx/zipx.go
@@ -41,22 +41,19 @@ func fileCopy(file *zip.File, destPath string) error {
 		return err
 	}
 	defer rc.Close()
+
 	// Ensure the file path does not contain directory traversal elements
 	if strings.Contains(file.Name, "..") {
 		return fmt.Errorf("invalid file path: %s", file.Name)
 	}
 
-	abs, err := filepath.Abs(filepath.Join(destPath, file.Name))
+	abs, err := filepath.Abs(file.Name)
 	if err != nil {
 		return err
 	}
 
-	// Ensure the destination path is within the intended directory
-	if !strings.HasPrefix(abs, destPath) {
-		return fmt.Errorf("file path is outside the destination directory: %s", abs)
-	}
-
-	dir := filepath.Dir(abs)
+	filename := filepath.Join(destPath, filepath.Base(abs))
+	dir := filepath.Dir(filename)
 	err = pathx.MkdirIfNotExist(dir)
 	if err != nil {
 		return err


### PR DESCRIPTION
Potential fix for [https://github.com/zeromicro/go-zero/security/code-scanning/57](https://github.com/zeromicro/go-zero/security/code-scanning/57)

To fix the problem, we need to ensure that the file paths extracted from the zip archive do not contain any directory traversal elements (e.g., `..`). This can be done by validating the file paths before using them in file system operations.

1. Modify the `fileCopy` function to check for directory traversal elements in the file paths.
2. Ensure that the destination path is within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
