### PR TITLE
perf(hash): optimize Md5Hex encoding performance

### DIFF
--- a/core/hash/hash.go
+++ b/core/hash/hash.go
@@ -2,7 +2,7 @@ package hash
 
 import (
 	"crypto/md5"
-	"fmt"
+	"encoding/hex"
 
 	"github.com/spaolacci/murmur3"
 )
@@ -20,6 +20,7 @@ func Md5(data []byte) []byte {
 }
 
 // Md5Hex returns the md5 hex string of data.
+// This function is optimized for better performance than fmt.Sprintf.
 func Md5Hex(data []byte) string {
-	return fmt.Sprintf("%x", Md5(data))
+	return hex.EncodeToString(Md5(data))
 }


### PR DESCRIPTION
Replace fmt.Sprintf with hex.EncodeToString for better performance


Benchmark:
```go
// Simulate MD5 hash value (fixed 16 bytes)
var md5TestHash = []byte{
	0x5d, 0x41, 0x40, 0x2a, 0xbc, 0x4b, 0x2a, 0x76,
	0xb9, 0x71, 0x9d, 0x91, 0x10, 0x17, 0xc5, 0x92,
}


func BenchmarkHexEncode_Optimized(b *testing.B) {
	b.ResetTimer()
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		hex.EncodeToString(md5TestHash)
	}
}

func BenchmarkHexEncode_Sprintf(b *testing.B) {
	b.ResetTimer()
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		fmt.Sprintf("%x", md5TestHash)
	}
}
```



Benchmark | Iterations | Time per Operation | Memory Allocated | Allocations
-- | -- | -- | -- | --
BenchmarkHexEncode_Optimized-10 | 44772151 | 25.61 ns/op | 32 B/op | 1 allocs/op
BenchmarkHexEncode_Sprintf-10 | 15792062 | 74.95 ns/op | 56 B/op | 2 allocs/op




