### PR TITLE
[WIP] Draft: chore: add operation id for swagger

### DIFF
--- a/tools/goctl/api/swagger/const.go
+++ b/tools/goctl/api/swagger/const.go
@@ -56,6 +56,8 @@ const (
 	propertyKeyBasePath                = "basePath"
 	propertyKeyWrapCodeMsg             = "wrapCodeMsg"
 	propertyKeyBizCodeEnumDescription  = "bizCodeEnumDescription"
+	propertyKeyOperationId             = "operationId"
+	propertyKeyGroup                   = "group"
 )
 
 const (

--- a/tools/goctl/api/swagger/example/example.api
+++ b/tools/goctl/api/swagger/example/example.api
@@ -239,3 +239,63 @@ service Swagger {
 	post /json/complex (ComplexJsonReq) returns (ComplexJsonResp)
 }
 
+// @doc annotation examples
+
+
+@server(
+	tags: "doc"
+	summary: "doc API set"
+)
+service Swagger {
+	@doc (
+		description: "simple doc request body API"
+	)
+	@handler docSimple
+	post /doc/simple (DocSimpleReq) returns (DocSimpleResp)
+
+	@doc (
+		description: "replace operation id API"
+		operationId: "replace-operation-id"
+	)
+	@handler docReplaceOperationId
+	post /doc/replace-operation-id (DocReplaceOperationIdReq) returns (DocReplaceOperationIdResp)
+}
+
+type (
+	DocSimpleReq {
+		Id   int    `json:"id,example=10"`
+		Name string `json:"name,example=keson.an"`
+	}
+	DocSimpleResp {
+		Id   int    `json:"id,example=10"`
+		Name string `json:"name,example=keson.an"`
+	}
+	DocReplaceOperationIdReq {
+		Id   int    `json:"id,example=10"`
+		Name string `json:"name,example=keson.an"`
+	}
+	DocReplaceOperationIdResp {
+		Id   int    `json:"id,example=10"`
+		Name string `json:"name,example=keson.an"`
+	}
+)
+
+@server(
+	tags: "doc"
+	summary: "doc API set"
+	group: "doc"
+)
+service Swagger {
+	@doc (
+		description: "simple doc request body API"
+	)
+	@handler docSimpleWithGroup
+	post /doc/simple/group (DocSimpleReq) returns (DocSimpleResp)
+
+	@doc (
+		description: "replace operation id API"
+		operationId: "replace-operation-id-group"
+	)
+	@handler docReplaceOperationIdWithGroup
+	post /doc/replace-operation-id/group (DocReplaceOperationIdReq) returns (DocReplaceOperationIdResp)
+}

--- a/tools/goctl/api/swagger/example/example.swagger.json
+++ b/tools/goctl/api/swagger/example/example.swagger.json
@@ -6,6 +6,7 @@
     "application/json"
   ],
   "schemes": [
+    "http",
     "https"
   ],
   "swagger": "2.0",
@@ -27,6 +28,270 @@
   "host": "example.com",
   "basePath": "/v1",
   "paths": {
+    "/doc/replace-operation-id": {
+      "post": {
+        "description": "replace operation id API",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "doc"
+        ],
+        "summary": "docReplaceOperationId",
+        "operationId": "replace-operation-id",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "id",
+                "name"
+              ],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "example": 10
+                },
+                "name": {
+                  "type": "string",
+                  "example": "keson.an"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "description": "1001-User not login\u003cbr\u003e1002-User permission denied",
+                  "type": "integer",
+                  "example": 0
+                },
+                "data": {
+                  "$ref": "#/definitions/DocReplaceOperationIdResp"
+                },
+                "msg": {
+                  "description": "business message",
+                  "type": "string",
+                  "example": "ok"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/doc/replace-operation-id/group": {
+      "post": {
+        "description": "replace operation id API",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "doc"
+        ],
+        "summary": "docReplaceOperationIdWithGroup",
+        "operationId": "replace-operation-id-group",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "id",
+                "name"
+              ],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "example": 10
+                },
+                "name": {
+                  "type": "string",
+                  "example": "keson.an"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "description": "1001-User not login\u003cbr\u003e1002-User permission denied",
+                  "type": "integer",
+                  "example": 0
+                },
+                "data": {
+                  "$ref": "#/definitions/DocReplaceOperationIdResp"
+                },
+                "msg": {
+                  "description": "business message",
+                  "type": "string",
+                  "example": "ok"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/doc/simple": {
+      "post": {
+        "description": "simple doc request body API",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "doc"
+        ],
+        "summary": "docSimple",
+        "operationId": "docSimple",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "id",
+                "name"
+              ],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "example": 10
+                },
+                "name": {
+                  "type": "string",
+                  "example": "keson.an"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "description": "1001-User not login\u003cbr\u003e1002-User permission denied",
+                  "type": "integer",
+                  "example": 0
+                },
+                "data": {
+                  "$ref": "#/definitions/DocSimpleResp"
+                },
+                "msg": {
+                  "description": "business message",
+                  "type": "string",
+                  "example": "ok"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/doc/simple/group": {
+      "post": {
+        "description": "simple doc request body API",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "doc"
+        ],
+        "summary": "docSimpleWithGroup",
+        "operationId": "doc_docSimpleWithGroup",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "id",
+                "name"
+              ],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "example": 10
+                },
+                "name": {
+                  "type": "string",
+                  "example": "keson.an"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "description": "1001-User not login\u003cbr\u003e1002-User permission denied",
+                  "type": "integer",
+                  "example": 0
+                },
+                "data": {
+                  "$ref": "#/definitions/DocSimpleResp"
+                },
+                "msg": {
+                  "description": "business message",
+                  "type": "string",
+                  "example": "ok"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/form": {
       "post": {
         "description": "form demo",
@@ -43,6 +308,7 @@
           "form"
         ],
         "summary": "form",
+        "operationId": "form",
         "parameters": [
           {
             "maximum": 10000,
@@ -100,6 +366,7 @@
           "postJson"
         ],
         "summary": "jsonComplex",
+        "operationId": "jsonComplex",
         "parameters": [
           {
             "name": "body",
@@ -1579,6 +1846,7 @@
           "postJson"
         ],
         "summary": "jsonSimple",
+        "operationId": "jsonSimple",
         "parameters": [
           {
             "name": "body",
@@ -1672,6 +1940,7 @@
           "query"
         ],
         "summary": "query",
+        "operationId": "query",
         "parameters": [
           {
             "maximum": 10000,
@@ -1737,6 +2006,7 @@
           "query"
         ],
         "summary": "queryPath",
+        "operationId": "queryPath",
         "parameters": [
           {
             "maximum": 10000,
@@ -4794,6 +5064,74 @@
         }
       }
     },
+    "DocReplaceOperationIdReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "example": 10
+        },
+        "name": {
+          "type": "string",
+          "example": "keson.an"
+        }
+      }
+    },
+    "DocReplaceOperationIdResp": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "example": 10
+        },
+        "name": {
+          "type": "string",
+          "example": "keson.an"
+        }
+      }
+    },
+    "DocSimpleReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "example": 10
+        },
+        "name": {
+          "type": "string",
+          "example": "keson.an"
+        }
+      }
+    },
+    "DocSimpleResp": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "example": 10
+        },
+        "name": {
+          "type": "string",
+          "example": "keson.an"
+        }
+      }
+    },
     "FormReq": {
       "type": "object",
       "required": [
@@ -4972,7 +5310,7 @@
       "in": "header"
     }
   },
-  "x-date": "2025-05-10 21:16:52",
+  "x-date": "2025-05-17 12:41:13",
   "x-description": "This is a goctl generated swagger file.",
   "x-github": "https://github.com/zeromicro/go-zero",
   "x-go-zero-doc": "https://go-zero.dev/",

--- a/tools/goctl/api/swagger/operationid.go
+++ b/tools/goctl/api/swagger/operationid.go
@@ -1,0 +1,11 @@
+package swagger
+
+import "fmt"
+
+func generateDefaultOperationId(groupName string, handlerName string) string {
+	if groupName == "" {
+		return handlerName
+	}
+
+	return fmt.Sprintf("%s_%s", groupName, handlerName)
+}

--- a/tools/goctl/api/swagger/operationid_test.go
+++ b/tools/goctl/api/swagger/operationid_test.go
@@ -1,0 +1,30 @@
+package swagger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_generateDefaultOperationId(t *testing.T) {
+	testCases := []struct {
+		groupName   string
+		handlerName string
+		expected    string
+	}{
+		{
+			groupName:   "group",
+			handlerName: "handler",
+			expected:    "group_handler",
+		},
+		{
+			groupName:   "",
+			handlerName: "handler",
+			expected:    "handler",
+		},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.expected, generateDefaultOperationId(tc.groupName, tc.handlerName))
+	}
+}

--- a/tools/goctl/api/swagger/path.go
+++ b/tools/goctl/api/swagger/path.go
@@ -78,6 +78,7 @@ func spec2Path(ctx Context, group apiSpec.Group, route apiSpec.Route) spec.PathI
 			Schemes:     getListFromInfoOrDefault(route.AtDoc.Properties, propertyKeySchemes, []string{schemeHttps}),
 			Tags:        getListFromInfoOrDefault(group.Annotation.Properties, propertyKeyTags, getListFromInfoOrDefault(group.Annotation.Properties, propertyKeySummary, []string{})),
 			Summary:     getStringFromKVOrDefault(route.AtDoc.Properties, propertyKeySummary, getFirstUsableString(route.AtDoc.Text, route.Handler)),
+			ID:          getStringFromKVOrDefault(route.AtDoc.Properties, propertyKeyOperationId, generateDefaultOperationId(getListFromInfoOrDefault(group.Annotation.Properties, propertyKeyGroup, []string{""})[0], getFirstUsableString(route.AtDoc.Text, route.Handler))),
 			Deprecated:  getBoolFromKVOrDefault(route.AtDoc.Properties, propertyKeyDeprecated, false),
 			Parameters:  parametersFromType(ctx, route.Method, route.RequestType),
 			Responses:   jsonResponseFromType(ctx, route.AtDoc, route.ResponseType),


### PR DESCRIPTION
The operationId is a unique identifier for each API endpoint in OpenAPI/Swagger specifications. It is commonly used to distinguish individual operations and serves as a method name when generating server or client code using tools like OpenAPI Generator. Currently, the generated Swagger output in this project does not include operationId, which may reduce usability for developers relying on automated tooling. Adding operationId will improve compatibility with code generation tools and enhance clarity when managing or referencing API operations. 