### PR TITLE
test(hash): modify TestConsistentHashTransferOnFailure to more reasonable test transfer ratio

### DIFF
--- a/core/hash/consistenthash_test.go
+++ b/core/hash/consistenthash_test.go
@@ -86,6 +86,14 @@ func TestConsistentHashIncrementalTransfer(t *testing.T) {
 
 func TestConsistentHashTransferOnFailure(t *testing.T) {
 	index := 41
+	ratioNotExists := getTransferRatioOnFailure(t, index)
+	assert.True(t, ratioNotExists == 0, fmt.Sprintf("%d: %f", index, ratioNotExists))
+	index = 13
+	ratio := getTransferRatioOnFailure(t, index)
+	assert.True(t, ratio < 2.5/keySize, fmt.Sprintf("%d: %f", index, ratio))
+}
+
+func getTransferRatioOnFailure(t *testing.T, index int) float32 {
 	keys, newKeys := getKeysBeforeAndAfterFailure(t, "localhost:", index)
 	var transferred int
 	for k, v := range newKeys {
@@ -93,14 +101,12 @@ func TestConsistentHashTransferOnFailure(t *testing.T) {
 			transferred++
 		}
 	}
-
-	ratio := float32(transferred) / float32(requestSize)
-	assert.True(t, ratio < 2.5/float32(keySize), fmt.Sprintf("%d: %f", index, ratio))
+	return float32(transferred) / float32(requestSize)
 }
 
 func TestConsistentHashLeastTransferOnFailure(t *testing.T) {
 	prefix := "localhost:"
-	index := 41
+	index := 13
 	keys, newKeys := getKeysBeforeAndAfterFailure(t, prefix, index)
 	for k, v := range keys {
 		newV := newKeys[k]


### PR DESCRIPTION
As I comprehend it, this UT `TestConsistentHashTransferOnFailure` aims to validate the transfer ratio of `ConsistentHash` when a physical node is taken offline, but the transferred count is always zero when given `index := 41`, because of the key size only has 20.

```go
const (
	keySize     = 20
	requestSize = 1000
)

func TestConsistentHashTransferOnFailure(t *testing.T) {
        // index 41 is not exists in ConsistentHash
	index := 41
	keys, newKeys := getKeysBeforeAndAfterFailure(t, "localhost:", index)
        // transferred is always 0
	var transferred int
	for k, v := range newKeys {
		if v != keys[k] {
			transferred++
		}
	}

	ratio := float32(transferred) / float32(requestSize)
	assert.True(t, ratio < 2.5/float32(keySize), fmt.Sprintf("%d: %f", index, ratio))
}

func getKeysBeforeAndAfterFailure(t *testing.T, prefix string, index int) (map[int]string, map[int]string) {
	ch := NewConsistentHash()
	for i := 0; i < keySize; i++ {
		ch.Add(prefix + strconv.Itoa(i))
	}
        // .......
}

```
