### PR TITLE
chore: fix grammar and typos in comments

### DIFF
--- a/core/bloom/bloom.go
+++ b/core/bloom/bloom.go
@@ -40,7 +40,7 @@ type (
 	}
 )
 
-// New create a Filter, store is the backed redis, key is the key for the bloom filter,
+// New creates a Filter, store is the backed redis, key is the key for the bloom filter,
 // bits is how many bits will be used, maps is how many hashes for each addition.
 // best practices:
 // elements - means how many actual elements

--- a/core/fx/stream.go
+++ b/core/fx/stream.go
@@ -168,7 +168,7 @@ func (s Stream) Count() (count int) {
 	return
 }
 
-// Distinct removes the duplicated items base on the given KeyFunc.
+// Distinct removes the duplicated items based on the given KeyFunc.
 func (s Stream) Distinct(fn KeyFunc) Stream {
 	source := make(chan any)
 
@@ -459,7 +459,7 @@ func (s Stream) Tail(n int64) Stream {
 	return Range(source)
 }
 
-// Walk lets the callers handle each item, the caller may write zero, one or more items base on the given item.
+// Walk lets the callers handle each item, the caller may write zero, one or more items based on the given item.
 func (s Stream) Walk(fn WalkFunc, opts ...Option) Stream {
 	option := buildOptions(opts...)
 	if option.unlimitedWorkers {

--- a/core/hash/consistenthash.go
+++ b/core/hash/consistenthash.go
@@ -96,7 +96,7 @@ func (h *ConsistentHash) AddWithWeight(node any, weight int) {
 	h.AddWithReplicas(node, replicas)
 }
 
-// Get returns the corresponding node from h base on the given v.
+// Get returns the corresponding node from h based on the given v.
 func (h *ConsistentHash) Get(v any) (any, bool) {
 	h.lock.RLock()
 	defer h.lock.RUnlock()

--- a/core/logx/rotatelogger.go
+++ b/core/logx/rotatelogger.go
@@ -66,7 +66,7 @@ type (
 		gzip        bool
 	}
 
-	// SizeLimitRotateRule a rotation rule that make the log file rotated base on size
+	// SizeLimitRotateRule a rotation rule that makes the log file rotated based on size
 	SizeLimitRotateRule struct {
 		DailyRotateRule
 		maxSize    int64

--- a/core/mathx/unstable.go
+++ b/core/mathx/unstable.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// An Unstable is used to generate random value around the mean value base on given deviation.
+// An Unstable is used to generate random value around the mean value based on given deviation.
 type Unstable struct {
 	deviation float64
 	r         *rand.Rand

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -43,7 +43,7 @@ func AddProbe(probe Probe) {
 	defaultHealthManager.addProbe(probe)
 }
 
-// CreateHttpHandler create health http handler base on given probe.
+// CreateHttpHandler creates a health http handler based on the given probe.
 func CreateHttpHandler(healthResponse string) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		if defaultHealthManager.IsReady() {

--- a/tools/goctl/api/docgen/gen.go
+++ b/tools/goctl/api/docgen/gen.go
@@ -36,7 +36,7 @@ func DocCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	if !pathx.FileExists(dir) {
-		return fmt.Errorf("dir %s not exsit", dir)
+		return fmt.Errorf("dir %s not exist", dir)
 	}
 
 	dir, err := filepath.Abs(dir)

--- a/tools/goctl/change.md
+++ b/tools/goctl/change.md
@@ -11,7 +11,7 @@
 ## swagger
 1. [bug fix] remove example generation when request body are `query`, `path` and `header`
 - it not supported in api spec 2.0
-- it's will generate example when request body is json format.
+- it will generate example when request body is json format.
 2. [features] swagger generation supported definitions
 - supported response definitions
 - supported json request body definitions


### PR DESCRIPTION
Fixes grammatical errors in code comments and documentation:

  - **"base on" → "based on"** (6 occurrences) - Correct passive voice requires past participle
  - **"create" → "creates"** (2 occurrences) - Go doc comments should use third-person singular for functions
  - **"it's will" → "it will"** - "it's" is contraction of "it is", incompatible with "will"
  - **"exsit" → "exist"** - Typo correction