### PR TITLE
fix: the file size inconsistencies after log files were rotated and compressed by size

### DIFF
--- a/core/logx/rotatelogger_test.go
+++ b/core/logx/rotatelogger_test.go
@@ -74,7 +74,8 @@ func TestDailyRotateRuleOutdatedFiles(t *testing.T) {
 func TestDailyRotateRuleShallRotate(t *testing.T) {
 	var rule DailyRotateRule
 	rule.rotatedTime = time.Now().Add(time.Hour * 24).Format(time.DateOnly)
-	assert.True(t, rule.ShallRotate(0))
+	i, _ := rule.ShallRotate(0, 0)
+	assert.True(t, i)
 }
 
 func TestSizeLimitRotateRuleMarkRotated(t *testing.T) {
@@ -179,10 +180,13 @@ func TestSizeLimitRotateRuleShallRotate(t *testing.T) {
 	var rule SizeLimitRotateRule
 	rule.rotatedTime = time.Now().Add(time.Hour * 24).Format(fileTimeFormat)
 	rule.maxSize = 0
-	assert.False(t, rule.ShallRotate(0))
+	i, _ := rule.ShallRotate(0, 0)
+	assert.False(t, i)
 	rule.maxSize = 100
-	assert.False(t, rule.ShallRotate(0))
-	assert.True(t, rule.ShallRotate(101*megaBytes))
+	i, _ = rule.ShallRotate(0, 0)
+	assert.False(t, i)
+	i, _ = rule.ShallRotate(101*megaBytes, 0)
+	assert.True(t, i)
 }
 
 func TestRotateLoggerClose(t *testing.T) {


### PR DESCRIPTION

When my service is configured according to the following logconfig, but the compressed file size is abnormal as the graph.
# Log 日志配置
    Log:
      Mode: file
      Compress: true 
      MaxSize: 200
      Rotation: size

![filesize](https://github.com/user-attachments/assets/2fad70ad-ebde-426b-bfed-c7d0073cfe01)
