### PR TITLE
Fix Grammar and Typo in Comments

### DIFF
--- a/rest/router/patrouter.go
+++ b/rest/router/patrouter.go
@@ -19,7 +19,7 @@ const (
 var (
 	// ErrInvalidMethod is an error that indicates not a valid http method.
 	ErrInvalidMethod = errors.New("not a valid http method")
-	// ErrInvalidPath is an error that indicates path is not start with /.
+	// ErrInvalidPath is an error that indicates path does not start with /.
 	ErrInvalidPath = errors.New("path must begin with '/'")
 )
 

--- a/tools/goctl/api/dartgen/vars.go
+++ b/tools/goctl/api/dartgen/vars.go
@@ -132,7 +132,7 @@ Future _apiRequest(String method, String path, dynamic data,
 	/// data: any request class that will be converted to json automatically
 	/// ok: is called when request succeeds
 	/// fail: is called when request fails
-	/// eventually: is always called until the nearby functions returns
+	/// eventually: is always called after the nearby function returns
 	Future apiPost(String path, dynamic data,
 			{Map<String, String>? header,
 			Function(Map<String, dynamic>)? ok,
@@ -146,7 +146,7 @@ Future _apiRequest(String method, String path, dynamic data,
 	///
 	/// ok: is called when request succeeds
 	/// fail: is called when request fails
-	/// eventually: is always called until the nearby functions returns
+	/// eventually: is always called after the nearby function returns
 	Future apiGet(String path,
 			{Map<String, String>? header,
 			Function(Map<String, dynamic>)? ok,

--- a/tools/goctl/api/parser/g4/ast/apiparser.go
+++ b/tools/goctl/api/parser/g4/ast/apiparser.go
@@ -28,7 +28,7 @@ type (
 		syntax                   *SyntaxExpr
 	}
 
-	// ParserOption defines an function with argument Parser
+	// ParserOption defines a function with argument Parser
 	ParserOption func(p *Parser)
 )
 


### PR DESCRIPTION
Fixes grammatical errors and typos in code comments:
- "path is not start" → "path does not start"  - Corrects syntax and logic in error comment
- "until" → "after"- Corrects execution timing description
- "functions" → "function" - Fixes noun number agreement
- "an" → "a"  - Fixes article usage for consonant-starting word
