### PR TITLE
fix: correct duration type comparison in environment variable processing

### DIFF
--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -766,8 +766,8 @@ func (u *Unmarshaler) processFieldWithEnvValue(fieldType reflect.Type, value ref
 	}
 
 	fieldKind := fieldType.Kind()
-	switch fieldKind {
-	case reflect.Bool:
+	switch true {
+	case fieldKind == reflect.Bool:
 		val, err := strconv.ParseBool(envVal)
 		if err != nil {
 			return fmt.Errorf("unmarshal field %q with environment variable, %w", fullName, err)
@@ -775,13 +775,13 @@ func (u *Unmarshaler) processFieldWithEnvValue(fieldType reflect.Type, value ref
 
 		value.SetBool(val)
 		return nil
-	case durationType.Kind():
+	case fieldType == durationType:
 		if err := fillDurationValue(fieldType, value, envVal); err != nil {
 			return fmt.Errorf("unmarshal field %q with environment variable, %w", fullName, err)
 		}
 
 		return nil
-	case reflect.String:
+	case fieldKind == reflect.String:
 		value.SetString(envVal)
 		return nil
 	default:

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -4679,6 +4679,23 @@ func TestUnmarshal_EnvInt(t *testing.T) {
 	}
 }
 
+func TestUnmarshal_EnvInt64(t *testing.T) {
+	type Value struct {
+		Age int64 `key:"age,env=TEST_NAME_INT64"`
+	}
+
+	const (
+		envName = "TEST_NAME_INT64"
+		envVal  = "88"
+	)
+	t.Setenv(envName, envVal)
+
+	var v Value
+	if assert.NoError(t, UnmarshalKey(emptyMap, &v)) {
+		assert.Equal(t, int64(88), v.Age)
+	}
+}
+
 func TestUnmarshal_EnvIntOverwrite(t *testing.T) {
 	type Value struct {
 		Age int `key:"age,env=TEST_NAME_INT"`


### PR DESCRIPTION
- Prevent confusion between duration and other int64 types in env var processing
- Add test case for int64 environment variable handling

This fixes a bug where duration fields could be incorrectly processed as regular int64 fields when using environment variables, leading to type mismatch errors.