### PR TITLE
feat: add OkHandler support in gateway EventHandler for HTTP responses

### DIFF
--- a/gateway/internal/eventhandler.go
+++ b/gateway/internal/eventhandler.go
@@ -1,20 +1,27 @@
 package internal
 
 import (
+	"bytes"
+	"context"
 	"io"
+	"net/http"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/zeromicro/go-zero/core/logx"
+	"github.com/zeromicro/go-zero/rest/httpx"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
 type EventHandler struct {
-	Status    *status.Status
-	writer    io.Writer
-	marshaler jsonpb.Marshaler
+	Status       *status.Status
+	writer       io.Writer
+	marshaler    jsonpb.Marshaler
+	ctx          context.Context
+	httpWriter   http.ResponseWriter
+	useOkHandler bool
 }
 
 func NewEventHandler(writer io.Writer, resolver jsonpb.AnyResolver) *EventHandler {
@@ -27,9 +34,36 @@ func NewEventHandler(writer io.Writer, resolver jsonpb.AnyResolver) *EventHandle
 	}
 }
 
+// NewEventHandlerWithContext creates an EventHandler that supports httpx.OkHandler callbacks
+func NewEventHandlerWithContext(ctx context.Context, w http.ResponseWriter, resolver jsonpb.AnyResolver) *EventHandler {
+	return &EventHandler{
+		writer: w,
+		marshaler: jsonpb.Marshaler{
+			EmitDefaults: true,
+			AnyResolver:  resolver,
+		},
+		ctx:          ctx,
+		httpWriter:   w,
+		useOkHandler: true,
+	}
+}
+
 func (h *EventHandler) OnReceiveResponse(message proto.Message) {
-	if err := h.marshaler.Marshal(h.writer, message); err != nil {
-		logx.Error(err)
+	if h.useOkHandler && h.httpWriter != nil {
+		// Use httpx.OkJsonCtx to trigger the OkHandler callback
+		var buf bytes.Buffer
+		if err := h.marshaler.Marshal(&buf, message); err != nil {
+			logx.Error(err)
+			return
+		}
+
+		result := buf.Bytes()
+		httpx.OkJsonCtx(h.ctx, h.httpWriter, result)
+	} else {
+		// Fallback to original behavior
+		if err := h.marshaler.Marshal(h.writer, message); err != nil {
+			logx.Error(err)
+		}
 	}
 }
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -121,7 +121,7 @@ func (s *Server) buildGrpcHandler(source grpcurl.DescriptorSource, resolver json
 		}
 
 		w.Header().Set(httpx.ContentType, httpx.JsonContentType)
-		handler := internal.NewEventHandler(w, resolver)
+		handler := internal.NewEventHandlerWithContext(r.Context(), w, resolver)
 		if err := grpcurl.InvokeRPC(r.Context(), source, cli.Conn(), rpcPath, s.prepareMetadata(r.Header),
 			handler, parser.Next); err != nil {
 			httpx.ErrorCtx(r.Context(), w, err)


### PR DESCRIPTION
背景:
我在使用gateway(http) -> grpc的过程中，发现httpx.SetOkHandler这个函数不生效， 目前的实现中没有设置勾子函数。此pr是为了让该函数生效。