### PR TITLE
 A new logx property `CompressType` add in the logConf object for optimizing the compress type.

### DIFF
--- a/core/logx/config.go
+++ b/core/logx/config.go
@@ -24,7 +24,7 @@ type LogConf struct {
 	// Compress represents whether to compress the log file, default is `false`.
 	Compress bool `json:",optional"`
 	// CompressType represents whitch type to compress the log file, default is `.gz`.
-	CompressType string `json:",optional"`
+	CompressType string `json:",default=gz,options=[zip,tar]"`
 	// Stat represents whether to log statistics, default is `true`.
 	Stat bool `json:",default=true"`
 	// KeepDays represents how many days the log files will be kept. Default to keep all files.

--- a/core/logx/config.go
+++ b/core/logx/config.go
@@ -23,6 +23,8 @@ type LogConf struct {
 	MaxContentLength uint32 `json:",optional"`
 	// Compress represents whether to compress the log file, default is `false`.
 	Compress bool `json:",optional"`
+	// CompressType represents whitch type to compress the log file, default is `.gz`.
+	CompressType string `json:",optional"`
 	// Stat represents whether to log statistics, default is `true`.
 	Stat bool `json:",default=true"`
 	// KeepDays represents how many days the log files will be kept. Default to keep all files.

--- a/core/logx/rotatelogger.go
+++ b/core/logx/rotatelogger.go
@@ -22,8 +22,8 @@ const (
 	bufferSize      = 100
 	defaultDirMode  = 0o755
 	defaultFileMode = 0o600
-	gzipExt         = ".gz"
-	megaBytes       = 1 << 20
+	// gzipExt         = ".gz"
+	megaBytes = 1 << 20
 )
 
 var (
@@ -31,6 +31,8 @@ var (
 	ErrLogFileClosed = errors.New("error: log file closed")
 
 	fileTimeFormat = time.RFC3339
+
+	gzipExt = ".gz"
 )
 
 type (

--- a/core/logx/writer.go
+++ b/core/logx/writer.go
@@ -174,6 +174,13 @@ func newConsoleWriter() Writer {
 	}
 }
 
+var (
+	compress_type = map[string]bool{
+		"tar": true,
+		"zip": true,
+	}
+)
+
 func newFileWriter(c LogConf) (Writer, error) {
 	var err error
 	var opts []LogOption
@@ -190,7 +197,9 @@ func newFileWriter(c LogConf) (Writer, error) {
 
 	opts = append(opts, WithCooldownMillis(c.StackCooldownMillis))
 	if c.Compress {
-		gzipExt = c.CompressType
+		if compress_type[c.CompressType] {
+			gzipExt = fmt.Sprintf("%s%s", ".", c.CompressType)
+		}
 		opts = append(opts, WithGzip())
 	}
 	if c.KeepDays > 0 {

--- a/core/logx/writer.go
+++ b/core/logx/writer.go
@@ -190,6 +190,7 @@ func newFileWriter(c LogConf) (Writer, error) {
 
 	opts = append(opts, WithCooldownMillis(c.StackCooldownMillis))
 	if c.Compress {
+		gzipExt = c.CompressType
 		opts = append(opts, WithGzip())
 	}
 	if c.KeepDays > 0 {


### PR DESCRIPTION
// A LogConf is a logging config.
type LogConf struct {	
	// CompressType represents whitch type to compress the log file, default is `.gz`.
	CompressType string `json:",default=gz,options=[zip,tar]"`
}