### PR TITLE
feat/sql-pool-config: Added command support for poolConfig for sql

### DIFF
--- a/core/stores/postgres/postgresql.go
+++ b/core/stores/postgres/postgresql.go
@@ -10,6 +10,6 @@ import (
 const postgresDriverName = "pgx"
 
 // New returns a postgres connection.
-func New(datasource string, opts ...sqlx.SqlOption) sqlx.SqlConn {
-	return sqlx.NewSqlConn(postgresDriverName, datasource, opts...)
+func New(datasource string, poolConfig sqlx.PoolConfig, opts ...sqlx.SqlOption) sqlx.SqlConn {
+	return sqlx.NewSqlConn(postgresDriverName, datasource, poolConfig, opts...)
 }

--- a/core/stores/postgres/postgresql_test.go
+++ b/core/stores/postgres/postgresql_test.go
@@ -2,10 +2,16 @@ package postgres
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/stores/sqlx"
 )
 
 func TestPostgreSql(t *testing.T) {
-	assert.NotNil(t, New("postgre"))
+	assert.NotNil(t, New("postgre", sqlx.PoolConfig{
+		MaxIdleConns: 10,
+		MaxOpenConns: 10,
+		MaxLifetime:  time.Minute,
+	}))
 }

--- a/core/stores/sqlx/mysql.go
+++ b/core/stores/sqlx/mysql.go
@@ -12,9 +12,9 @@ const (
 )
 
 // NewMysql returns a mysql connection.
-func NewMysql(datasource string, opts ...SqlOption) SqlConn {
+func NewMysql(datasource string, poolConfig PoolConfig, opts ...SqlOption) SqlConn {
 	opts = append([]SqlOption{withMysqlAcceptable()}, opts...)
-	return NewSqlConn(mysqlDriverName, datasource, opts...)
+	return NewSqlConn(mysqlDriverName, datasource, poolConfig, opts...)
 }
 
 func mysqlAcceptable(err error) bool {

--- a/core/stores/sqlx/mysql_test.go
+++ b/core/stores/sqlx/mysql_test.go
@@ -3,7 +3,7 @@ package sqlx
 import (
 	"errors"
 	"testing"
-
+	"time"
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/zeromicro/go-zero/core/breaker"
@@ -35,7 +35,11 @@ func TestBreakerOnNotHandlingDuplicateEntry(t *testing.T) {
 }
 
 func TestMysqlAcceptable(t *testing.T) {
-	conn := NewMysql("nomysql").(*commonSqlConn)
+	conn := NewMysql("nomysql", PoolConfig{
+		MaxIdleConns: 10,	
+		MaxOpenConns: 10,
+		MaxLifetime:  time.Minute,
+	}).(*commonSqlConn)
 	withMysqlAcceptable()(conn)
 	assert.True(t, mysqlAcceptable(nil))
 	assert.False(t, mysqlAcceptable(errors.New("any")))

--- a/core/stores/sqlx/sqlconn.go
+++ b/core/stores/sqlx/sqlconn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/zeromicro/go-zero/core/breaker"
 	"github.com/zeromicro/go-zero/core/errorx"
@@ -54,6 +55,12 @@ type (
 		accept   breaker.Acceptable
 	}
 
+	PoolConfig struct {
+		MaxIdleConns int
+		MaxOpenConns int
+		MaxLifetime  time.Duration
+	}
+
 	connProvider func() (*sql.DB, error)
 
 	sessionConn interface {
@@ -65,10 +72,10 @@ type (
 )
 
 // NewSqlConn returns a SqlConn with given driver name and datasource.
-func NewSqlConn(driverName, datasource string, opts ...SqlOption) SqlConn {
+func NewSqlConn(driverName, datasource string, poolConfig PoolConfig, opts ...SqlOption) SqlConn {
 	conn := &commonSqlConn{
 		connProv: func() (*sql.DB, error) {
-			return getSqlConn(driverName, datasource)
+			return getSqlConn(driverName, datasource, poolConfig)
 		},
 		onError: func(ctx context.Context, err error) {
 			logInstanceError(ctx, datasource, err)

--- a/core/stores/sqlx/sqlconn_test.go
+++ b/core/stores/sqlx/sqlconn_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"io"
 	"testing"
-
+	"time"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/zeromicro/go-zero/core/breaker"
@@ -26,11 +26,19 @@ func TestSqlConn(t *testing.T) {
 	assert.Nil(t, err)
 	mock.ExpectExec("any")
 	mock.ExpectQuery("any").WillReturnRows(sqlmock.NewRows([]string{"foo"}))
-	conn := NewMysql(mockedDatasource)
+	conn := NewMysql(mockedDatasource, PoolConfig{
+		MaxIdleConns: 10,
+		MaxOpenConns: 10,
+		MaxLifetime:  time.Minute,
+	})
 	db, err := conn.RawDB()
 	assert.Nil(t, err)
 	rawConn := NewSqlConnFromDB(db, withMysqlAcceptable())
-	badConn := NewMysql("badsql")
+	badConn := NewMysql("badsql", PoolConfig{
+		MaxIdleConns: 10,
+		MaxOpenConns: 10,
+		MaxLifetime:  time.Minute,
+	})
 	_, err = conn.Exec("any", "value")
 	assert.NotNil(t, err)
 	_, err = badConn.Exec("any", "value")

--- a/tools/goctl/model/cmd.go
+++ b/tools/goctl/model/cmd.go
@@ -44,6 +44,9 @@ func init() {
 	datasourceCmdFlags.StringVar(&command.VarStringHome, "home")
 	datasourceCmdFlags.StringVar(&command.VarStringRemote, "remote")
 	datasourceCmdFlags.StringVar(&command.VarStringBranch, "branch")
+	datasourceCmdFlags.IntVarP(&command.VarIntMaxIdleConns, "max-idle-conns", "i", 64)
+	datasourceCmdFlags.IntVarP(&command.VarIntMaxOpenConns, "max-open-conns", "o", 64)
+	datasourceCmdFlags.IntVarP(&command.VarIntMaxLifetime, "max-lifetime", "l", 60)
 
 	pgDatasourceCmdFlags.StringVar(&command.VarStringURL, "url")
 	pgDatasourceCmdFlags.StringSliceVarP(&command.VarStringSliceTable, "table", "t")
@@ -56,6 +59,9 @@ func init() {
 	pgDatasourceCmdFlags.StringVar(&command.VarStringHome, "home")
 	pgDatasourceCmdFlags.StringVar(&command.VarStringRemote, "remote")
 	pgDatasourceCmdFlags.StringVar(&command.VarStringBranch, "branch")
+	pgDatasourceCmdFlags.IntVarP(&command.VarIntMaxIdleConns, "max-idle-conns", "i", 64)
+	pgDatasourceCmdFlags.IntVarP(&command.VarIntMaxOpenConns, "max-open-conns", "o", 64)
+	pgDatasourceCmdFlags.IntVarP(&command.VarIntMaxLifetime, "max-lifetime", "l", 60)
 	pgCmd.PersistentFlags().StringSliceVarPWithDefaultValue(&command.VarStringSliceIgnoreColumns,
 		"ignore-columns", "i", []string{"create_at", "created_at", "create_time", "update_at", "updated_at", "update_time"})
 


### PR DESCRIPTION
#4530 : Moved SQL connection pool defaults from core to command flags
- Removed hardcoded default values for maxIdleConns, maxOpenConns, and maxLifetime from SQL connections
- Added these settings as command-line flags to allow user configuration
- If not specified, falls back to default values defined in core/stores/sqlx/sqlmanager.go