### PR TITLE
refactor(core): replace TakeOne usage with cmp.Or

### DIFF
--- a/core/mapping/utils.go
+++ b/core/mapping/utils.go
@@ -1,6 +1,7 @@
 package mapping
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,7 +13,6 @@ import (
 	"sync"
 
 	"github.com/zeromicro/go-zero/core/lang"
-	"github.com/zeromicro/go-zero/core/stringx"
 )
 
 const (
@@ -278,7 +278,7 @@ func parseKeyAndOptions(tagName string, field reflect.StructField) (string, *fie
 	cache, ok := optionsCache[value]
 	cacheLock.RUnlock()
 	if ok {
-		return stringx.TakeOne(cache.key, field.Name), cache.options, cache.err
+		return cmp.Or(cache.key, field.Name), cache.options, cache.err
 	}
 
 	key, options, err := doParseKeyAndOptions(field, value)
@@ -290,7 +290,7 @@ func parseKeyAndOptions(tagName string, field reflect.StructField) (string, *fie
 	}
 	cacheLock.Unlock()
 
-	return stringx.TakeOne(key, field.Name), options, err
+	return cmp.Or(key, field.Name), options, err
 }
 
 // support below notations:

--- a/core/stringx/strings.go
+++ b/core/stringx/strings.go
@@ -141,6 +141,7 @@ func Substr(str string, start, stop int) (string, error) {
 }
 
 // TakeOne returns valid string if not empty or later one.
+// Deprecated: use cmp.Or instead.
 func TakeOne(valid, or string) string {
 	if len(valid) > 0 {
 		return valid


### PR DESCRIPTION
The custom `TakeOne` function is redundant since Go 1.21 introduced `cmp.Or`, 
which provides identical functionality for selecting the first non-zero value.

Changes:
- Mark `TakeOne` as deprecated with a pointer to `cmp.Or`.
- Replace all internal usages of `TakeOne` with `cmp.Or`.