### PR TITLE
Feat/sse slow threshold

### DIFF
--- a/rest/handler/loghandler.go
+++ b/rest/handler/loghandler.go
@@ -24,12 +24,16 @@ import (
 )
 
 const (
-	limitBodyBytes         = 1024
-	limitDetailedBodyBytes = 4096
-	defaultSlowThreshold   = time.Millisecond * 500
+	limitBodyBytes          = 1024
+	limitDetailedBodyBytes  = 4096
+	defaultSlowThreshold    = time.Millisecond * 500
+	defaultSSESlowThreshold = time.Minute * 3
 )
 
-var slowThreshold = syncx.ForAtomicDuration(defaultSlowThreshold)
+var (
+	slowThreshold    = syncx.ForAtomicDuration(defaultSlowThreshold)
+	sseSlowThreshold = syncx.ForAtomicDuration(defaultSSESlowThreshold)
+)
 
 // LogHandler returns a middleware that logs http request and response.
 func LogHandler(next http.Handler) http.Handler {
@@ -109,6 +113,11 @@ func SetSlowThreshold(threshold time.Duration) {
 	slowThreshold.Set(threshold)
 }
 
+// SetSSESlowThreshold sets the slow threshold for SSE requests.
+func SetSSESlowThreshold(threshold time.Duration) {
+	sseSlowThreshold.Set(threshold)
+}
+
 func dumpRequest(r *http.Request) string {
 	reqContent, err := httputil.DumpRequest(r, true)
 	if err != nil {
@@ -129,7 +138,15 @@ func logBrief(r *http.Request, code int, timer *utils.ElapsedTimer, logs *intern
 	logger := logx.WithContext(r.Context()).WithDuration(duration)
 	buf.WriteString(fmt.Sprintf("[HTTP] %s - %s %s - %s - %s",
 		wrapStatusCode(code), wrapMethod(r.Method), r.RequestURI, httpx.GetRemoteAddr(r), r.UserAgent()))
-	if duration > slowThreshold.Load() {
+
+	var threshold time.Duration
+	if r.Header.Get(headerAccept) == valueSSE {
+		threshold = sseSlowThreshold.Load()
+	} else {
+		threshold = slowThreshold.Load()
+	}
+
+	if duration > threshold {
 		logger.Slowf("[HTTP] %s - %s %s - %s - %s - slowcall(%s)",
 			wrapStatusCode(code), wrapMethod(r.Method), r.RequestURI, httpx.GetRemoteAddr(r), r.UserAgent(),
 			timex.ReprOfDuration(duration))
@@ -160,7 +177,16 @@ func logDetails(r *http.Request, response *detailLoggedResponseWriter, timer *ut
 	logger := logx.WithContext(r.Context())
 	buf.WriteString(fmt.Sprintf("[HTTP] %s - %d - %s - %s\n=> %s\n",
 		r.Method, code, r.RemoteAddr, timex.ReprOfDuration(duration), dumpRequest(r)))
-	if duration > slowThreshold.Load() {
+
+	// Choose appropriate threshold based on request type
+	var threshold time.Duration
+	if r.Header.Get(headerAccept) == valueSSE {
+		threshold = sseSlowThreshold.Load()
+	} else {
+		threshold = slowThreshold.Load()
+	}
+
+	if duration > threshold {
 		logger.Slowf("[HTTP] %s - %d - %s - slowcall(%s)\n=> %s\n", r.Method, code, r.RemoteAddr,
 			timex.ReprOfDuration(duration), dumpRequest(r))
 	}

--- a/tools/goctl/api/gogen/sse_handler.tpl
+++ b/tools/goctl/api/gogen/sse_handler.tpl
@@ -30,11 +30,12 @@ func {{.HandlerName}}(svcCtx *svc.ServiceContext) http.HandlerFunc {
         // w.Header().Set("Cache-Control", "no-cache")
         // w.Header().Set("Connection", "keep-alive")
 		client := make(chan {{.ResponseType}}, 16)
-        defer func() {
-            close(client)
-        }()
+
         l := {{.LogicName}}.New{{.LogicType}}(r.Context(), svcCtx)
         threading.GoSafeCtx(r.Context(), func() {
+            defer func() {
+                close(client)
+            }()
             err := l.{{.Call}}({{if .HasRequest}}&req, {{end}}client)
             if err != nil {
                 logc.Errorw(r.Context(), "{{.HandlerName}}", logc.Field("error", err))
@@ -44,7 +45,10 @@ func {{.HandlerName}}(svcCtx *svc.ServiceContext) http.HandlerFunc {
 
         for {
             select {
-            case data := <-client:
+            case data, ok := <-client:
+                if !ok {
+                    return
+                }
                 output, err := json.Marshal(data)
                 if err != nil {
                     logc.Errorw(r.Context(), "{{.HandlerName}}", logc.Field("error", err))


### PR DESCRIPTION
SSE (Server-Sent Events) requests are incorrectly using the regular HTTP slow log threshold (500ms), causing numerous false positive slow request logs.