### PR TITLE
fix pg to mysql type

### DIFF
--- a/tools/goctl/model/sql/model/postgresqlmodel.go
+++ b/tools/goctl/model/sql/model/postgresqlmodel.go
@@ -9,8 +9,7 @@ import (
 
 var p2m = map[string]string{
 	"int8":        "bigint",
-	"numeric":     "double",
-	"decimal":     "double",
+	"numeric":     "decimal",
 	"float8":      "double",
 	"float4":      "float",
 	"int2":        "smallint",


### PR DESCRIPTION
In PostgreSQL, numeric and decimal are equivalent types. If you directly convert numeric and decimal to float during type casting, the actual types cannot be retrieved in the goctl.yml configuration, causing custom type definitions for numeric and decimal to become ineffective.