### PR TITLE
fix(logx): add missing color for levelSevere in wrapLevelWithColor

### DIFF
--- a/core/logx/writer.go
+++ b/core/logx/writer.go
@@ -444,6 +444,8 @@ func wrapLevelWithColor(level string) string {
 		colour = color.FgRed
 	case levelError:
 		colour = color.FgRed
+	case levelSevere:
+		colour = color.FgRed
 	case levelFatal:
 		colour = color.FgRed
 	case levelInfo:


### PR DESCRIPTION
Fix missing color handling for `levelSevere` in the `wrapLevelWithColor` function.