### PR TITLE
docs(mathx): add godoc comment to Numerical type constraint

### DIFF
--- a/core/mathx/range.go
+++ b/core/mathx/range.go
@@ -1,5 +1,6 @@
 package mathx
 
+// Numerical is a constraint that permits any numeric type.
 type Numerical interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 |
 		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |


### PR DESCRIPTION
**Problem**

The `Numerical` type constraint in `core/mathx/range.go` is the only exported type in the go-zero `core/` packages without a godoc comment. Every other exported type, function, and variable follows the Go convention of having a documentation comment.

**Solution**

Added a standard godoc comment:
```go
// Numerical is a constraint that permits any numeric type.
type Numerical interface {
    ~int | ~int8 | ~int16 | ~int32 | ~int64 |
        ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
        ~float32 | ~float64
}
```

**Impact**
- Documentation-only change — no behavior modified
- No public API changes
- No breaking changes
- Improves `go doc` output and IDE hover documentation

**Testing performed**
```
go vet ./core/mathx/...   # PASS
```

**Files changed**
- `core/mathx/range.go` — added 1 comment line