### PR TITLE
fix(trace): use sync.Once to prevent multiple trace initialization

### DIFF
--- a/core/trace/agent.go
+++ b/core/trace/agent.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/zeromicro/go-zero/core/lang"
 	"github.com/zeromicro/go-zero/core/logx"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/jaeger"
@@ -30,41 +29,32 @@ const (
 )
 
 var (
-	agents = make(map[string]lang.PlaceholderType)
-	lock   sync.Mutex
-	tp     *sdktrace.TracerProvider
+	once sync.Once
+	tp   *sdktrace.TracerProvider
 )
 
 // StartAgent starts an opentelemetry agent.
+// It uses sync.Once to ensure the agent is initialized only once,
+// similar to prometheus.StartAgent and logx.SetUp.
+// This prevents multiple ServiceConf.SetUp() calls from reinitializing
+// the global tracer provider when running multiple servers (e.g., REST + RPC)
+// in the same process.
 func StartAgent(c Config) {
 	if c.Disabled {
 		return
 	}
 
-	lock.Lock()
-	defer lock.Unlock()
-
-	_, ok := agents[c.Endpoint]
-	if ok {
-		return
-	}
-
-	// if error happens, let later calls run.
-	if err := startAgent(c); err != nil {
-		return
-	}
-
-	agents[c.Endpoint] = lang.Placeholder
+	once.Do(func() {
+		if err := startAgent(c); err != nil {
+			logx.Error(err)
+		}
+	})
 }
 
 // StopAgent shuts down the span processors in the order they were registered.
 func StopAgent() {
-	lock.Lock()
-	defer lock.Unlock()
-
 	if tp != nil {
 		_ = tp.Shutdown(context.Background())
-		tp = nil
 	}
 }
 

--- a/core/trace/agent_test.go
+++ b/core/trace/agent_test.go
@@ -89,23 +89,8 @@ func TestStartAgent(t *testing.T) {
 	StartAgent(c10)
 	defer StopAgent()
 
-	lock.Lock()
-	defer lock.Unlock()
-
-	// because remotehost cannot be resolved
-	assert.Equal(t, 6, len(agents))
-	_, ok := agents[""]
-	assert.True(t, ok)
-	_, ok = agents[endpoint1]
-	assert.True(t, ok)
-	_, ok = agents[endpoint2]
-	assert.False(t, ok)
-	_, ok = agents[endpoint5]
-	assert.True(t, ok)
-	_, ok = agents[endpoint6]
-	assert.False(t, ok)
-	_, ok = agents[endpoint71]
-	assert.True(t, ok)
-	_, ok = agents[endpoint72]
-	assert.False(t, ok)
+	// With sync.Once, only the first non-disabled config (c1) takes effect.
+	// Subsequent calls are ignored, which is the desired behavior to prevent
+	// multiple servers (REST + RPC) from reinitializing the global tracer.
+	assert.NotNil(t, tp)
 }


### PR DESCRIPTION
Fixes #5242

Problem:
When running multiple servers (REST + RPC) with tracing enabled, the trace agent would reinitialize for each server with different endpoints, causing the global TracerProvider to be overwritten. Only the last configuration would take effect, and the first configuration was silently lost.

Root Cause:
The StartAgent function only prevented re-initialization when the exact same endpoint was used. If different endpoints were configured (common in multi-server setups), startAgent() would be called again, creating a new TracerProvider and overwriting the global one via otel.SetTracerProvider().

Solution:
Adopted the sync.Once pattern used by prometheus.StartAgent and logx.SetUp to ensure trace initialization happens only once. The first configuration wins, and subsequent calls are safely ignored.