### PR TITLE
 Fix typos and grammar in comments

### DIFF
--- a/rest/handler/tracehandler.go
+++ b/rest/handler/tracehandler.go
@@ -13,7 +13,7 @@ import (
 )
 
 type (
-	// TraceOption defines the method to customize an traceOptions.
+	// TraceOption defines the method to customize a traceOptions.
 	TraceOption func(options *traceOptions)
 
 	// traceOptions is TraceHandler options.


### PR DESCRIPTION
Fixes three issues in comments and error messages:

  - `an traceOptions` → `a traceOptions` (consonant sound requires "a")
  - `comamnd` → `command` (typo)
  - `unsupport` → `unsupported` (grammatically incorrect)