### PR TITLE
fix: fix the bug of the numeric/decimal data type in pg

### DIFF
--- a/tools/goctl/model/sql/model/postgresqlmodel.go
+++ b/tools/goctl/model/sql/model/postgresqlmodel.go
@@ -2,14 +2,15 @@ package model
 
 import (
 	"database/sql"
-	"strings"
 
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
+	"strings"
 )
 
 var p2m = map[string]string{
 	"int8":        "bigint",
-	"numeric":     "bigint",
+	"numeric":     "double",
+	"decimal":     "double",
 	"float8":      "double",
 	"float4":      "float",
 	"int2":        "smallint",


### PR DESCRIPTION
Issue #4624.

I tried the PostgreSQL DDL and use both numeric and decimal type to generate the model.
`balance_test_tab.sql`
```sql
CREATE TABLE balance_test_tab (
      id bigserial NOT NULL,
      balance numeric(78) DEFAULT 0 NOT NULL,
      CONSTRAINT balance_test_tab_pk PRIMARY KEY (id)
);

CREATE TABLE balance_test_tab (
      id bigserial NOT NULL,
      balance decimal(78) DEFAULT 0 NOT NULL,
      CONSTRAINT balance_test_tab_pk PRIMARY KEY (id)
);
```

### Output
These cases both gave the int64 type to the code.
```go
BalanceTestTab struct {
		Id      int64 `db:"id"`
		Balance int64 `db:"balance"`
}
```


Otherwise, I use DDL in MySQL below:
```sql
CREATE TABLE balance_test_tab (
  id BIGINT AUTO_INCREMENT NOT NULL,
  balance DECIMAL(78,0) DEFAULT 0 NOT NULL,
  PRIMARY KEY (id)
);
```

 ### Output
The type was float64.
```go
	BalanceTestTab struct {
		Id      int64   `db:"id"`
		Balance float64 `db:"balance"`
	}
```

## Key Reason
When goctl use datasource to get the columns info, it will transfer the type to mysql type. The `numeric/decimal` was transfer to the bigint type, and it was not reasonable.

`tools/goctl/model/sql/model/postgresqlmodel.go`
```go
var p2m = map[string]string{
	"int8":        "bigint",
	"numeric":     "double", // it was bigint, after I changed it 
	"decimal":     "double", // add it to support the type
	"float8":      "double",
	"float4":      "float",
	"int2":        "smallint",
	"int4":        "integer",
	"timestamptz": "timestamp",
}

func (m *PostgreSqlModel) convertPostgreSqlTypeIntoMysqlType(in string) string {
	r, ok := p2m[strings.ToLower(in)]
	if ok {
		return r
	}

	return in
}
```

