### PR TITLE
feat: add Serve(w, r) to support serverless services like vercel

### DIFF
--- a/rest/server.go
+++ b/rest/server.go
@@ -95,6 +95,13 @@ func (s *Server) Routes() []Route {
 	return routes
 }
 
+// Serve is for serverless purpose.
+// Don't use it when using the Server in regular HTTP server mode.
+// see https://vercel.com/docs/functions/runtimes/go
+func (s *Server) Serve(w http.ResponseWriter, r *http.Request) {
+	s.router.ServeHTTP(w, r)
+}
+
 // Start starts the Server.
 // Graceful shutdown is enabled by default.
 // Use proc.SetTimeToForceQuit to customize the graceful shutdown period.

--- a/rest/server_test.go
+++ b/rest/server_test.go
@@ -819,6 +819,6 @@ func TestServerEmbedFileSystem(t *testing.T) {
 //	serve(server, w, r)
 //	// verify the response
 func serve(s *Server, w http.ResponseWriter, r *http.Request) {
-	s.ngin.bindRoutes(s.router)
-	s.router.ServeHTTP(w, r)
+	_ = s.ngin.bindRoutes(s.router)
+	s.Serve(w, r)
 }


### PR DESCRIPTION
fix #4892 

also, we need to avoid the problem mentioned in #4639 

see also https://vercel.com/docs/functions/runtimes/go