### PR TITLE
fix: global fields not valid for third-party loggers

### DIFF
--- a/core/logx/logs.go
+++ b/core/logx/logs.go
@@ -449,7 +449,8 @@ func WithRotation(r string) LogOption {
 	}
 }
 
-func addCaller(fields ...LogField) []LogField {
+func assembleFields(fields ...LogField) []LogField {
+	fields = combineGlobalFields(fields)
 	return append(fields, Field(callerKey, getCaller(callerDepth)))
 }
 
@@ -560,7 +561,7 @@ func shallLogStat() bool {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeDebug(val any, fields ...LogField) {
-	getWriter().Debug(val, addCaller(fields...)...)
+	getWriter().Debug(val, assembleFields(fields...)...)
 }
 
 // writeError writes v into the error log.
@@ -568,7 +569,7 @@ func writeDebug(val any, fields ...LogField) {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeError(val any, fields ...LogField) {
-	getWriter().Error(val, addCaller(fields...)...)
+	getWriter().Error(val, assembleFields(fields...)...)
 }
 
 // writeInfo writes v into info log.
@@ -576,7 +577,7 @@ func writeError(val any, fields ...LogField) {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeInfo(val any, fields ...LogField) {
-	getWriter().Info(val, addCaller(fields...)...)
+	getWriter().Info(val, assembleFields(fields...)...)
 }
 
 // writeSevere writes v into severe log.
@@ -592,7 +593,7 @@ func writeSevere(msg string) {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeSlow(val any, fields ...LogField) {
-	getWriter().Slow(val, addCaller(fields...)...)
+	getWriter().Slow(val, assembleFields(fields...)...)
 }
 
 // writeStack writes v into stack log.
@@ -608,5 +609,5 @@ func writeStack(msg string) {
 // If we check shallLog here, the fmt.Sprint might be called even if the log level is not enabled.
 // The caller should check shallLog before calling this function.
 func writeStat(msg string) {
-	getWriter().Stat(msg, addCaller()...)
+	getWriter().Stat(msg, assembleFields()...)
 }

--- a/core/logx/writer.go
+++ b/core/logx/writer.go
@@ -362,7 +362,6 @@ func output(writer io.Writer, level string, val any, fields ...LogField) {
 		}
 	}
 
-	fields = combineGlobalFields(fields)
 	// +3 for timestamp, level and content
 	entry := make(logEntry, len(fields)+3)
 	for _, field := range fields {


### PR DESCRIPTION
fix #4398 