### PR TITLE
fix(api): validate path parameters against route placeholders in swag…

### DIFF
--- a/tools/goctl/api/swagger/parameter.go
+++ b/tools/goctl/api/swagger/parameter.go
@@ -34,7 +34,7 @@ func isRequestBodyJson(ctx Context, method string, tp apiSpec.Type) (string, boo
 	return structType.RawName, hasJsonField
 }
 
-func parametersFromType(ctx Context, method string, tp apiSpec.Type) []spec.Parameter {
+func parametersFromType(ctx Context, method string, tp apiSpec.Type, routePath string) []spec.Parameter {
 	if tp == nil {
 		return []spec.Parameter{}
 	}
@@ -43,6 +43,9 @@ func parametersFromType(ctx Context, method string, tp apiSpec.Type) []spec.Para
 	if !ok {
 		return []spec.Parameter{}
 	}
+
+	// Extract valid path parameter names from the route path
+	pathPlaceholders := extractPathPlaceholders(routePath)
 
 	var (
 		resp           []spec.Parameter
@@ -85,8 +88,17 @@ func parametersFromType(ctx Context, method string, tp apiSpec.Type) []spec.Para
 		}
 
 		if hasPathParameter {
+			// Validate path parameter: only generate if the route path contains a matching placeholder
+			if !pathPlaceholders[pathParameterTag.Name] {
+				// Warn about unmatched path parameter - this is a potential API design error
+				// TODO: Consider adding a logging/warning mechanism for this
+				// For now, we simply skip this parameter to avoid invalid swagger generation
+			}
 			minimum, maximum, exclusiveMinimum, exclusiveMaximum := rangeValueFromOptions(pathParameterTag.Options)
-			resp = append(resp, spec.Parameter{
+
+			// Only add the path parameter if it matches a placeholder in the route path
+			if pathPlaceholders[pathParameterTag.Name] {
+				resp = append(resp, spec.Parameter{
 				CommonValidations: spec.CommonValidations{
 					Maximum:          maximum,
 					ExclusiveMaximum: exclusiveMaximum,
@@ -106,8 +118,9 @@ func parametersFromType(ctx Context, method string, tp apiSpec.Type) []spec.Para
 					Description: formatComment(member.Comment),
 					Required:    required,
 				},
-			})
-		}
+				})
+			}
+		} // End of if hasPathParameter
 
 		if hasForm {
 			minimum, maximum, exclusiveMinimum, exclusiveMaximum := rangeValueFromOptions(formTag.Options)

--- a/tools/goctl/api/swagger/parameter_path_filter_test.go
+++ b/tools/goctl/api/swagger/parameter_path_filter_test.go
@@ -1,0 +1,187 @@
+package swagger
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiSpec "github.com/zeromicro/go-zero/tools/goctl/api/spec"
+)
+
+func TestParametersFromType_PathParameterValidation(t *testing.T) {
+	tests := []struct {
+		name                string
+		routePath           string
+		structType          apiSpec.DefineStruct
+		expectedPathParams  []string
+	}{
+		{
+			name:      "path parameter matches route placeholder",
+			routePath: "/api/users/:id",
+			structType: apiSpec.DefineStruct{
+				RawName: "TestRequest",
+				Members: []apiSpec.Member{
+					{
+						Name: "ID",
+						Type: apiSpec.PrimitiveType{RawName: "string"},
+						Tag:  `path:"id"`,
+					},
+				},
+			},
+			expectedPathParams: []string{"id"},
+		},
+		{
+			name:      "path parameter matches {id} style placeholder",
+			routePath: "/api/users/{id}",
+			structType: apiSpec.DefineStruct{
+				RawName: "TestRequest",
+				Members: []apiSpec.Member{
+					{
+						Name: "ID",
+						Type: apiSpec.PrimitiveType{RawName: "string"},
+						Tag:  `path:"id"`,
+					},
+				},
+			},
+			expectedPathParams: []string{"id"},
+		},
+		{
+			name:      "path parameter does NOT match route placeholder - should be filtered out",
+			routePath: "/api/users",
+			structType: apiSpec.DefineStruct{
+				RawName: "TestRequest",
+				Members: []apiSpec.Member{
+					{
+						Name: "ID",
+						Type: apiSpec.PrimitiveType{RawName: "string"},
+						Tag:  `path:"id"`,
+					},
+				},
+			},
+			expectedPathParams: []string{}, // No path params should be generated
+		},
+		{
+			name:      "multiple path parameters, only some match route placeholders",
+			routePath: "/api/:namespace/users/:id",
+			structType: apiSpec.DefineStruct{
+				RawName: "TestRequest",
+				Members: []apiSpec.Member{
+					{
+						Name: "Namespace",
+						Type: apiSpec.PrimitiveType{RawName: "string"},
+						Tag:  `path:"namespace"`,
+					},
+					{
+						Name: "ID",
+						Type: apiSpec.PrimitiveType{RawName: "string"},
+						Tag:  `path:"id"`,
+					},
+					{
+						Name: "Extra",
+						Type: apiSpec.PrimitiveType{RawName: "string"},
+						Tag:  `path:"extra"`, // This should be filtered out
+					},
+				},
+			},
+			expectedPathParams: []string{"namespace", "id"},
+		},
+		{
+			name:      "no path tag - no path params should be generated",
+			routePath: "/api/users/:id",
+			structType: apiSpec.DefineStruct{
+				RawName: "TestRequest",
+				Members: []apiSpec.Member{
+					{
+						Name: "ID",
+						Type: apiSpec.PrimitiveType{RawName: "string"},
+						Tag:  `form:"id"`, // Form param, not path param
+					},
+				},
+			},
+			expectedPathParams: []string{},
+		},
+		{
+			name:      "mixed route path - colon and brace styles",
+			routePath: "/api/:namespace/users/{id}",
+			structType: apiSpec.DefineStruct{
+				RawName: "TestRequest",
+				Members: []apiSpec.Member{
+					{
+						Name: "Namespace",
+						Type: apiSpec.PrimitiveType{RawName: "string"},
+						Tag:  `path:"namespace"`,
+					},
+					{
+						Name: "ID",
+						Type: apiSpec.PrimitiveType{RawName: "string"},
+						Tag:  `path:"id"`,
+					},
+				},
+			},
+			expectedPathParams: []string{"namespace", "id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testingContext(t)
+
+			params := parametersFromType(ctx, http.MethodGet, tt.structType, tt.routePath)
+
+			// Filter only path parameters
+			var pathParams []string
+			for _, param := range params {
+				if param.In == paramsInPath {
+					pathParams = append(pathParams, param.Name)
+				}
+			}
+
+			// Verify we have the expected number of path parameters
+			assert.Equal(t, len(tt.expectedPathParams), len(pathParams),
+				"Expected %d path parameters, got %d. Route: %s, Expected: %v, Got: %v",
+				len(tt.expectedPathParams), len(pathParams), tt.routePath, tt.expectedPathParams, pathParams)
+
+			// Verify all expected path parameters are present
+			for _, expected := range tt.expectedPathParams {
+				assert.Contains(t, pathParams, expected,
+					"Expected path parameter '%s' to be present", expected)
+			}
+		})
+	}
+}
+
+func TestParametersFromType_PathParameterFilteringWithQueryString(t *testing.T) {
+	// Test query string parameters are NOT affected by path parameter filtering
+	ctx := testingContext(t)
+
+	structType := apiSpec.DefineStruct{
+		RawName: "TestRequest",
+		Members: []apiSpec.Member{
+			{
+				Name: "ID",
+				Type: apiSpec.PrimitiveType{RawName: "string"},
+				Tag:  `path:"id"`,
+			},
+			{
+				Name: "Name",
+				Type: apiSpec.PrimitiveType{RawName: "string"},
+				Tag:  `form:"name"`, // Query param should still be generated
+			},
+		},
+	}
+
+	// Route has placeholder for id, so path param should be generated
+	params := parametersFromType(ctx, http.MethodGet, structType, "/api/:id")
+
+	var pathParams, queryParams []string
+	for _, param := range params {
+		if param.In == paramsInPath {
+			pathParams = append(pathParams, param.Name)
+		} else if param.In == paramsInQuery {
+			queryParams = append(queryParams, param.Name)
+		}
+	}
+
+	assert.Equal(t, []string{"id"}, pathParams)
+	assert.Equal(t, []string{"name"}, queryParams)
+}

--- a/tools/goctl/api/swagger/parameter_test.go
+++ b/tools/goctl/api/swagger/parameter_test.go
@@ -60,7 +60,7 @@ func TestParametersFromType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := Context{UseDefinitions: tt.useDefinitions}
 			testStruct := createTestStruct("TestStruct", tt.hasJson)
-			params := parametersFromType(ctx, tt.method, testStruct)
+			params := parametersFromType(ctx, tt.method, testStruct, "/test/path")
 
 			assert.Equal(t, tt.expectedCount, len(params))
 			if tt.expectedBody {
@@ -75,11 +75,11 @@ func TestParametersFromType(t *testing.T) {
 func TestParametersFromType_EdgeCases(t *testing.T) {
 	ctx := testingContext(t)
 
-	params := parametersFromType(ctx, http.MethodPost, nil)
+	params := parametersFromType(ctx, http.MethodPost, nil, "/test/path")
 	assert.Empty(t, params)
 
 	primitiveType := apiSpec.PrimitiveType{RawName: "string"}
-	params = parametersFromType(ctx, http.MethodPost, primitiveType)
+	params = parametersFromType(ctx, http.MethodPost, primitiveType, "/test/path")
 	assert.Empty(t, params)
 }
 

--- a/tools/goctl/api/swagger/path.go
+++ b/tools/goctl/api/swagger/path.go
@@ -91,7 +91,7 @@ func spec2Path(ctx Context, group apiSpec.Group, route apiSpec.Route) spec.PathI
 			Summary:     getStringFromKVOrDefault(route.AtDoc.Properties, propertyKeySummary, getFirstUsableString(route.AtDoc.Text, route.Handler)),
 			ID:          operationId,
 			Deprecated:  getBoolFromKVOrDefault(route.AtDoc.Properties, propertyKeyDeprecated, false),
-			Parameters:  parametersFromType(ctx, route.Method, route.RequestType),
+			Parameters:  parametersFromType(ctx, route.Method, route.RequestType, route.Path),
 			Security:    security,
 			Responses:   jsonResponseFromType(ctx, route.AtDoc, route.ResponseType),
 		},

--- a/tools/goctl/api/swagger/vars.go
+++ b/tools/goctl/api/swagger/vars.go
@@ -1,5 +1,7 @@
 package swagger
 
+import "strings"
+
 var (
 	tpMapper = map[string]string{
 		"uint8":   swaggerTypeInteger,
@@ -25,3 +27,31 @@ var (
 		return r == '/'
 	}
 )
+
+// extractPathPlaceholders
+// Supports both :id style (go-zero format) and {id} style (OpenAPI format).
+// For example: "/foo/:id/bar/{namespace}" returns ["id", "namespace"]
+func extractPathPlaceholders(path string) map[string]bool {
+	placeholders := make(map[string]bool)
+	items := strings.FieldsFunc(path, slashRune)
+
+	for _, item := range items {
+		// Handle :id style placeholders
+		if strings.HasPrefix(item, ":") {
+			name := strings.TrimPrefix(item, ":")
+			if name != "" {
+				placeholders[name] = true
+			}
+		}
+
+		// Handle {id} style placeholders
+		if strings.HasPrefix(item, "{") && strings.HasSuffix(item, "}") {
+			name := strings.TrimSuffix(strings.TrimPrefix(item, "{"), "}")
+			if name != "" {
+				placeholders[name] = true
+			}
+		}
+	}
+
+	return placeholders
+}

--- a/tools/goctl/api/swagger/vars_test.go
+++ b/tools/goctl/api/swagger/vars_test.go
@@ -1,0 +1,115 @@
+package swagger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractPathPlaceholders(t *testing.T) {
+	tests := []struct {
+		name                string
+		path                string
+		expectedPlaceholders []string
+	}{
+		{
+			name:                "empty path",
+			path:                "",
+			expectedPlaceholders: []string{},
+		},
+		{
+			name:                "no placeholders",
+			path:                "/api/v1/users",
+			expectedPlaceholders: []string{},
+		},
+		{
+			name:                "single :id style placeholder",
+			path:                "/api/v1/users/:id",
+			expectedPlaceholders: []string{"id"},
+		},
+		{
+			name:                "single {id} style placeholder",
+			path:                "/api/v1/users/{id}",
+			expectedPlaceholders: []string{"id"},
+		},
+		{
+			name:                "multiple :id style placeholders",
+			path:                "/api/v1/:namespace/:id",
+			expectedPlaceholders: []string{"namespace", "id"},
+		},
+		{
+			name:                "multiple {id} style placeholders",
+			path:                "/api/v1/{namespace}/{id}",
+			expectedPlaceholders: []string{"namespace", "id"},
+		},
+		{
+			name:                "mixed style placeholders",
+			path:                "/api/v1/:namespace/users/{id}",
+			expectedPlaceholders: []string{"namespace", "id"},
+		},
+		{
+			name:                "placeholder at root",
+			path:                "/:id",
+			expectedPlaceholders: []string{"id"},
+		},
+		{
+			name:                "placeholder after static segments",
+			path:                "/foo/bar/:id",
+			expectedPlaceholders: []string{"id"},
+		},
+		{
+			name:                "empty placeholder name with colon",
+			path:                "/api/v1/:/users",
+			expectedPlaceholders: []string{},
+		},
+		{
+			name:                "empty placeholder name with braces",
+			path:                "/api/v1/{}/users",
+			expectedPlaceholders: []string{},
+		},
+		{
+			name:                "trailing slash with placeholder",
+			path:                "/api/v1/:id/",
+			expectedPlaceholders: []string{"id"},
+		},
+		{
+			name:                "complex path with multiple placeholders",
+			path:                "/api/v1/:org/:namespace/:id",
+			expectedPlaceholders: []string{"org", "namespace", "id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			placeholders := extractPathPlaceholders(tt.path)
+
+			// Check that we have the expected number of placeholders
+			assert.Equal(t, len(tt.expectedPlaceholders), len(placeholders))
+
+			// Check that all expected placeholders are present
+			for _, expected := range tt.expectedPlaceholders {
+				assert.True(t, placeholders[expected], "Expected placeholder '%s' to be present", expected)
+			}
+		})
+	}
+}
+
+func TestExtractPathPlaceholders_Duplicates(t *testing.T) {
+	// When the same placeholder appears multiple times, it should be deduplicated
+	path := "/api/v1/:id/other/:id"
+	placeholders := extractPathPlaceholders(path)
+
+	assert.Equal(t, 1, len(placeholders))
+	assert.True(t, placeholders["id"])
+}
+
+func TestExtractPathPlaceholders_CaseSensitive(t *testing.T) {
+	// Placeholders should be case-sensitive
+	path := "/api/v1/:ID/:id/:Id"
+	placeholders := extractPathPlaceholders(path)
+
+	assert.Equal(t, 3, len(placeholders))
+	assert.True(t, placeholders["ID"])
+	assert.True(t, placeholders["id"])
+	assert.True(t, placeholders["Id"])
+}


### PR DESCRIPTION
在生成路径参数前，解析路由路径中的占位符（支持 :id 和 {id} 两种格式），仅当路径中存在匹配的占位符时才生成对应的路径参数。对于未匹配的路径参数，静默跳过以避免生成无效的 Swagger 文档。

核心改动

1. 新增 extractPathPlaceholders() 函数 (tools/goctl/api/swagger/vars.go)

•  支持解析 :id 风格的 go-zero 占位符
•  支持解析 {id} 风格的 OpenAPI 占位符
•  返回路由路径中所有有效的路径参数名称集合

2. 修改 parametersFromType() 函数 (tools/goctl/api/swagger/parameter.go)

•  新增 routePath string 参数，接收原始路由路径
•  在生成路径参数前调用 extractPathPlaceholders() 获取允许的占位符集
•  仅当 pathParameterTag.Name 在占位符集合中时才生成参数
•  未匹配的路径参数被静默过滤

3. 更新 spec2Path() 函数 (tools/goctl/api/swagger/path.go)

•  调用 parametersFromType() 时传入 route.Path

4. 新增单元测试

•  vars_test.go: 测试占位符提取逻辑（14 个测试用例）
◦  覆盖空路径、无占位符
◦  单/多占位符
◦  混合格式 (:id 和 {id})
◦  边缘情况（空占位符名称、尾随斜杠等）
•  parameter_path_filter_test.go: 测试路径参数验证逻辑（6 个测试用例）
◦  覆盖匹配/不匹配场景
◦  多个路径参数部分匹配的场景
◦  查询参数不受影响的验证
•  修复 parameter_test.go: 兼容新的参数签名