### PR TITLE
rpc service use proto.Package.Name by support multi proto file

### DIFF
--- a/tools/goctl/rpc/generator/mkdir.go
+++ b/tools/goctl/rpc/generator/mkdir.go
@@ -199,7 +199,7 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 			return nil, err
 		}
 	}
-	serviceName := strings.TrimSuffix(proto.Name, filepath.Ext(proto.Name))
+	serviceName := proto.Package.Name
 	return &defaultDirContext{
 		ctx:         ctx,
 		inner:       inner,


### PR DESCRIPTION
[proto-split-guide_CN.md](https://github.com/user-attachments/files/24763052/proto-split-guide_CN.md)
[build.sh](https://github.com/user-attachments/files/24763079/build.sh)
<img width="850" height="205" alt="image" src="https://github.com/user-attachments/assets/c84b3f86-c348-4720-b637-f4b0b0e98463" />
通过修改服务命名取的地方就可以在一个rpc里使用多个Porto了,skills也放到上面了,编译的时候使用build.sh,win下可以使用git bash,build.sh 目前是通过ai来生成, 独立之后从一个服务一个proto最多2600多行,ai改不动,到拆分后最复杂的659行,ai根据需要去看文件即可,极大的降低了ai的压力和token的消耗