### PR TITLE
goctl features of 1.8.4-alpha

### DIFF
--- a/tools/goctl/api/cmd.go
+++ b/tools/goctl/api/cmd.go
@@ -77,6 +77,7 @@ func init() {
 	goCmdFlags.StringVar(&gogen.VarStringRemote, "remote")
 	goCmdFlags.StringVar(&gogen.VarStringBranch, "branch")
 	goCmdFlags.BoolVar(&gogen.VarBoolWithTest, "test")
+	goCmdFlags.BoolVar(&gogen.VarBoolTypesGroup, "types-group")
 	goCmdFlags.StringVarWithDefaultValue(&gogen.VarStringStyle, "style", config.DefaultFormat)
 
 	javaCmdFlags.StringVar(&javagen.VarStringDir, "dir")

--- a/tools/goctl/api/gogen/gen.go
+++ b/tools/goctl/api/gogen/gen.go
@@ -40,6 +40,8 @@ var (
 	// VarStringStyle describes the style of output files.
 	VarStringStyle  string
 	VarBoolWithTest bool
+	// VarBoolTypesGroup describes whether to group types.
+	VarBoolTypesGroup bool
 )
 
 // GoCommand gen go project files from command line

--- a/tools/goctl/api/gogen/gentypes.go
+++ b/tools/goctl/api/gogen/gentypes.go
@@ -3,13 +3,13 @@ package gogen
 import (
 	_ "embed"
 	"fmt"
-	"github.com/zeromicro/go-zero/core/collection"
 	"io"
 	"os"
 	"path"
 	"sort"
 	"strings"
 
+	"github.com/zeromicro/go-zero/core/collection"
 	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
 	apiutil "github.com/zeromicro/go-zero/tools/goctl/api/util"
 	"github.com/zeromicro/go-zero/tools/goctl/config"

--- a/tools/goctl/api/swagger/parameter.go
+++ b/tools/goctl/api/swagger/parameter.go
@@ -46,7 +46,6 @@ func parametersFromType(method string, tp apiSpec.Type) []spec.Parameter {
 				SimpleSchema: spec.SimpleSchema{
 					Type:    sampleTypeFromGoType(member.Type),
 					Default: defValueFromOptions(headerTag.Options, member.Type),
-					Example: exampleValueFromOptions(headerTag.Options, member.Type),
 					Items:   sampleItemsFromGoType(member.Type),
 				},
 				ParamProps: spec.ParamProps{
@@ -70,7 +69,6 @@ func parametersFromType(method string, tp apiSpec.Type) []spec.Parameter {
 				SimpleSchema: spec.SimpleSchema{
 					Type:    sampleTypeFromGoType(member.Type),
 					Default: defValueFromOptions(pathParameterTag.Options, member.Type),
-					Example: exampleValueFromOptions(pathParameterTag.Options, member.Type),
 					Items:   sampleItemsFromGoType(member.Type),
 				},
 				ParamProps: spec.ParamProps{
@@ -95,7 +93,6 @@ func parametersFromType(method string, tp apiSpec.Type) []spec.Parameter {
 					SimpleSchema: spec.SimpleSchema{
 						Type:    sampleTypeFromGoType(member.Type),
 						Default: defValueFromOptions(formTag.Options, member.Type),
-						Example: exampleValueFromOptions(formTag.Options, member.Type),
 						Items:   sampleItemsFromGoType(member.Type),
 					},
 					ParamProps: spec.ParamProps{
@@ -118,7 +115,6 @@ func parametersFromType(method string, tp apiSpec.Type) []spec.Parameter {
 					SimpleSchema: spec.SimpleSchema{
 						Type:    sampleTypeFromGoType(member.Type),
 						Default: defValueFromOptions(formTag.Options, member.Type),
-						Example: exampleValueFromOptions(formTag.Options, member.Type),
 						Items:   sampleItemsFromGoType(member.Type),
 					},
 					ParamProps: spec.ParamProps{

--- a/tools/goctl/internal/flags/default_en.json
+++ b/tools/goctl/internal/flags/default_en.json
@@ -38,7 +38,8 @@
         "remote": "{{.global.remote}}",
         "branch": "{{.global.branch}}",
         "style": "{{.global.style}}",
-        "test": "Generate test files"
+        "test": "Generate test files",
+        "types-group": "Generate types group files"
       },
       "new": {
         "short": "Fast create api service",

--- a/tools/goctl/internal/version/version.go
+++ b/tools/goctl/internal/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // BuildVersion is the version of goctl.
-const BuildVersion = "1.8.4-beta"
+const BuildVersion = "1.8.4-alpha"
 
 var tag = map[string]int{"pre-alpha": 0, "alpha": 1, "pre-bata": 2, "beta": 3, "released": 4, "": 5}
 

--- a/tools/goctl/internal/version/version.go
+++ b/tools/goctl/internal/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // BuildVersion is the version of goctl.
-const BuildVersion = "1.8.3"
+const BuildVersion = "1.8.4-beta"
 
 var tag = map[string]int{"pre-alpha": 0, "alpha": 1, "pre-bata": 2, "beta": 3, "released": 4, "": 5}
 


### PR DESCRIPTION
1. [bug fix] remove example generation when request body are `query`, `path` and `header`
> it not supported in api spec 2.0
> it's will generate example when request body is json format.
2. [bug-fix] Add flag `--types-group` to control the output of types(deprecated: experimental switch control type grouping is no longer used), if true, the types in only one group will separate by file.
> example `goctl api go --api demo.api --dir demo --types-group`
>  use `group` keyword in @server block to define  the group name in api file, for example
```go
@server(
  group: user
)
service demo{
  ...
}
```
the example of separated types by file
```
.
└── types
    ├── common.go
    ├── gotoolexport.go
    ├── importfile.go
    ├── process.go
    └── types.go
```
