### PR TITLE
fix(swagger): 修复POST JSON参数判断逻辑错误

### DIFF
--- a/tools/goctl/api/swagger/parameter.go
+++ b/tools/goctl/api/swagger/parameter.go
@@ -9,7 +9,7 @@ import (
 )
 
 func isPostJson(ctx Context, method string, tp apiSpec.Type) (string, bool) {
-	if strings.EqualFold(method, http.MethodPost) {
+	if !strings.EqualFold(method, http.MethodPost) {
 		return "", false
 	}
 	structType, ok := tp.(apiSpec.DefineStruct)


### PR DESCRIPTION
Fix the Swagger documentation generated when useDefinitions is set to true in the API file info. For POST type interfaces, although the parameter definitions are fully generated in the definitions, the parameters will be missing.