### PR TITLE
fix: the time.Duration type panics due to numerical values

### DIFF
--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -622,7 +622,11 @@ func (u *Unmarshaler) processFieldNotFromString(fieldType reflect.Type, value re
 
 		return u.fillSliceFromString(fieldType, value, mapValue, fullName)
 	case valueKind == reflect.String && derefedFieldType == durationType:
-		return fillDurationValue(fieldType, value, mapValue.(string))
+		v, ok := mapValue.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T, expected a string value for field %s", mapValue, fullName)
+		}
+		return fillDurationValue(fieldType, value, v)
 	case valueKind == reflect.String && typeKind == reflect.Struct && u.implementsUnmarshaler(fieldType):
 		return u.fillUnmarshalerStruct(fieldType, value, mapValue.(string))
 	default:

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/zeromicro/go-zero/core/jsonx"
 	"github.com/zeromicro/go-zero/core/stringx"
 )
@@ -201,6 +202,20 @@ func TestUnmarshalDuration(t *testing.T) {
 		assert.Equal(t, time.Hour, *in.PtrDuration)
 		assert.Equal(t, time.Hour*2, **in.PtrPtrDuration)
 	}
+}
+
+func TestUnmarshalDurationUnexpectedError(t *testing.T) {
+	type inner struct {
+		Duration time.Duration `key:"duration"`
+	}
+	content := "{\"duration\": 1}"
+	var m = map[string]any{}
+	err := jsonx.Unmarshal([]byte(content), &m)
+	assert.NoError(t, err)
+	var in inner
+	err = UnmarshalKey(m, &in)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected type")
 }
 
 func TestUnmarshalDurationDefault(t *testing.T) {


### PR DESCRIPTION
```
type inner struct {
	Duration time.Duration `json:"duration"`
}

func TestUnmarshalerPanic(t *testing.T) {
	content := `
{
	"duration": 1
}
`
	var in inner
	err := conf.LoadFromJsonBytes([]byte(content), &in) // panic here
	fmt.Println(in, err)
}

```
Panic before repair：

> // === RUN   TestUnmarshalerPanic
> //--- FAIL: TestUnmarshalerPanic (0.00s)
> //panic: interface conversion: interface {} is json.Number, not string [recovered]
> //	panic: interface conversion: interface {} is json.Number, not string

error after repair：

> === RUN   TestUnmarshalerPanic
> {0s} unexpected type json.Number, expected a string value for field duration
> --- PASS: TestUnmarshalerPanic (0.00s)
