### PR TITLE
feat(goctl): generate mongo model with cache prefix

### DIFF
--- a/tools/goctl/internal/flags/default_en.json
+++ b/tools/goctl/internal/flags/default_en.json
@@ -206,6 +206,7 @@
         "short": "Generate mongo model",
         "type": "Specified model type name",
         "cache": "Generate code with cache [optional]",
+        "prefix": "Generate code with cache prefix [optional]",
         "easy": "Generate code with auto generated CollectionName for easy declare [optional]",
         "dir": "{{.goctl.model.dir}}",
         "style": "{{.global.style}}",

--- a/tools/goctl/model/cmd.go
+++ b/tools/goctl/model/cmd.go
@@ -62,6 +62,7 @@ func init() {
 
 	mongoCmdFlags.StringSliceVarP(&mongo.VarStringSliceType, "type", "t")
 	mongoCmdFlags.BoolVarP(&mongo.VarBoolCache, "cache", "c")
+	mongoCmdFlags.StringVarP(&mongo.VarStringPrefix, "prefix", "p")
 	mongoCmdFlags.BoolVarP(&mongo.VarBoolEasy, "easy", "e")
 	mongoCmdFlags.StringVarP(&mongo.VarStringDir, "dir", "d")
 	mongoCmdFlags.StringVar(&mongo.VarStringStyle, "style")

--- a/tools/goctl/model/mongo/generate/generate.go
+++ b/tools/goctl/model/mongo/generate/generate.go
@@ -17,6 +17,7 @@ import (
 type Context struct {
 	Types  []string
 	Cache  bool
+	Prefix string
 	Easy   bool
 	Output string
 	Cfg    *config.Config
@@ -60,6 +61,7 @@ func generateModel(ctx *Context) error {
 			"Type":      stringx.From(t).Title(),
 			"lowerType": stringx.From(t).Untitle(),
 			"Cache":     ctx.Cache,
+			"Prefix":    ctx.Prefix,
 			"version":   version.BuildVersion,
 		}, output, true); err != nil {
 			return err

--- a/tools/goctl/model/mongo/mongo.go
+++ b/tools/goctl/model/mongo/mongo.go
@@ -19,6 +19,8 @@ var (
 	VarStringDir string
 	// VarBoolCache describes whether cache is enabled.
 	VarBoolCache bool
+	// VarStringPrefix string describes the prefix for the cache key.
+	VarStringPrefix string
 	// VarBoolEasy  describes whether to generate Collection Name in the code for easy declare.
 	VarBoolEasy bool
 	// VarStringStyle describes the style.
@@ -35,6 +37,7 @@ var (
 func Action(_ *cobra.Command, _ []string) error {
 	tp := VarStringSliceType
 	c := VarBoolCache
+	p := VarStringPrefix
 	easy := VarBoolEasy
 	o := strings.TrimSpace(VarStringDir)
 	s := VarStringStyle
@@ -74,6 +77,7 @@ func Action(_ *cobra.Command, _ []string) error {
 	return generate.Do(&generate.Context{
 		Types:  tp,
 		Cache:  c,
+		Prefix: p,
 		Easy:   easy,
 		Output: a,
 		Cfg:    cfg,

--- a/tools/goctl/model/mongo/template/model.tpl
+++ b/tools/goctl/model/mongo/template/model.tpl
@@ -13,7 +13,7 @@ import (
     "go.mongodb.org/mongo-driver/mongo"
 )
 
-{{if .Cache}}var prefix{{.Type}}CacheKey = "cache:{{.lowerType}}:"{{end}}
+{{if .Cache}}var prefix{{.Type}}CacheKey = "{{if .Prefix}}{{.Prefix}}:{{end}}cache:{{.lowerType}}:"{{end}}
 
 type {{.lowerType}}Model interface{
     Insert(ctx context.Context,data *{{.Type}}) error


### PR DESCRIPTION
Support mongo model's cache prefix like the mysql model do.