### PR TITLE
fix(zrpc): fix slow threshold priority in stat interceptor

### DIFF
--- a/zrpc/internal/serverinterceptors/statinterceptor.go
+++ b/zrpc/internal/serverinterceptors/statinterceptor.go
@@ -63,8 +63,12 @@ func UnaryStatInterceptor(metrics *stat.Metrics, conf StatConf) grpc.UnaryServer
 }
 
 func isSlow(duration, durationThreshold time.Duration) bool {
-	return duration > slowThreshold.Load() ||
-		(durationThreshold > 0 && duration > durationThreshold)
+	// Prioritize explicit config over global setting
+	if durationThreshold > 0 {
+		return duration > durationThreshold
+	}
+
+	return duration > slowThreshold.Load()
 }
 
 func logDuration(ctx context.Context, method string, req any, duration time.Duration,

--- a/zrpc/internal/serverinterceptors/statinterceptor_test.go
+++ b/zrpc/internal/serverinterceptors/statinterceptor_test.go
@@ -252,6 +252,15 @@ func Test_isSlow(t *testing.T) {
 				SetSlowThreshold(time.Millisecond * 100)
 			},
 		},
+		{
+			"config_priority_fix",
+			args{
+				duration:            time.Millisecond * 600,
+				staticSlowThreshold: time.Millisecond * 1000,
+			},
+			false,
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fix #5306 

