### PR TITLE
Fix api doc url in readme-cn.md

### DIFF
--- a/readme-cn.md
+++ b/readme-cn.md
@@ -175,7 +175,7 @@ GO111MODULE=on GOPROXY=https://goproxy.cn/,direct go get -u github.com/zeromicro
 
 * API 文档
 
-  [https://go-zero.dev/cn/](https://go-zero.dev/cn/)
+  [https://go-zero.dev](https://go-zero.dev)
 
 * awesome 系列（更多文章见『微服务实践』公众号）
 


### PR DESCRIPTION
**Describe the bug**
The API documentation link in the readme-cn.md file: https://go-zero.dev/cn/ is leading to a broken page.

**To Reproduce**
1. Open https://github.com/zeromicro/go-zero/blob/master/readme-cn.md

2. Click 【API 文档】https://go-zero.dev/cn/

**Expected behavior**
Redirect to the go-zero documentation homepage.

**Screenshots**
Not working doc url：
<img width="2448" height="1756" alt="Image" src="https://github.com/user-attachments/assets/d350f0fb-3a86-4d1e-8946-c286048fdc03" />

The expected documentation page：

<img width="2288" height="1720" alt="Image" src="https://github.com/user-attachments/assets/e3ff578f-4b82-44a5-87e6-b7bdf9231617" />

**Environments (please complete the following information):**
 - OS: windows 11
 - go-zero version: master
