### PR TITLE
perf(core/stringx): replace manual char filter with strings.Map

### DIFF
--- a/core/stringx/strings.go
+++ b/core/stringx/strings.go
@@ -3,6 +3,7 @@ package stringx
 import (
 	"errors"
 	"slices"
+	"strings"
 	"unicode"
 
 	"github.com/zeromicro/go-zero/core/lang"
@@ -21,20 +22,14 @@ func Contains(list []string, str string) bool {
 	return slices.Contains(list, str)
 }
 
-// Filter filters chars from s with given filter function.
-func Filter(s string, filter func(r rune) bool) string {
-	var n int
-	chars := []rune(s)
-	for i, x := range chars {
-		if n < i {
-			chars[n] = x
+// Filter filters chars from s with given remove function.
+func Filter(s string, remove func(r rune) bool) string {
+	return strings.Map(func(r rune) rune {
+		if remove(r) {
+			return -1
 		}
-		if !filter(x) {
-			n++
-		}
-	}
-
-	return string(chars[:n])
+		return r
+	}, s)
 }
 
 // FirstN returns first n runes from s.

--- a/core/stringx/strings_test.go
+++ b/core/stringx/strings_test.go
@@ -92,6 +92,24 @@ func TestFilter(t *testing.T) {
 	}
 }
 
+func BenchmarkFilter(b *testing.B) {
+	b.Run("true", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			Filter(`ab,cd,ef`, func(r rune) bool { return r == ',' })
+		}
+	})
+
+	b.Run("false", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			Filter(`ab,cd,ef`, func(r rune) bool { return r == '!' })
+		}
+	})
+}
+
 func TestFirstN(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
The original Filter function used a manual []rune loop to remove characters
satisfying a predicate. This change:

- Replaces it with a simpler, more efficient implementation using strings.Map
- Renames the predicate parameter from 'filter' to 'remove' to accurately
  reflect that the function removes characters for which remove(r) is true