### PR TITLE
feat(zrpc): change NonBlock default to true following gRPC best practices

### DIFF
--- a/zrpc/client.go
+++ b/zrpc/client.go
@@ -21,6 +21,9 @@ var (
 	WithDialOption = internal.WithDialOption
 	// WithNonBlock sets the dialing to be nonblock.
 	WithNonBlock = internal.WithNonBlock
+	// WithBlock sets the dialing to be blocking.
+	// Deprecated: blocking dials are not recommended by gRPC.
+	WithBlock = internal.WithBlock
 	// WithStreamClientInterceptor is an alias of internal.WithStreamClientInterceptor.
 	WithStreamClientInterceptor = internal.WithStreamClientInterceptor
 	// WithTimeout is an alias of internal.WithTimeout.
@@ -61,6 +64,8 @@ func NewClient(c RpcClientConf, options ...ClientOption) (Client, error) {
 	}
 	if c.NonBlock {
 		opts = append(opts, WithNonBlock())
+	} else {
+		opts = append(opts, WithBlock())
 	}
 	if c.Timeout > 0 {
 		opts = append(opts, WithTimeout(time.Duration(c.Timeout)*time.Millisecond))

--- a/zrpc/config.go
+++ b/zrpc/config.go
@@ -27,7 +27,7 @@ type (
 		Target        string          `json:",optional"`
 		App           string          `json:",optional"`
 		Token         string          `json:",optional"`
-		NonBlock      bool            `json:",optional"`
+		NonBlock      bool            `json:",default=true"`
 		Timeout       int64           `json:",default=2000"`
 		KeepaliveTime time.Duration   `json:",optional"`
 		Middlewares   ClientMiddlewaresConf

--- a/zrpc/internal/client.go
+++ b/zrpc/internal/client.go
@@ -141,6 +141,15 @@ func (c *client) dial(server string, opts ...ClientOption) error {
 	return nil
 }
 
+// WithBlock sets the dialing to be blocking.
+// Deprecated: blocking dials are not recommended by gRPC.
+// See https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md
+func WithBlock() ClientOption {
+	return func(options *ClientOptions) {
+		options.NonBlock = false
+	}
+}
+
 // WithDialOption returns a func to customize a ClientOptions with given dial option.
 func WithDialOption(opt grpc.DialOption) ClientOption {
 	return func(options *ClientOptions) {

--- a/zrpc/internal/client_test.go
+++ b/zrpc/internal/client_test.go
@@ -34,6 +34,13 @@ func TestWithNonBlock(t *testing.T) {
 	assert.True(t, options.NonBlock)
 }
 
+func TestWithBlock(t *testing.T) {
+	var options ClientOptions
+	opt := WithBlock()
+	opt(&options)
+	assert.False(t, options.NonBlock)
+}
+
 func TestWithStreamClientInterceptor(t *testing.T) {
 	var options ClientOptions
 	opt := WithStreamClientInterceptor(func(ctx context.Context, desc *grpc.StreamDesc,


### PR DESCRIPTION
Changes
- Changed RpcClientConf.NonBlock default from optional to true
- Added deprecated WithBlock() option for backward compatibility
- Updated client initialization to explicitly handle blocking/non-blocking
- Added test coverage for WithBlock functionality

According to gRPC anti-patterns documentation:
https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md
- grpc.WithBlock() is deprecated
- Non-blocking dials are recommended
- RPCs automatically wait for connection establishment

This change aligns go-zero with gRPC best practices while maintaining full backward compatibility through the WithBlock() option.