### PR TITLE
feat: Add support for serialization of anonymous fields in HTTP client(httpc)

### DIFF
--- a/core/mapping/marshaler_test.go
+++ b/core/mapping/marshaler_test.go
@@ -27,6 +27,99 @@ func TestMarshal(t *testing.T) {
 	assert.True(t, m[emptyTag]["Anonymous"].(bool))
 }
 
+func TestMarshal_Anonymous(t *testing.T) {
+	type BaseHeader struct {
+		Token string `header:"token"`
+	}
+	v := struct {
+		Name    string `json:"name"`
+		Address string `json:"address,options=[beijing,shanghai]"`
+		Age     int    `json:"age"`
+		BaseHeader
+	}{
+		Name:    "kevin",
+		Address: "shanghai",
+		Age:     20,
+		BaseHeader: BaseHeader{
+			Token: "token_xxx",
+		},
+	}
+	m, err := Marshal(v)
+	assert.Nil(t, err)
+	assert.Equal(t, "kevin", m["json"]["name"])
+	assert.Equal(t, "shanghai", m["json"]["address"])
+	assert.Equal(t, 20, m["json"]["age"].(int))
+	assert.Equal(t, "token_xxx", m["header"]["token"])
+
+	v1 := struct {
+		Name    string `json:"name"`
+		Address string `json:"address,options=[beijing,shanghai]"`
+		Age     int    `json:"age"`
+		BaseHeader
+	}{
+		Name:    "kevin",
+		Address: "shanghai",
+		Age:     20,
+	}
+	m1, err1 := Marshal(v1)
+	assert.Nil(t, err1)
+	assert.Equal(t, "kevin", m1["json"]["name"])
+	assert.Equal(t, "shanghai", m1["json"]["address"])
+	assert.Equal(t, 20, m1["json"]["age"].(int))
+
+	type AnotherHeader struct {
+		Version string `header:"version"`
+	}
+	v2 := struct {
+		Name    string `json:"name"`
+		Address string `json:"address,options=[beijing,shanghai]"`
+		Age     int    `json:"age"`
+		BaseHeader
+		AnotherHeader
+	}{
+		Name:    "kevin",
+		Address: "shanghai",
+		Age:     20,
+		BaseHeader: BaseHeader{
+			Token: "token_xxx",
+		},
+		AnotherHeader: AnotherHeader{
+			Version: "v1.0",
+		},
+	}
+	m2, err2 := Marshal(v2)
+	assert.Nil(t, err2)
+	assert.Equal(t, "kevin", m2["json"]["name"])
+	assert.Equal(t, "shanghai", m2["json"]["address"])
+	assert.Equal(t, 20, m2["json"]["age"].(int))
+	assert.Equal(t, "token_xxx", m2["header"]["token"])
+	assert.Equal(t, "v1.0", m2["header"]["version"])
+
+	type PointerHeader struct {
+		Ref *string `header:"ref"`
+	}
+	ref := "reference"
+	v3 := struct {
+		Name    string `json:"name"`
+		Address string `json:"address,options=[beijing,shanghai]"`
+		Age     int    `json:"age"`
+		PointerHeader
+	}{
+		Name:    "kevin",
+		Address: "shanghai",
+		Age:     20,
+		PointerHeader: PointerHeader{
+			Ref: &ref,
+		},
+	}
+	m3, err3 := Marshal(v3)
+	assert.Nil(t, err3)
+	assert.Equal(t, "kevin", m3["json"]["name"])
+	assert.Equal(t, "shanghai", m3["json"]["address"])
+	assert.Equal(t, 20, m3["json"]["age"].(int))
+	assert.Equal(t, "reference", *m3["header"]["ref"].(*string))
+}
+
 func TestMarshal_Ptr(t *testing.T) {
 	v := &struct {
 		Name      string `path:"name"`


### PR DESCRIPTION


### **PR Title**
**"Add support for serialization of anonymous fields in httpc's Do method"**

---

### **PR Description**

#### **Background & Problem Description**
During development, I discovered that the `Do` method in the `httpc` library does not currently support parsing anonymous struct fields. This leads to redundant code when defining request parameters for services that share common headers or fields. For example:

We define a generic request header structure `BaseHeader`:
```go
type BaseHeader struct {
    OperationID string `header:"operationID"`
    Token       string `header:"token"`
}
```

Then we embed this structure into a specific request struct:
```go
type GetTokenReq struct {
    BaseHeader
    UserID string `json:"userID"`
    Secret string `json:"secret"`
}
```

In this scenario, the fields defined in `BaseHeader` (e.g., `OperationID` and `Token`) are not automatically added to the HTTP request headers. As a result, developers need to manually handle these fields, leading to increased code complexity and maintenance overhead.

#### **Solution**
This PR enhances the `Do` method in `httpc` to correctly parse anonymous struct fields and serialize their values into HTTP request headers or bodies. The changes include:
1. Modifying the serialization logic in the `Do` method to recursively parse nested anonymous fields.
2. Ensuring that tags (e.g., `header` or `json`) on anonymous fields are properly recognized and applied.

#### **Improved Example**
After this change, the above code can be used directly without additional handling:
```go
req := GetTokenReq{
    BaseHeader: BaseHeader{
        OperationID: "12345",
        Token:       "abcde",
    },
    UserID: "user123",
    Secret: "secret456",
}

resp, err := client.Do(req)
if err != nil {
    // Handle error
}
```

In this case, `OperationID` and `Token` will automatically be added to the HTTP request headers, while `UserID` and `Secret` will be serialized into the request body.

#### **Testing & Verification**
- Added relevant unit tests to ensure the proper parsing and serialization of anonymous fields.
- Verified backward compatibility to ensure existing functionality remains unaffected.

#### **Summary**
This PR resolves the issue of insufficient support for anonymous struct fields in the `httpc` library, significantly reducing redundant code and improving development efficiency and code maintainability. I hope this improvement will benefit more developers!