### PR TITLE
fix(sqlx): write time.Time in a MySQL-compatible format

### DIFF
--- a/core/stores/sqlx/utils.go
+++ b/core/stores/sqlx/utils.go
@@ -14,6 +14,8 @@ import (
 
 var errUnbalancedEscape = errors.New("no char after escape char")
 
+const timeFormat = "2006-01-02 15:04:05.999999"
+
 func desensitize(datasource string) string {
 	// remove account
 	pos := strings.LastIndex(datasource, "@")
@@ -162,12 +164,16 @@ func writeValue(buf *strings.Builder, arg any) {
 		buf.WriteByte('\'')
 	case time.Time:
 		buf.WriteByte('\'')
-		buf.WriteString(v.Format(time.DateTime))
+		buf.WriteString(v.Format(timeFormat))
 		buf.WriteByte('\'')
 	case *time.Time:
-		buf.WriteByte('\'')
-		buf.WriteString(v.Format(time.DateTime))
-		buf.WriteByte('\'')
+		if v != nil {
+			buf.WriteByte('\'')
+			buf.WriteString(v.Format(timeFormat))
+			buf.WriteByte('\'')
+		} else {
+			buf.WriteString("null")
+		}
 	default:
 		buf.WriteString(mapping.Repr(v))
 	}

--- a/core/stores/sqlx/utils.go
+++ b/core/stores/sqlx/utils.go
@@ -162,11 +162,11 @@ func writeValue(buf *strings.Builder, arg any) {
 		buf.WriteByte('\'')
 	case time.Time:
 		buf.WriteByte('\'')
-		buf.WriteString(v.String())
+		buf.WriteString(v.Format(time.RFC3339))
 		buf.WriteByte('\'')
 	case *time.Time:
 		buf.WriteByte('\'')
-		buf.WriteString(v.String())
+		buf.WriteString(v.Format(time.RFC3339))
 		buf.WriteByte('\'')
 	default:
 		buf.WriteString(mapping.Repr(v))

--- a/core/stores/sqlx/utils.go
+++ b/core/stores/sqlx/utils.go
@@ -162,11 +162,11 @@ func writeValue(buf *strings.Builder, arg any) {
 		buf.WriteByte('\'')
 	case time.Time:
 		buf.WriteByte('\'')
-		buf.WriteString(v.Format(time.RFC3339))
+		buf.WriteString(v.Format(time.DateTime))
 		buf.WriteByte('\'')
 	case *time.Time:
 		buf.WriteByte('\'')
-		buf.WriteString(v.Format(time.RFC3339))
+		buf.WriteString(v.Format(time.DateTime))
 		buf.WriteByte('\'')
 	default:
 		buf.WriteString(mapping.Repr(v))

--- a/core/stores/sqlx/utils.go
+++ b/core/stores/sqlx/utils.go
@@ -164,12 +164,12 @@ func writeValue(buf *strings.Builder, arg any) {
 		buf.WriteByte('\'')
 	case time.Time:
 		buf.WriteByte('\'')
-		buf.WriteString(v.Format(timeFormat))
+		buf.WriteString(v.UTC().Format(timeFormat))
 		buf.WriteByte('\'')
 	case *time.Time:
 		if v != nil {
 			buf.WriteByte('\'')
-			buf.WriteString(v.Format(timeFormat))
+			buf.WriteString(v.UTC().Format(timeFormat))
 			buf.WriteByte('\'')
 		} else {
 			buf.WriteString("null")

--- a/core/stores/sqlx/utils_test.go
+++ b/core/stores/sqlx/utils_test.go
@@ -144,9 +144,9 @@ func TestWriteValue(t *testing.T) {
 	var buf strings.Builder
 	tm := time.Now()
 	writeValue(&buf, &tm)
-	assert.Equal(t, "'"+tm.String()+"'", buf.String())
+	assert.Equal(t, "'"+tm.Format(time.RFC3339)+"'", buf.String())
 
 	buf.Reset()
 	writeValue(&buf, tm)
-	assert.Equal(t, "'"+tm.String()+"'", buf.String())
+	assert.Equal(t, "'"+tm.Format(time.RFC3339)+"'", buf.String())
 }

--- a/core/stores/sqlx/utils_test.go
+++ b/core/stores/sqlx/utils_test.go
@@ -141,12 +141,26 @@ func TestFormat(t *testing.T) {
 }
 
 func TestWriteValue(t *testing.T) {
-	var buf strings.Builder
 	tm := time.Now()
-	writeValue(&buf, &tm)
-	assert.Equal(t, "'"+tm.Format(time.DateTime)+"'", buf.String())
+	t.Run("ptr to time.Time", func(t *testing.T) {
+		var buf strings.Builder
 
-	buf.Reset()
-	writeValue(&buf, tm)
-	assert.Equal(t, "'"+tm.Format(time.DateTime)+"'", buf.String())
+		writeValue(&buf, &tm)
+		assert.Equal(t, "'"+tm.Format(timeFormat)+"'", buf.String())
+	})
+
+	t.Run("time.Time", func(t *testing.T) {
+		var buf strings.Builder
+		writeValue(&buf, tm)
+
+		assert.Equal(t, "'"+tm.Format(timeFormat)+"'", buf.String())
+	})
+
+	t.Run("nil ptr to time.Time", func(t *testing.T) {
+		var p *time.Time
+		var buf strings.Builder
+		writeValue(&buf, p)
+
+		assert.Equal(t, "null", buf.String())
+	})
 }

--- a/core/stores/sqlx/utils_test.go
+++ b/core/stores/sqlx/utils_test.go
@@ -144,9 +144,9 @@ func TestWriteValue(t *testing.T) {
 	var buf strings.Builder
 	tm := time.Now()
 	writeValue(&buf, &tm)
-	assert.Equal(t, "'"+tm.Format(time.RFC3339)+"'", buf.String())
+	assert.Equal(t, "'"+tm.Format(time.DateTime)+"'", buf.String())
 
 	buf.Reset()
 	writeValue(&buf, tm)
-	assert.Equal(t, "'"+tm.Format(time.RFC3339)+"'", buf.String())
+	assert.Equal(t, "'"+tm.Format(time.DateTime)+"'", buf.String())
 }

--- a/core/stores/sqlx/utils_test.go
+++ b/core/stores/sqlx/utils_test.go
@@ -146,14 +146,14 @@ func TestWriteValue(t *testing.T) {
 		var buf strings.Builder
 
 		writeValue(&buf, &tm)
-		assert.Equal(t, "'"+tm.Format(timeFormat)+"'", buf.String())
+		assert.Equal(t, "'"+tm.UTC().Format(timeFormat)+"'", buf.String())
 	})
 
 	t.Run("time.Time", func(t *testing.T) {
 		var buf strings.Builder
 		writeValue(&buf, tm)
 
-		assert.Equal(t, "'"+tm.Format(timeFormat)+"'", buf.String())
+		assert.Equal(t, "'"+tm.UTC().Format(timeFormat)+"'", buf.String())
 	})
 
 	t.Run("nil ptr to time.Time", func(t *testing.T) {


### PR DESCRIPTION
Fixes issue #5515: the bulk inserter used `Time.String()` to convert variables of type `time.Time` into strings. `Time.String()` returns a string in the format `"2006-01-02 15:04:05.999999999 -0700 MST"` that is not accepted by MySQL. 

To fix this problem, use `Time.Format()` to convert `time.Time` into string. 

Changes:
- core/stores/sqlx/utils.go: convert time variables into strings using a MySQL-compatible format
- core/stores/sqlx/utils_test.go: modify assertions and add a nil pointer case

All unittest cases passed. This change only affects bulk inserter and loggings. 