### PR TITLE
fix: correct spelling of 'TimeoutHandler' in timeout handler comment

### DIFF
--- a/rest/handler/timeouthandler.go
+++ b/rest/handler/timeouthandler.go
@@ -106,7 +106,7 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case <-ctx.Done():
 		tw.mu.Lock()
 		defer tw.mu.Unlock()
-		// there isn't any user-defined middleware before TimoutHandler,
+		// there isn't any user-defined middleware before TimeoutHandler,
 		// so we can guarantee that cancelation in biz related code won't come here.
 		httpx.ErrorCtx(r.Context(), w, ctx.Err(), func(w http.ResponseWriter, err error) {
 			if errors.Is(err, context.Canceled) {


### PR DESCRIPTION
## 📝 Description

Fix a spelling error in the timeout handler comment where "TimoutHandler" is missing the 'e' and should be "TimeoutHandler".

## 🔧 Changes Made

- **File**: `rest/handler/timeouthandler.go`
- **Line**: 108
- **Change**: `TimoutHandler` → `TimeoutHandler`

## 📍 Location

```go
// Before
// there isn't any user-defined middleware before TimoutHandler,

// After
// there isn't any user-defined middleware before TimeoutHandler,
```

## 🎯 Type of Change

- [x] Bug fix (spelling correction)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Impact

- **Risk Level**: None (comment-only change)
- **Backward Compatibility**: ✅ Fully compatible
- **Performance Impact**: None
- **API Changes**: None

## 🧪 Testing

No functional testing required as this is a comment-only change. The spelling correction ensures the comment accurately references the `TimeoutHandler` function name.

## 📚 Additional Context

This change ensures consistency between the comment and the actual function name `TimeoutHandler`. Accurate documentation helps developers understand the middleware execution order and enhances code maintainability.