### PR TITLE
feat(gateway): export WithDialer option for custom gRPC client configuration

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -329,8 +329,9 @@ func createDescriptorSource(cli zrpc.Client, up Upstream) (grpcurl.DescriptorSou
 	return source, nil
 }
 
-// withDialer sets a dialer to create a gRPC client.
-func withDialer(dialer func(conf zrpc.RpcClientConf) zrpc.Client) func(*Server) {
+// WithDialer sets a dialer to create a gRPC client.
+// This allows customization of gRPC client options, such as message size limits.
+func WithDialer(dialer func(conf zrpc.RpcClientConf) zrpc.Client) func(*Server) {
 	return func(s *Server) {
 		s.dialer = dialer
 	}

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -54,7 +54,7 @@ func TestMustNewServer(t *testing.T) {
 	c.Host = "localhost"
 	c.Port = 18881
 
-	s := MustNewServer(c, withDialer(func(conf zrpc.RpcClientConf) zrpc.Client {
+	s := MustNewServer(c, WithDialer(func(conf zrpc.RpcClientConf) zrpc.Client {
 		return zrpc.MustNewClient(conf, zrpc.WithDialOption(grpc.WithContextDialer(dialer())))
 	}), WithHeaderProcessor(func(header http.Header) []string {
 		return []string{"foo"}


### PR DESCRIPTION
Fixes #5404

## Summary

Export the previously internal `withDialer` function as `WithDialer` to allow users to customize gRPC client options when creating gateway servers.

## Problem

Users reported encountering gRPC message size limit errors when using the gateway with messages larger than 4MB (the default limit):

```
rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4404186 vs. 4194304)
```

Previously, there was no way to customize gRPC dial options for the gateway's internal gRPC client without modifying the framework code.

## Solution

Export the `withDialer` function as `WithDialer`, allowing users to provide custom gRPC client configurations:

```go
s := gateway.MustNewServer(c, 
    gateway.WithDialer(func(conf zrpc.RpcClientConf) zrpc.Client {
        return zrpc.MustNewClient(conf,
            zrpc.WithDialOption(grpc.MaxCallRecvMsgSize(50*1024*1024)),
            zrpc.WithDialOption(grpc.MaxCallSendMsgSize(50*1024*1024)),
        )
    }),
)
```

## Changes

- Renamed `withDialer` to `WithDialer` (exported)
- Added comprehensive documentation explaining the use case
- Updated test to use the exported function

## Breaking Changes

None - this was an internal function, so exporting it doesn't break any existing usage.

## Testing

- Existing tests pass with the exported function
- Verified compilation and test execution