### PR TITLE
perf(mapping): use strings.EqualFold to optimize bool parsing

### DIFF
--- a/core/mapping/utils.go
+++ b/core/mapping/utils.go
@@ -104,14 +104,13 @@ func convertToString(val any, fullName string) (string, error) {
 func convertTypeFromString(kind reflect.Kind, str string) (any, error) {
 	switch kind {
 	case reflect.Bool:
-		switch strings.ToLower(str) {
-		case "1", "true":
+		if str == "1" || strings.EqualFold(str, "true") {
 			return true, nil
-		case "0", "false":
-			return false, nil
-		default:
-			return false, errTypeMismatch
 		}
+		if str == "0" || strings.EqualFold(str, "false") {
+			return false, nil
+		}
+		return false, errTypeMismatch
 	case reflect.Int:
 		return strconv.ParseInt(str, 10, intSize)
 	case reflect.Int8:

--- a/core/mapping/utils_test.go
+++ b/core/mapping/utils_test.go
@@ -334,3 +334,43 @@ func TestValidateValueRange(t *testing.T) {
 func TestSetMatchedPrimitiveValue(t *testing.T) {
 	assert.Error(t, setMatchedPrimitiveValue(reflect.Func, reflect.ValueOf(2), "1"))
 }
+
+func TestConvertTypeFromString_Bool(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    bool
+		wantErr bool
+	}{
+		// true cases
+		{name: "1", input: "1", want: true, wantErr: false},
+		{name: "true lowercase", input: "true", want: true, wantErr: false},
+		{name: "True mixed", input: "True", want: true, wantErr: false},
+		{name: "TRUE uppercase", input: "TRUE", want: true, wantErr: false},
+		{name: "TrUe mixed", input: "TrUe", want: true, wantErr: false},
+		// false cases
+		{name: "0", input: "0", want: false, wantErr: false},
+		{name: "false lowercase", input: "false", want: false, wantErr: false},
+		{name: "False mixed", input: "False", want: false, wantErr: false},
+		{name: "FALSE uppercase", input: "FALSE", want: false, wantErr: false},
+		{name: "FaLsE mixed", input: "FaLsE", want: false, wantErr: false},
+		// error cases
+		{name: "invalid yes", input: "yes", want: false, wantErr: true},
+		{name: "invalid no", input: "no", want: false, wantErr: true},
+		{name: "invalid empty", input: "", want: false, wantErr: true},
+		{name: "invalid 2", input: "2", want: false, wantErr: true},
+		{name: "invalid truee", input: "truee", want: false, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertTypeFromString(reflect.Bool, tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replace strings.ToLower with strings.EqualFold in convertTypeFromString
for bool type conversion to reduce memory allocation.

Benchmark results:
<img width="888" height="274" alt="image" src="https://github.com/user-attachments/assets/485033d7-374b-4e90-b512-50158320f838" />

Benchmark code
```go 
func parseBoolToLower(str string) (bool, error) {
	switch strings.ToLower(str) {
	case "1", "true":
		return true, nil
	case "0", "false":
		return false, nil
	default:
		return false, errTypeMismatch
	}
}

func parseBoolEqualFold(str string) (bool, error) {
	if str == "1" || strings.EqualFold(str, "true") {
		return true, nil
	}
	if str == "0" || strings.EqualFold(str, "false") {
		return false, nil
	}
	return false, errTypeMismatch
}

func BenchmarkBoolParseToLower(b *testing.B) {
	testCases := []string{"true", "True", "TRUE", "false", "False", "FALSE", "1", "0"}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		str := testCases[i%len(testCases)]
		_, _ = parseBoolToLower(str)
	}
}

func BenchmarkBoolParseEqualFold(b *testing.B) {
	testCases := []string{"true", "True", "TRUE", "false", "False", "FALSE", "1", "0"}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		str := testCases[i%len(testCases)]
		_, _ = parseBoolEqualFold(str)
	}
}
```


