### PR TITLE
delete: Delete the body limit of brief log because declare by not used.

### DIFF
--- a/rest/handler/loghandler.go
+++ b/rest/handler/loghandler.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	limitBodyBytes       = 1024
 	defaultSlowThreshold = time.Millisecond * 500
 )
 
@@ -36,11 +35,7 @@ func LogHandler(next http.Handler) http.Handler {
 		timer := utils.NewElapsedTimer()
 		logs := new(internal.LogCollector)
 		lrw := response.NewWithCodeResponseWriter(w)
-
-		var dup io.ReadCloser
-		r.Body, dup = iox.LimitDupReadCloser(r.Body, limitBodyBytes)
 		next.ServeHTTP(lrw, r.WithContext(internal.WithLogCollector(r.Context(), logs)))
-		r.Body = dup
 		logBrief(r, lrw.Code, timer, logs)
 	})
 }

--- a/rest/handler/loghandler_test.go
+++ b/rest/handler/loghandler_test.go
@@ -44,7 +44,7 @@ func TestLogHandler(t *testing.T) {
 
 func TestLogHandlerVeryLong(t *testing.T) {
 	var buf bytes.Buffer
-	for i := 0; i < limitBodyBytes<<1; i++ {
+	for i := 0; i < 1<<24; i++ {
 		buf.WriteByte('a')
 	}
 


### PR DESCRIPTION
delete: Delete the body limit of brief log because declare by not used.