### PR TITLE
fix(marshaler): fix bug when marshal array

### DIFF
--- a/core/mapping/marshaler.go
+++ b/core/mapping/marshaler.go
@@ -142,7 +142,7 @@ func validateOptional(field reflect.StructField, value reflect.Value) error {
 		if value.IsNil() {
 			return fmt.Errorf("field %q is nil", field.Name)
 		}
-	case reflect.Array, reflect.Slice, reflect.Map:
+	case reflect.Slice, reflect.Map:
 		if value.IsNil() || value.Len() == 0 {
 			return fmt.Errorf("field %q is empty", field.Name)
 		}

--- a/core/mapping/marshaler_test.go
+++ b/core/mapping/marshaler_test.go
@@ -472,5 +472,5 @@ func TestMarshal_Array(t *testing.T) {
 
 	m, err := Marshal(v)
 	assert.Nil(t, err)
-	assert.Equal(t, "[1]", m["json"]["age"].(string))
+	assert.Equal(t, "[1]", m["json"]["h"].(string))
 }

--- a/core/mapping/marshaler_test.go
+++ b/core/mapping/marshaler_test.go
@@ -462,3 +462,15 @@ func TestMarshal_FromString(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "10", m["json"]["age"].(string))
 }
+
+func TestMarshal_Array(t *testing.T) {
+	v := struct {
+		H [1]int `json:"h,string"`
+	}{
+		H: [1]int{1},
+	}
+
+	m, err := Marshal(v)
+	assert.Nil(t, err)
+	assert.Equal(t, "[1]", m["json"]["age"].(string))
+}


### PR DESCRIPTION
if it is not optional in struct, it panics when do reflect on reflect.isNil, because array never be nullable.