### PR TITLE
fix(core/service): defer tracing exporter termination until graceful shutdown completes

### DIFF
--- a/core/service/serviceconf.go
+++ b/core/service/serviceconf.go
@@ -66,9 +66,6 @@ func (sc ServiceConf) SetUp() error {
 	}
 	trace.StartAgent(sc.Telemetry)
 	proc.Setup(sc.Shutdown)
-	proc.AddShutdownListener(func() {
-		trace.StopAgent()
-	})
 
 	if len(sc.MetricsUrl) > 0 {
 		stat.SetReportWriter(stat.NewRemoteWriter(sc.MetricsUrl))
@@ -78,6 +75,11 @@ func (sc ServiceConf) SetUp() error {
 	profiling.Start(sc.Profiling)
 
 	return nil
+}
+
+// TearDown tear down the service.
+func (sc ServiceConf) TearDown() {
+	trace.StopAgent()
 }
 
 func (sc ServiceConf) initMode() {

--- a/core/service/serviceconf_test.go
+++ b/core/service/serviceconf_test.go
@@ -20,6 +20,7 @@ func TestServiceConf(t *testing.T) {
 			HealthPath: "/healthz",
 		},
 	}
+	defer c.TearDown()
 	c.MustSetUp()
 }
 
@@ -32,5 +33,6 @@ func TestServiceConfWithMetricsUrl(t *testing.T) {
 		Mode:       "dev",
 		MetricsUrl: "http://localhost:8080",
 	}
+	defer c.TearDown()
 	assert.NoError(t, c.SetUp())
 }

--- a/rest/server.go
+++ b/rest/server.go
@@ -111,6 +111,7 @@ func (s *Server) StartWithOpts(opts ...StartOption) {
 
 // Stop stops the Server.
 func (s *Server) Stop() {
+	s.ngin.conf.TearDown()
 	logx.Close()
 }
 

--- a/zrpc/server.go
+++ b/zrpc/server.go
@@ -15,6 +15,7 @@ import (
 
 // A RpcServer is a rpc server.
 type RpcServer struct {
+	conf     RpcServerConf
 	server   internal.Server
 	register internal.RegisterFn
 }
@@ -57,6 +58,7 @@ func NewServer(c RpcServerConf, register internal.RegisterFn) (*RpcServer, error
 	}
 
 	rpcServer := &RpcServer{
+		conf:     c,
 		server:   server,
 		register: register,
 	}
@@ -94,6 +96,7 @@ func (rs *RpcServer) Start() {
 
 // Stop stops the RpcServer.
 func (rs *RpcServer) Stop() {
+	rs.conf.TearDown()
 	logx.Close()
 }
 


### PR DESCRIPTION
Currently, the tracing provider is torn down prior to the completion of the service’s graceful shutdown sequence. Consequently, spans emitted during this phase—such as those from in-flight requests or cleanup routines—are dropped, as the exporter terminates before it can flush pending data to the backend.