### PR TITLE
Support wildcard prefix pattern (*.example.com) for allowed origins

### DIFF
--- a/rest/internal/cors/handlers.go
+++ b/rest/internal/cors/handlers.go
@@ -94,6 +94,15 @@ func isOriginAllowed(allows []string, origin string) bool {
 			return true
 		}
 
+		// Support wildcard prefix pattern like "*.example.com"
+		if strings.HasPrefix(allow, "*.") {
+			suffix := allow[1:] // Get ".example.com" from "*.example.com"
+			if strings.HasSuffix(origin, suffix) {
+				return true
+			}
+			continue
+		}
+
 		if strings.HasSuffix(origin, "."+allow) {
 			return true
 		}

--- a/rest/internal/cors/handlers_test.go
+++ b/rest/internal/cors/handlers_test.go
@@ -127,6 +127,29 @@ func TestCorsHandlerWithOrigins(t *testing.T) {
 			origins:   []string{"safe.com"},
 			reqOrigin: "not-safe.com",
 		},
+		{
+			name:      "allow wildcard prefix pattern",
+			origins:   []string{"*.example.com"},
+			reqOrigin: "sub.example.com",
+			expect:    "sub.example.com",
+		},
+		{
+			name:      "allow wildcard prefix pattern with deep subdomain",
+			origins:   []string{"*.example.com"},
+			reqOrigin: "deep.sub.example.com",
+			expect:    "deep.sub.example.com",
+		},
+		{
+			name:      "wildcard prefix pattern not matching root domain",
+			origins:   []string{"*.example.com"},
+			reqOrigin: "example.com",
+		},
+		{
+			name:      "wildcard prefix pattern case insensitive",
+			origins:   []string{"*.Example.COM"},
+			reqOrigin: "SUB.example.com",
+			expect:    "SUB.example.com",
+		},
 	}
 
 	methods := []string{


### PR DESCRIPTION
Add support for wildcard prefix patterns like *.example.com in CORS origin configuration. This allows matching any subdomain of a domain using explicit wildcard syntax.

The current CORS implementation supports subdomain suffix matching (e.g., example.com matches sub.example.com), but lacks explicit wildcard syntax that is commonly used in production CORS configurations across other frameworks (nginx, Express.js, etc.).

Users expect *.example.com syntax to work as it's an industry-standard pattern for CORS configuration.

This provides more precise control over allowed origins:

- *.example.com → matches api.example.com, app.example.com, dev.api.example.com
- *.example.com → does NOT match example.com (root domain excluded)
- Case-insensitive matching