### PR TITLE
fix: correct spelling of 'underlying' in Header method comment

### DIFF
--- a/rest/handler/timeouthandler.go
+++ b/rest/handler/timeouthandler.go
@@ -151,7 +151,7 @@ func (tw *timeoutWriter) Flush() {
 	flusher.Flush()
 }
 
-// Header returns the underline temporary http.Header.
+// Header returns the underlying temporary http.Header.
 func (tw *timeoutWriter) Header() http.Header {
 	return tw.h
 }


### PR DESCRIPTION
## 📝 Description

Fix a spelling error in the `timeoutWriter.Header()` method comment where "underline" should be "underlying".

## 🔧 Changes Made

- **File**: `rest/handler/timeouthandler.go`
- **Line**: 153
- **Change**: `underline` → `underlying`

## 📍 Location

```go
// Before
// Header returns the underline temporary http.Header.

// After
// Header returns the underlying temporary http.Header.
```

## 🎯 Type of Change

- [x] Bug fix (spelling correction)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Impact

- **Risk Level**: None (comment-only change)
- **Backward Compatibility**: ✅ Fully compatible
- **Performance Impact**: None
- **API Changes**: None

## 🧪 Testing

No functional testing required as this is a comment-only change. The spelling correction improves the accuracy of the method documentation.

## 📚 Additional Context

The word "underlying" is the correct term in this context, as it refers to the base or foundational `http.Header` that the method returns. "Underline" would refer to a text formatting style, which is not applicable here.

This change improves API documentation clarity and helps developers better understand what the `Header()` method returns.