### PR TITLE
Fix the issue of generating swagger @doc "xxx" that fails, and use th…

### DIFF
--- a/tools/goctl/api/swagger/annotation.go
+++ b/tools/goctl/api/swagger/annotation.go
@@ -69,3 +69,16 @@ func getListFromInfoOrDefault(properties map[string]string, key string, def []st
 	}
 	return resp
 }
+
+func getFirstUsableString(def ...string) string {
+	if len(def) == 0 {
+		return ""
+	}
+	for _, val := range def {
+		str := util.Unquote(val)
+		if len(str) != 0 {
+			return str
+		}
+	}
+	return ""
+}

--- a/tools/goctl/api/swagger/path.go
+++ b/tools/goctl/api/swagger/path.go
@@ -77,7 +77,7 @@ func spec2Path(info apiSpec.Info, group apiSpec.Group, route apiSpec.Route) spec
 			Produces:    getListFromInfoOrDefault(route.AtDoc.Properties, "produces", []string{applicationJson}),
 			Schemes:     getListFromInfoOrDefault(route.AtDoc.Properties, "schemes", []string{schemeHttps}),
 			Tags:        getListFromInfoOrDefault(group.Annotation.Properties, "tags", []string{""}),
-			Summary:     getStringFromKVOrDefault(route.AtDoc.Properties, "summary", ""),
+			Summary:     getStringFromKVOrDefault(route.AtDoc.Properties, "summary", getFirstUsableString(route.AtDoc.Text, route.Handler)),
 			Deprecated:  getBoolFromKVOrDefault(route.AtDoc.Properties, "deprecated", false),
 			Parameters:  parametersFromType(route.Method, route.RequestType),
 			Responses:   jsonResponseFromType(info, route.ResponseType),


### PR DESCRIPTION
Fix the issue of generating swagger `@doc "xxx"` that fails, and use the `handler` **name** as the default `summary`