### PR TITLE
fix: SSE handler blocking

### DIFF
--- a/tools/goctl/api/gogen/sse_handler.tpl
+++ b/tools/goctl/api/gogen/sse_handler.tpl
@@ -33,9 +33,7 @@ func {{.HandlerName}}(svcCtx *svc.ServiceContext) http.HandlerFunc {
 
         l := {{.LogicName}}.New{{.LogicType}}(r.Context(), svcCtx)
         threading.GoSafeCtx(r.Context(), func() {
-            defer func() {
-                close(client)
-            }()
+            defer close(client)
             err := l.{{.Call}}({{if .HasRequest}}&req, {{end}}client)
             if err != nil {
                 logc.Errorw(r.Context(), "{{.HandlerName}}", logc.Field("error", err))

--- a/tools/goctl/api/gogen/sse_handler.tpl
+++ b/tools/goctl/api/gogen/sse_handler.tpl
@@ -30,11 +30,12 @@ func {{.HandlerName}}(svcCtx *svc.ServiceContext) http.HandlerFunc {
         // w.Header().Set("Cache-Control", "no-cache")
         // w.Header().Set("Connection", "keep-alive")
 		client := make(chan {{.ResponseType}}, 16)
-        defer func() {
-            close(client)
-        }()
+
         l := {{.LogicName}}.New{{.LogicType}}(r.Context(), svcCtx)
         threading.GoSafeCtx(r.Context(), func() {
+            defer func() {
+                close(client)
+            }()
             err := l.{{.Call}}({{if .HasRequest}}&req, {{end}}client)
             if err != nil {
                 logc.Errorw(r.Context(), "{{.HandlerName}}", logc.Field("error", err))
@@ -44,7 +45,10 @@ func {{.HandlerName}}(svcCtx *svc.ServiceContext) http.HandlerFunc {
 
         for {
             select {
-            case data := <-client:
+            case data, ok := <-client:
+                if !ok {
+                    return
+                }
                 output, err := json.Marshal(data)
                 if err != nil {
                     logc.Errorw(r.Context(), "{{.HandlerName}}", logc.Field("error", err))


### PR DESCRIPTION
https://github.com/zeromicro/go-zero/issues/5182
https://github.com/zeromicro/go-zero/issues/5155
https://github.com/zeromicro/go-zero/issues/5094

1.  The `close(client)` call is placed in the top-level `http.HandlerFunc`'s `defer`, which means the channel is only closed when the entire HTTP request handler returns.
2.  The actual event generation (`l.{{.Call}}`) runs in a separate `threading.GoSafeCtx` goroutine. When this goroutine finishes sending all events, the `client` channel remains open because `close(client)` is not executed within its scope.
3.  The main `for` loop, which reads from the `client` channel, will then block indefinitely on `case data := <-client:` because it never receives a "closed" signal, even though no more events will be sent.
4.  Furthermore, the `case data := <-client:` lacks an `ok` check, which is a standard Go practice to detect if a channel has been closed, preventing unnecessary processing of zero values.

This results in:
-   **Goroutine Leak**: The main `for` loop goroutine remains active indefinitely, consuming resources, even after all events have been sent.
-   **Blocking Behavior**: SSE connections do not terminate gracefully after event completion, holding clients in a waiting state.