### PR TITLE
fix(test): correct log suppression in panic recovery tests

### DIFF
--- a/core/fx/stream_test.go
+++ b/core/fx/stream_test.go
@@ -1,7 +1,6 @@
 package fx
 
 import (
-	"io"
 	"math/rand"
 	"reflect"
 	"runtime"
@@ -12,7 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/zeromicro/go-zero/core/logx"
+	"github.com/zeromicro/go-zero/core/logx/logtest"
 	"github.com/zeromicro/go-zero/core/stringx"
 	"go.uber.org/goleak"
 )
@@ -238,7 +237,7 @@ func TestLast(t *testing.T) {
 
 func TestMap(t *testing.T) {
 	runCheckedTest(t, func(t *testing.T) {
-		logx.SetWriter(logx.NewWriter(io.Discard))
+		logtest.Discard(t)
 
 		tests := []struct {
 			mapper MapFunc

--- a/core/mr/mapreduce_test.go
+++ b/core/mr/mapreduce_test.go
@@ -4,22 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/zeromicro/go-zero/core/logx"
 	"go.uber.org/goleak"
 )
 
 var errDummy = errors.New("dummy")
 
-func init() {
-	logx.SetWriter(logx.NewWriter(io.Discard))
-}
 
 func TestFinish(t *testing.T) {
 	defer goleak.VerifyNone(t)

--- a/core/threading/routinegroup_test.go
+++ b/core/threading/routinegroup_test.go
@@ -1,13 +1,12 @@
 package threading
 
 import (
-	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/zeromicro/go-zero/core/logx"
+	"github.com/zeromicro/go-zero/core/logx/logtest"
 )
 
 func TestRoutineGroupRun(t *testing.T) {
@@ -25,7 +24,7 @@ func TestRoutineGroupRun(t *testing.T) {
 }
 
 func TestRoutingGroupRunSafe(t *testing.T) {
-	logx.SetWriter(logx.NewWriter(io.Discard))
+	logtest.Discard(t)
 	var count int32
 	group := NewRoutineGroup()
 	var once sync.Once

--- a/core/threading/routines_test.go
+++ b/core/threading/routines_test.go
@@ -3,12 +3,12 @@ package threading
 import (
 	"bytes"
 	"context"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zeromicro/go-zero/core/lang"
 	"github.com/zeromicro/go-zero/core/logx"
+	"github.com/zeromicro/go-zero/core/logx/logtest"
 )
 
 func TestRoutineId(t *testing.T) {
@@ -16,7 +16,7 @@ func TestRoutineId(t *testing.T) {
 }
 
 func TestRunSafe(t *testing.T) {
-	logx.SetWriter(logx.NewWriter(io.Discard))
+	logtest.Discard(t)
 
 	i := 0
 


### PR DESCRIPTION
fix #5300 
Replace log.SetOutput(io.Discard) with logx.SetWriter(logx.NewWriter(io.Discard))
