### PR TITLE
perf(config): optimize getfullname

### DIFF
--- a/core/conf/config.go
+++ b/core/conf/config.go
@@ -368,5 +368,5 @@ func getFullName(parent, child string) string {
 		return child
 	}
 
-	return strings.Join([]string{parent, child}, ".")
+	return parent + "." + child
 }

--- a/core/conf/config_test.go
+++ b/core/conf/config_test.go
@@ -1377,3 +1377,23 @@ func (m mockConfig) Validate() error {
 
 	return nil
 }
+
+func TestGetFullName(t *testing.T) {
+	tests := []struct {
+		parent string
+		child  string
+		want   string
+	}{
+		{"", "child", "child"},
+		{"parent", "child", "parent.child"},
+		{"a.b", "c", "a.b.c"},
+		{"root", "nested.field", "root.nested.field"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.parent+"."+tt.child, func(t *testing.T) {
+			got := getFullName(tt.parent, tt.child)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
optimize getFullName with string concatenation
Use direct string concatenation instead of strings.Join to avoid temporary slice allocation.

Benchmark
<img width="1110" height="442" alt="image" src="https://github.com/user-attachments/assets/2f2042b9-3290-4a13-894a-38ddd9e3a545" />

benchmark code
```go

// getFullNameOld is the original implementation using strings.Join for benchmark comparison.
func getFullNameOld(parent, child string) string {
	if len(parent) == 0 {
		return child
	}

	return strings.Join([]string{parent, child}, ".")
}

func BenchmarkGetFullName(b *testing.B) {
	b.Run("StringConcat", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			_ = getFullName("parent", "child")
		}
	})

	b.Run("StringsJoin", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			_ = getFullNameOld("parent", "child")
		}
	})
}

func BenchmarkGetFullNameLongStrings(b *testing.B) {
	parent := "very.long.parent.path.with.multiple.segments"
	child := "another.long.child.path"

	b.Run("StringConcat", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			_ = getFullName(parent, child)
		}
	})

	b.Run("StringsJoin", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			_ = getFullNameOld(parent, child)
		}
	})
}
```
