### PR TITLE
test(hash): add unit tests for Hash, Hash determinism, and Md5Hex edg…

### DIFF
--- a/core/hash/hash_test.go
+++ b/core/hash/hash_test.go
@@ -25,6 +25,29 @@ func TestMd5Hex(t *testing.T) {
 	assert.Equal(t, md5Digest, actual)
 }
 
+func TestHash(t *testing.T) {
+	result := Hash([]byte(text))
+	assert.NotEqual(t, uint64(0), result)
+}
+
+func TestHash_Deterministic(t *testing.T) {
+	data := []byte("consistent-hash-test")
+	first := Hash(data)
+	second := Hash(data)
+	assert.Equal(t, first, second)
+}
+
+func TestHash_Empty(t *testing.T) {
+	// Hash should not panic on empty input.
+	result := Hash([]byte{})
+	_ = result
+}
+
+func TestMd5Hex_Empty(t *testing.T) {
+	result := Md5Hex([]byte{})
+	assert.Equal(t, 32, len(result))
+}
+
 func BenchmarkHashFnv(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h := fnv.New32()


### PR DESCRIPTION
**Problem**

The `Hash()` function in `core/hash/hash.go` (murmur3 wrapper) has no dedicated unit test. Only `Md5()` and `Md5Hex()` are directly tested. While `Hash()` is exercised indirectly through `consistenthash_test.go`, the function itself lacks isolated coverage.

**Solution**

Added 4 new test cases to `core/hash/hash_test.go`:

| Test | Purpose |
|------|---------|
| `TestHash` | Verifies `Hash()` returns a non-zero value for non-empty input |
| `TestHash_Deterministic` | Verifies identical inputs always produce the same hash |
| `TestHash_Empty` | Ensures `Hash()` does not panic on empty byte slice |
| `TestMd5Hex_Empty` | Validates `Md5Hex()` returns a valid 32-char hex string for empty input |

**Impact**
- Test-only change — no production code modified
- No public API changes
- No breaking changes

**Testing performed**
```
go test -v -count=1 ./core/hash/...   # PASS
go vet ./core/hash/...                # PASS
```

**Files changed**
- `core/hash/hash_test.go` — added 4 test functions