### PR TITLE
fix: goctl api tsgen

### DIFF
--- a/tools/goctl/api/tsgen/util.go
+++ b/tools/goctl/api/tsgen/util.go
@@ -34,6 +34,10 @@ func writeProperty(writer io.Writer, member spec.Member, indent int) error {
 		return err
 	}
 
+	if strings.Contains(name, "-") {
+		name = fmt.Sprintf("'%s'", name)
+	}
+
 	comment := member.GetComment()
 	if len(comment) > 0 {
 		comment = strings.TrimPrefix(comment, "//")


### PR DESCRIPTION
#4717
Fix: Resolve the issue where the goctl api ts command fails to generate correct TypeScript code when field names contain hyphens.
Before:
![image](https://github.com/user-attachments/assets/0b7a143f-5823-4b38-8e5e-cf1c44cd8732)
After:
![image](https://github.com/user-attachments/assets/c9567e95-16e5-4742-a666-0a6cb7b07222)

