### PR TITLE
test(mathx,stringx): add missing edge case tests for CalcEntropy and …

### DIFF
--- a/core/mathx/entropy_test.go
+++ b/core/mathx/entropy_test.go
@@ -29,3 +29,10 @@ func TestCalcDiffEntropy(t *testing.T) {
 	}
 	assert.True(t, CalcEntropy(m) < .99)
 }
+
+func TestCalcEntropySingleItem(t *testing.T) {
+	m := map[any]int{
+		"only": 42,
+	}
+	assert.Equal(t, float64(1), CalcEntropy(m))
+}

--- a/core/stringx/strings_test.go
+++ b/core/stringx/strings_test.go
@@ -29,6 +29,40 @@ func TestContainsString(t *testing.T) {
 	}
 }
 
+func TestHasEmpty(t *testing.T) {
+	cases := []struct {
+		args   []string
+		expect bool
+	}{
+		{
+			args:   []string{"a", "b", "c"},
+			expect: false,
+		},
+		{
+			args:   []string{"a", "", "c"},
+			expect: true,
+		},
+		{
+			args:   []string{""},
+			expect: true,
+		},
+		{
+			args:   []string{},
+			expect: false,
+		},
+		{
+			args:   nil,
+			expect: false,
+		},
+	}
+
+	for _, each := range cases {
+		t.Run(path.Join(each.args...), func(t *testing.T) {
+			assert.Equal(t, each.expect, HasEmpty(each.args...))
+		})
+	}
+}
+
 func TestNotEmpty(t *testing.T) {
 	cases := []struct {
 		args   []string


### PR DESCRIPTION
**Problem**

1. **`CalcEntropy`** in `core/mathx/entropy.go` has an explicit early-return branch for `len(m) == 1` (returns `1`), but no test exercises a map with exactly one key. Only empty maps and multi-key maps are tested.

2. **`HasEmpty`** in `core/stringx/strings.go` has no direct test function. It is only tested indirectly through `TestNotEmpty`. This makes coverage traceability harder and misses edge cases like `nil` input.

**Solution**

Added 2 new test functions:

| Test | File | Purpose |
|------|------|---------|
| `TestCalcEntropySingleItem` | `core/mathx/entropy_test.go` | Covers the `len(m)==1` branch, verifies it returns `1.0` |
| `TestHasEmpty` | `core/stringx/strings_test.go` | Table-driven test with 5 cases: all non-empty, mixed, single empty, empty slice, `nil` |

**Impact**
- Test-only change — no production code modified
- No public API changes
- No breaking changes

**Testing performed**
```
go test -v -count=1 ./core/mathx/...    # PASS
go test -v -count=1 ./core/stringx/...  # PASS
go vet ./core/mathx/... ./core/stringx/...  # PASS
```

**Files changed**
- `core/mathx/entropy_test.go` — added `TestCalcEntropySingleItem`
- `core/stringx/strings_test.go` — added `TestHasEmpty`
