### PR TITLE
feat(redis): added func `SetIgnoreCmds` to set breaker hook ignore cmds

### DIFF
--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -10,6 +10,7 @@ import (
 	red "github.com/redis/go-redis/v9"
 	"github.com/zeromicro/go-zero/core/breaker"
 	"github.com/zeromicro/go-zero/core/errorx"
+	"github.com/zeromicro/go-zero/core/lang"
 	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/mapping"
 	"github.com/zeromicro/go-zero/core/syncx"
@@ -33,6 +34,9 @@ var (
 	// ErrNilNode is an error that indicates a nil redis node.
 	ErrNilNode    = errors.New("nil redis node")
 	slowThreshold = syncx.ForAtomicDuration(defaultSlowThreshold)
+	ignoreCmds    = map[string]lang.PlaceholderType{
+		"blpop": {},
+	}
 )
 
 type (
@@ -2429,6 +2433,12 @@ func Cluster() Option {
 // SetSlowThreshold sets the slow threshold.
 func SetSlowThreshold(threshold time.Duration) {
 	slowThreshold.Set(threshold)
+}
+
+func SetIgnoreCmds(cmds ...string) {
+	for _, cmd := range cmds {
+		ignoreCmds[cmd] = lang.Placeholder
+	}
 }
 
 // WithHook customizes the given Redis with given durationHook.

--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -2024,6 +2024,15 @@ func TestSetSlowThreshold(t *testing.T) {
 	assert.Equal(t, time.Second, slowThreshold.Load())
 }
 
+func TestSetIgnoreCmds(t *testing.T) {
+	SetIgnoreCmds("hello")
+	_, ok := ignoreCmds["hello"]
+	assert.True(t, ok)
+
+	_, ok = ignoreCmds["client"]
+	assert.False(t, ok)
+}
+
 func TestRedis_WithUserPass(t *testing.T) {
 	runOnRedis(t, func(client *Redis) {
 		err := newRedis(client.Addr, WithUser("any"), WithPass("any")).Ping()


### PR DESCRIPTION
In order to be compatible with the lower version of redis, the missing commands caused the breaker to be triggered, such as `hello` and `client`

help to review, plz~ @kevwan 