### PR TITLE
fix(rest): change SSE SetWriteDeadline error log to debug level

### DIFF
--- a/rest/engine.go
+++ b/rest/engine.go
@@ -389,7 +389,9 @@ func buildSSERoutes(routes []Route) []Route {
 			// because SSE requires the connection to be kept alive indefinitely.
 			rc := http.NewResponseController(w)
 			if err := rc.SetWriteDeadline(time.Time{}); err != nil {
-				logc.Errorf(r.Context(), "set conn write deadline failed: %v", err)
+				// Some ResponseWriter implementations (like timeoutWriter) don't support SetWriteDeadline.
+				// This is expected behavior and doesn't affect SSE functionality.
+				logc.Debugf(r.Context(), "unable to clear write deadline for SSE connection: %v", err)
 			}
 
 			w.Header().Set(header.ContentType, header.ContentTypeEventStream)


### PR DESCRIPTION
https://github.com/zeromicro/go-zero/issues/5155
https://github.com/zeromicro/go-zero/issues/5094

When using rest.WithSSE() with timeout middleware enabled and clients not sending "Accept: text/event-stream" header,
so
https://github.com/zeromicro/go-zero/blob/master/rest/handler/timeouthandler.go#L63

SetWriteDeadline fails on timeoutWriter which doesn't implement the SetWriteDeadline interface.

This error is expected behavior and doesn't affect SSE functionality:
- SSE still works correctly without clearing write deadline
- timeoutWriter wraps ResponseWriter when timeout middleware is active
- Error occurs when clients don't set proper Accept header

The error should be logged at debug level instead of error level to
avoid confusing users who see "feature not supported" errors that
don't actually indicate a problem.
