### PR TITLE
feat: can replace json Marshal and Unmarshal

### DIFF
--- a/core/jsoncode/jsoncode.go
+++ b/core/jsoncode/jsoncode.go
@@ -2,31 +2,25 @@ package jsoncode
 
 import "encoding/json"
 
-var defaultJsonCode JsonCode = &stdJson{}
+type (
+	MarshalFn   func(v any) ([]byte, error)
+	UnmarshalFn func(by []byte, v any) error
+)
 
-func SetJsonCode(jsonCode JsonCode) {
-	defaultJsonCode = jsonCode
+var (
+	Marshal MarshalFn = func(v any) ([]byte, error) {
+		return json.Marshal(v)
+	}
+
+	Unmarshal UnmarshalFn = func(by []byte, v any) error {
+		return json.Unmarshal(by, v)
+	}
+)
+
+func SetMarshalFn(fn MarshalFn) {
+	Marshal = fn
 }
 
-func Marshal(v any) ([]byte, error) {
-	return defaultJsonCode.Marshal(v)
-}
-
-func Unmarshal(by []byte, v any) error {
-	return defaultJsonCode.Unmarshal(by, v)
-}
-
-type stdJson struct{}
-
-func (s *stdJson) Marshal(v any) ([]byte, error) {
-	return json.Marshal(v)
-}
-
-func (s *stdJson) Unmarshal(by []byte, v any) error {
-	return json.Unmarshal(by, v)
-}
-
-type JsonCode interface {
-	Marshal(v any) ([]byte, error)
-	Unmarshal(data []byte, v any) error
+func SetUnmarshalFn(fn UnmarshalFn) {
+	Unmarshal = fn
 }

--- a/core/jsoncode/jsoncode.go
+++ b/core/jsoncode/jsoncode.go
@@ -1,0 +1,32 @@
+package jsoncode
+
+import "encoding/json"
+
+var defaultJsonCode JsonCode = &stdJson{}
+
+func SetJsonCode(jsonCode JsonCode) {
+	defaultJsonCode = jsonCode
+}
+
+func Marshal(v any) ([]byte, error) {
+	return defaultJsonCode.Marshal(v)
+}
+
+func Unmarshal(by []byte, v any) error {
+	return defaultJsonCode.Unmarshal(by, v)
+}
+
+type stdJson struct{}
+
+func (s *stdJson) Marshal(v any) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func (s *stdJson) Unmarshal(by []byte, v any) error {
+	return json.Unmarshal(by, v)
+}
+
+type JsonCode interface {
+	Marshal(v any) ([]byte, error)
+	Unmarshal(data []byte, v any) error
+}

--- a/core/jsoncode/jsoncode_test.go
+++ b/core/jsoncode/jsoncode_test.go
@@ -1,0 +1,70 @@
+package jsoncode
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshal(t *testing.T) {
+	var v = struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}{
+		Name: "John",
+		Age:  30,
+	}
+	bs, err := Marshal(v)
+	assert.Nil(t, err)
+	assert.Equal(t, `{"name":"John","age":30}`, string(bs))
+}
+
+func TestSetMarshal(t *testing.T) {
+	SetMarshalFn(func(v any) ([]byte, error) {
+		return []byte{}, nil
+	})
+
+	var v = struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}{
+		Name: "John",
+		Age:  30,
+	}
+	bs, err := Marshal(v)
+	assert.Nil(t, err)
+	assert.Equal(t, ``, string(bs))
+}
+
+func TestUnmarshal(t *testing.T) {
+	const s = `{"name":"John","age":30}`
+	var v struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	err := Unmarshal([]byte(s), &v)
+	assert.Nil(t, err)
+	assert.Equal(t, "John", v.Name)
+	assert.Equal(t, 30, v.Age)
+}
+
+func TestSetUnmarshal(t *testing.T) {
+	SetUnmarshalFn(func(by []byte, v any) error {
+		vValue := reflect.ValueOf(v).Elem()
+		vValue.FieldByName("Name").SetString("SetJohn")
+		vValue.FieldByName("Age").SetInt(40)
+
+		return nil
+	})
+
+	const s = `{"name":"John","age":30}`
+	var v struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	err := Unmarshal([]byte(s), &v)
+	assert.Nil(t, err)
+	assert.Equal(t, "SetJohn", v.Name)
+	assert.Equal(t, 40, v.Age)
+}

--- a/core/jsonx/json.go
+++ b/core/jsonx/json.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/zeromicro/go-zero/core/jsoncode"
 )
 
 // Marshal marshals v into json bytes.
 func Marshal(v any) ([]byte, error) {
-	return json.Marshal(v)
+	return jsoncode.Marshal(v)
 }
 
 // MarshalToString marshals v into a string.

--- a/core/logc/logs_test.go
+++ b/core/logc/logs_test.go
@@ -2,13 +2,13 @@ package logc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/logx/logtest"
 )
@@ -23,7 +23,7 @@ func TestAddGlobalFields(t *testing.T) {
 	AddGlobalFields(Field("c", "3"))
 	Info(context.Background(), "world")
 	var m map[string]any
-	assert.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+	assert.NoError(t, jsoncode.Unmarshal(buf.Bytes(), &m))
 	assert.Equal(t, "1", m["a"])
 	assert.Equal(t, "2", m["b"])
 	assert.Equal(t, "3", m["c"])

--- a/core/logx/fields_test.go
+++ b/core/logx/fields_test.go
@@ -3,13 +3,13 @@ package logx
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 )
 
 func TestAddGlobalFields(t *testing.T) {
@@ -26,7 +26,7 @@ func TestAddGlobalFields(t *testing.T) {
 	AddGlobalFields(Field("c", "3"))
 	Info("world")
 	var m map[string]any
-	assert.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+	assert.NoError(t, jsoncode.Unmarshal(buf.Bytes(), &m))
 	assert.Equal(t, "1", m["a"])
 	assert.Equal(t, "2", m["b"])
 	assert.Equal(t, "3", m["c"])

--- a/core/logx/logs_test.go
+++ b/core/logx/logs_test.go
@@ -1,7 +1,6 @@
 package logx
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 )
 
 var (
@@ -654,7 +654,7 @@ func TestStructedLogWithDuration(t *testing.T) {
 
 	WithDuration(time.Second).Info(message)
 	var entry map[string]any
-	if err := json.Unmarshal([]byte(w.String()), &entry); err != nil {
+	if err := jsoncode.Unmarshal([]byte(w.String()), &entry); err != nil {
 		t.Error(err)
 	}
 	assert.Equal(t, levelInfo, entry[levelKey])
@@ -946,7 +946,7 @@ func doTestStructedLog(t *testing.T, level string, w *mockWriter, write func(...
 	write(message)
 
 	var entry map[string]any
-	if err := json.Unmarshal([]byte(w.String()), &entry); err != nil {
+	if err := jsoncode.Unmarshal([]byte(w.String()), &entry); err != nil {
 		t.Error(err)
 	}
 
@@ -1009,7 +1009,7 @@ func (v ValStringer) String() string {
 
 func validateFields(t *testing.T, content string, fields map[string]any) {
 	var m map[string]any
-	if err := json.Unmarshal([]byte(content), &m); err != nil {
+	if err := jsoncode.Unmarshal([]byte(content), &m); err != nil {
 		t.Error(err)
 	}
 

--- a/core/logx/logtest/logtest.go
+++ b/core/logx/logtest/logtest.go
@@ -2,10 +2,10 @@ package logtest
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"testing"
 
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"github.com/zeromicro/go-zero/core/logx"
 )
 
@@ -45,7 +45,7 @@ func (b *Buffer) Bytes() []byte {
 
 func (b *Buffer) Content() string {
 	var m map[string]interface{}
-	if err := json.Unmarshal(b.buf.Bytes(), &m); err != nil {
+	if err := jsoncode.Unmarshal(b.buf.Bytes(), &m); err != nil {
 		return ""
 	}
 
@@ -59,7 +59,7 @@ func (b *Buffer) Content() string {
 		return val
 	default:
 		// err is impossible to be not nil, unmarshaled from b.buf.Bytes()
-		bs, _ := json.Marshal(content)
+		bs, _ := jsoncode.Marshal(content)
 		return string(bs)
 	}
 }

--- a/core/logx/richlogger_test.go
+++ b/core/logx/richlogger_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
@@ -278,7 +279,7 @@ func TestLogWithFields(t *testing.T) {
 	l.Info(testlog)
 
 	var val mockValue
-	assert.Nil(t, json.Unmarshal([]byte(w.String()), &val))
+	assert.Nil(t, jsoncode.Unmarshal([]byte(w.String()), &val))
 	assert.Equal(t, "bar", val.Foo)
 }
 
@@ -368,7 +369,7 @@ func TestLoggerWithFields(t *testing.T) {
 	l.Info(testlog)
 
 	var val mockValue
-	assert.Nil(t, json.Unmarshal([]byte(w.String()), &val))
+	assert.Nil(t, jsoncode.Unmarshal([]byte(w.String()), &val))
 	assert.Equal(t, "bar", val.Foo)
 }
 

--- a/core/logx/syslog_test.go
+++ b/core/logx/syslog_test.go
@@ -1,13 +1,13 @@
 package logx
 
 import (
-	"encoding/json"
 	"log"
 	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 )
 
 const testlog = "Stay hungry, stay foolish."
@@ -45,7 +45,7 @@ func captureOutput(f func()) string {
 
 func getContent(jsonStr string) string {
 	var entry map[string]any
-	json.Unmarshal([]byte(jsonStr), &entry)
+	jsoncode.Unmarshal([]byte(jsonStr), &entry)
 
 	val, ok := entry[contentKey]
 	if !ok {

--- a/core/logx/writer_test.go
+++ b/core/logx/writer_test.go
@@ -2,7 +2,6 @@ package logx
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"log"
 	"sync/atomic"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 )
 
 func TestNewWriter(t *testing.T) {
@@ -30,7 +30,7 @@ func TestConsoleWriter(t *testing.T) {
 	w.(*concreteWriter).errorLog = lw
 	w.Alert("foo bar 1")
 	var val mockedEntry
-	if err := json.Unmarshal(buf.Bytes(), &val); err != nil {
+	if err := jsoncode.Unmarshal(buf.Bytes(), &val); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, levelAlert, val.Level)
@@ -39,7 +39,7 @@ func TestConsoleWriter(t *testing.T) {
 	buf.Reset()
 	w.(*concreteWriter).errorLog = lw
 	w.Error("foo bar 2")
-	if err := json.Unmarshal(buf.Bytes(), &val); err != nil {
+	if err := jsoncode.Unmarshal(buf.Bytes(), &val); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, levelError, val.Level)
@@ -48,7 +48,7 @@ func TestConsoleWriter(t *testing.T) {
 	buf.Reset()
 	w.(*concreteWriter).infoLog = lw
 	w.Info("foo bar 3")
-	if err := json.Unmarshal(buf.Bytes(), &val); err != nil {
+	if err := jsoncode.Unmarshal(buf.Bytes(), &val); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, levelInfo, val.Level)
@@ -57,7 +57,7 @@ func TestConsoleWriter(t *testing.T) {
 	buf.Reset()
 	w.(*concreteWriter).severeLog = lw
 	w.Severe("foo bar 4")
-	if err := json.Unmarshal(buf.Bytes(), &val); err != nil {
+	if err := jsoncode.Unmarshal(buf.Bytes(), &val); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, levelFatal, val.Level)
@@ -66,7 +66,7 @@ func TestConsoleWriter(t *testing.T) {
 	buf.Reset()
 	w.(*concreteWriter).slowLog = lw
 	w.Slow("foo bar 5")
-	if err := json.Unmarshal(buf.Bytes(), &val); err != nil {
+	if err := jsoncode.Unmarshal(buf.Bytes(), &val); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, levelSlow, val.Level)
@@ -75,7 +75,7 @@ func TestConsoleWriter(t *testing.T) {
 	buf.Reset()
 	w.(*concreteWriter).statLog = lw
 	w.Stat("foo bar 6")
-	if err := json.Unmarshal(buf.Bytes(), &val); err != nil {
+	if err := jsoncode.Unmarshal(buf.Bytes(), &val); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, levelStat, val.Level)
@@ -238,7 +238,7 @@ func TestLogWithLimitContentLength(t *testing.T) {
 		w := NewWriter(&buf)
 		w.Info("1234567890")
 		var v1 mockedEntry
-		if err := json.Unmarshal(buf.Bytes(), &v1); err != nil {
+		if err := jsoncode.Unmarshal(buf.Bytes(), &v1); err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, "1234567890", v1.Content)
@@ -247,7 +247,7 @@ func TestLogWithLimitContentLength(t *testing.T) {
 		buf.Reset()
 		var v2 mockedEntry
 		w.Info("12345678901")
-		if err := json.Unmarshal(buf.Bytes(), &v2); err != nil {
+		if err := jsoncode.Unmarshal(buf.Bytes(), &v2); err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, "1234567890", v2.Content)

--- a/core/stat/remotewriter.go
+++ b/core/stat/remotewriter.go
@@ -2,11 +2,11 @@ package stat
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
 
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"github.com/zeromicro/go-zero/core/logx"
 )
 
@@ -31,7 +31,7 @@ func NewRemoteWriter(endpoint string) Writer {
 }
 
 func (rw *RemoteWriter) Write(report *StatReport) error {
-	bs, err := json.Marshal(report)
+	bs, err := jsoncode.Marshal(report)
 	if err != nil {
 		return err
 	}

--- a/core/stores/cache/cache_test.go
+++ b/core/stores/cache/cache_test.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zeromicro/go-zero/core/errorx"
 	"github.com/zeromicro/go-zero/core/hash"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"github.com/zeromicro/go-zero/core/stores/redis"
 	"github.com/zeromicro/go-zero/core/stores/redis/redistest"
 	"github.com/zeromicro/go-zero/core/syncx"
@@ -51,7 +51,7 @@ func (mc *mockedNode) Get(key string, val any) error {
 func (mc *mockedNode) GetCtx(ctx context.Context, key string, val any) error {
 	bs, ok := mc.vals[key]
 	if ok {
-		return json.Unmarshal(bs, val)
+		return jsoncode.Unmarshal(bs, val)
 	}
 
 	return mc.errNotFound
@@ -66,7 +66,7 @@ func (mc *mockedNode) Set(key string, val any) error {
 }
 
 func (mc *mockedNode) SetCtx(ctx context.Context, key string, val any) error {
-	data, err := json.Marshal(val)
+	data, err := jsoncode.Marshal(val)
 	if err != nil {
 		return err
 	}

--- a/core/stores/mon/util.go
+++ b/core/stores/mon/util.go
@@ -2,10 +2,10 @@ package mon
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"time"
 
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/timex"
 )
@@ -37,7 +37,7 @@ func logDurationWithDocs(ctx context.Context, name, method string, startTime tim
 	duration := timex.Since(startTime)
 	logger := logx.WithContext(ctx).WithDuration(duration)
 
-	content, jerr := json.Marshal(docs)
+	content, jerr := jsoncode.Marshal(docs)
 	// jerr should not be non-nil, but we don't care much on this,
 	// if non-nil, we just log without docs.
 	if jerr != nil {

--- a/core/stores/sqlc/cachedsql_test.go
+++ b/core/stores/sqlc/cachedsql_test.go
@@ -3,7 +3,6 @@ package sqlc
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +18,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/zeromicro/go-zero/core/fx"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stat"
 	"github.com/zeromicro/go-zero/core/stores/cache"
@@ -409,7 +409,7 @@ func TestCachedConnQueryRow(t *testing.T) {
 	actualValue, err := r.Get(key)
 	assert.Nil(t, err)
 	var actual string
-	assert.Nil(t, json.Unmarshal([]byte(actualValue), &actual))
+	assert.Nil(t, jsoncode.Unmarshal([]byte(actualValue), &actual))
 	assert.Equal(t, value, actual)
 	assert.Equal(t, value, user)
 	assert.True(t, ran)
@@ -436,7 +436,7 @@ func TestCachedConnQueryRowFromCache(t *testing.T) {
 	actualValue, err := r.Get(key)
 	assert.Nil(t, err)
 	var actual string
-	assert.Nil(t, json.Unmarshal([]byte(actualValue), &actual))
+	assert.Nil(t, jsoncode.Unmarshal([]byte(actualValue), &actual))
 	assert.Equal(t, value, actual)
 	assert.Equal(t, value, user)
 	assert.False(t, ran)

--- a/rest/httpx/requests_test.go
+++ b/rest/httpx/requests_test.go
@@ -2,7 +2,6 @@ package httpx
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"github.com/zeromicro/go-zero/rest/internal/header"
 	"github.com/zeromicro/go-zero/rest/pathvar"
 )
@@ -552,7 +552,7 @@ func TestParseJsonBody(t *testing.T) {
 		v1 := v{
 			Signature: []byte{0x01, 0xff, 0x00},
 		}
-		body, _ := json.Marshal(v1)
+		body, _ := jsoncode.Marshal(v1)
 		t.Logf("body:%s", string(body))
 		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
 		r.Header.Set(ContentType, header.ContentTypeJson)

--- a/rest/httpx/responses.go
+++ b/rest/httpx/responses.go
@@ -2,13 +2,13 @@ package httpx
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"sync"
 
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"github.com/zeromicro/go-zero/core/logc"
 	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/rest/internal/errcode"
@@ -173,7 +173,7 @@ func doHandleError(w http.ResponseWriter, err error, handler func(error) (int, a
 }
 
 func doWriteJson(w http.ResponseWriter, code int, v any) error {
-	bs, err := json.Marshal(v)
+	bs, err := jsoncode.Marshal(v)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return fmt.Errorf("marshal json failed, error: %w", err)

--- a/zrpc/internal/serverinterceptors/statinterceptor.go
+++ b/zrpc/internal/serverinterceptors/statinterceptor.go
@@ -2,11 +2,11 @@ package serverinterceptors
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
 	"time"
 
 	"github.com/zeromicro/go-zero/core/collection"
+	"github.com/zeromicro/go-zero/core/jsoncode"
 	"github.com/zeromicro/go-zero/core/lang"
 	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stat"
@@ -81,7 +81,7 @@ func logDuration(ctx context.Context, method string, req any, duration time.Dura
 			logger.Slowf("[RPC] slowcall - %s - %s", addr, method)
 		}
 	} else {
-		content, err := json.Marshal(req)
+		content, err := jsoncode.Marshal(req)
 		if err != nil {
 			logx.WithContext(ctx).Errorf("%s - %s", addr, err.Error())
 		} else if isSlow(duration, durationThreshold) {


### PR DESCRIPTION
During runtime profiling of the project, we observed significant latency in json.Marshal. This commit implements ​​swappable JSON marshaling/unmarshaling behaviors​​ that default to the standard library while allowing users to substitute custom implementations for optimized performance.