### PR TITLE
test(goctl): add regression test for per-service type alias filtering (#5481)

### DIFF
--- a/tools/goctl/rpc/generator/gencall_test.go
+++ b/tools/goctl/rpc/generator/gencall_test.go
@@ -108,18 +108,18 @@ func TestGenCallGroup_OnlyUsedTypesAliased(t *testing.T) {
 	require.NoError(t, err)
 	aFile := string(aContent)
 
-	assert.Contains(t, aFile, "AReq", "ServiceA file should alias AReq")
-	assert.Contains(t, aFile, "AResp", "ServiceA file should alias AResp")
-	assert.NotContains(t, aFile, "BReq", "ServiceA file must not alias BReq")
-	assert.NotContains(t, aFile, "BResp", "ServiceA file must not alias BResp")
+	assert.Contains(t, aFile, "AReq = pb.AReq", "ServiceA file should alias AReq")
+	assert.Contains(t, aFile, "AResp = pb.AResp", "ServiceA file should alias AResp")
+	assert.NotContains(t, aFile, "BReq = pb.BReq", "ServiceA file must not alias BReq")
+	assert.NotContains(t, aFile, "BResp = pb.BResp", "ServiceA file must not alias BResp")
 
 	// serviceb/serviceb.go — aliases for BReq/BResp only
 	bContent, err := os.ReadFile(filepath.Join(callBase, "serviceb", "serviceb.go"))
 	require.NoError(t, err)
 	bFile := string(bContent)
 
-	assert.Contains(t, bFile, "BReq", "ServiceB file should alias BReq")
-	assert.Contains(t, bFile, "BResp", "ServiceB file should alias BResp")
-	assert.NotContains(t, bFile, "AReq", "ServiceB file must not alias AReq")
-	assert.NotContains(t, bFile, "AResp", "ServiceB file must not alias AResp")
+	assert.Contains(t, bFile, "BReq = pb.BReq", "ServiceB file should alias BReq")
+	assert.Contains(t, bFile, "BResp = pb.BResp", "ServiceB file should alias BResp")
+	assert.NotContains(t, bFile, "AReq = pb.AReq", "ServiceB file must not alias AReq")
+	assert.NotContains(t, bFile, "AResp = pb.AResp", "ServiceB file must not alias AResp")
 }


### PR DESCRIPTION
## What

Adds `TestGenCallGroup_OnlyUsedTypesAliased` to `tools/goctl/rpc/generator/gencall_test.go` as a regression guard for #5481 (fixed in #5482).

## Why

The fix in #5482 was merged without a test. This test exercises `genCallGroup` directly with two services that have completely disjoint message sets and asserts:

- `servicea.go` contains aliases only for `AReq`/`AResp` (not `BReq`/`BResp`)
- `serviceb.go` contains aliases only for `BReq`/`BResp` (not `AReq`/`AResp`)

The test **fails** against the pre-fix code and **passes** with the fix, so it will catch any future regression.

## How to verify

```bash
cd tools/goctl
go test ./rpc/generator/... -run TestGenCallGroup_OnlyUsedTypesAliased -v
```