### PR TITLE
fix(goctl/swagger): ignore '-' tags in parameters and properties

### DIFF
--- a/tools/goctl/api/swagger/parameter.go
+++ b/tools/goctl/api/swagger/parameter.go
@@ -8,6 +8,10 @@ import (
 	apiSpec "github.com/zeromicro/go-zero/tools/goctl/api/spec"
 )
 
+func shouldIgnoreTag(tag *apiSpec.Tag) bool {
+	return tag != nil && tag.Name == "-"
+}
+
 func isRequestBodyJson(ctx Context, method string, tp apiSpec.Type) (string, bool) {
 	// Support HTTP methods that commonly use request bodies with JSON
 	// POST, PUT, PATCH are standard methods with bodies
@@ -60,6 +64,9 @@ func parametersFromType(ctx Context, method string, tp apiSpec.Type) []spec.Para
 		hasJson := jsonTag != nil
 
 		if hasHeader {
+			if shouldIgnoreTag(headerTag) {
+				return
+			}
 			minimum, maximum, exclusiveMinimum, exclusiveMaximum := rangeValueFromOptions(headerTag.Options)
 			resp = append(resp, spec.Parameter{
 				CommonValidations: spec.CommonValidations{
@@ -85,6 +92,9 @@ func parametersFromType(ctx Context, method string, tp apiSpec.Type) []spec.Para
 		}
 
 		if hasPathParameter {
+			if shouldIgnoreTag(pathParameterTag) {
+				return
+			}
 			minimum, maximum, exclusiveMinimum, exclusiveMaximum := rangeValueFromOptions(pathParameterTag.Options)
 			resp = append(resp, spec.Parameter{
 				CommonValidations: spec.CommonValidations{
@@ -110,6 +120,9 @@ func parametersFromType(ctx Context, method string, tp apiSpec.Type) []spec.Para
 		}
 
 		if hasForm {
+			if shouldIgnoreTag(formTag) {
+				return
+			}
 			minimum, maximum, exclusiveMinimum, exclusiveMaximum := rangeValueFromOptions(formTag.Options)
 			if strings.EqualFold(method, http.MethodGet) {
 				resp = append(resp, spec.Parameter{
@@ -161,6 +174,9 @@ func parametersFromType(ctx Context, method string, tp apiSpec.Type) []spec.Para
 		}
 
 		if hasJson {
+			if shouldIgnoreTag(jsonTag) {
+				return
+			}
 			minimum, maximum, exclusiveMinimum, exclusiveMaximum := rangeValueFromOptions(jsonTag.Options)
 			if required {
 				requiredFields = append(requiredFields, jsonTag.Name)

--- a/tools/goctl/api/swagger/parameter_test.go
+++ b/tools/goctl/api/swagger/parameter_test.go
@@ -118,6 +118,36 @@ func TestParametersFromType_ExampleField(t *testing.T) {
 	assert.EqualValues(t, int64(18), queryParam.SimpleSchema.Example, "form param example should be set")
 }
 
+func TestParametersFromType_IgnoreDashTagName(t *testing.T) {
+	ctx := testingContext(t)
+
+	testStruct := apiSpec.DefineStruct{
+		RawName: "Request",
+		Members: []apiSpec.Member{
+			{
+				Name: "A",
+				Type: apiSpec.PrimitiveType{RawName: "string"},
+				Tag:  `form:"a,optional"`,
+			},
+			{
+				Name: "Hidden1",
+				Type: apiSpec.PrimitiveType{RawName: "bool"},
+				Tag:  `form:"-"`,
+			},
+			{
+				Name: "Hidden2",
+				Type: apiSpec.ArrayType{Value: apiSpec.PrimitiveType{RawName: "int"}},
+				Tag:  `form:"-"`,
+			},
+		},
+	}
+
+	params := parametersFromType(ctx, http.MethodGet, testStruct)
+	assert.Len(t, params, 1)
+	assert.Equal(t, paramsInQuery, params[0].In)
+	assert.Equal(t, "a", params[0].Name)
+}
+
 func createTestStruct(name string, hasJson bool) apiSpec.DefineStruct {
 	tag := `form:"username"`
 	if hasJson {

--- a/tools/goctl/api/swagger/properties.go
+++ b/tools/goctl/api/swagger/properties.go
@@ -39,6 +39,9 @@ func propertiesFromType(ctx Context, tp apiSpec.Type) (spec.SchemaProperties, []
 
 			jsonTag, _ := tag.Get(tagJson)
 			if jsonTag != nil {
+				if shouldIgnoreTag(jsonTag) {
+					return
+				}
 				jsonTagString = jsonTag.Name
 				minimum, maximum, exclusiveMinimum, exclusiveMaximum = rangeValueFromOptions(jsonTag.Options)
 				example = exampleValueFromOptions(ctx, jsonTag.Options, member.Type)

--- a/tools/goctl/api/swagger/swagger_test.go
+++ b/tools/goctl/api/swagger/swagger_test.go
@@ -138,3 +138,28 @@ func TestArrayWithoutDefinitions(t *testing.T) {
 	assert.Contains(t, arrayField.Items.Schema.Properties, "itemName")
 	assert.Equal(t, []string{"itemName"}, arrayField.Items.Schema.Required)
 }
+
+func TestPropertiesFromType_IgnoresJsonDashTag(t *testing.T) {
+	ctx := testingContext(t)
+	testStruct := spec.DefineStruct{
+		RawName: "Req",
+		Members: []spec.Member{
+			{
+				Name: "Visible",
+				Type: spec.PrimitiveType{RawName: "string"},
+				Tag:  `json:"visible"`,
+			},
+			{
+				Name: "Hidden",
+				Type: spec.PrimitiveType{RawName: "string"},
+				Tag:  `json:"-"`,
+			},
+		},
+	}
+
+	properties, required := propertiesFromType(ctx, testStruct)
+	assert.Contains(t, properties, "visible")
+	assert.NotContains(t, properties, "-")
+	assert.NotContains(t, required, "-")
+	assert.Equal(t, []string{"visible"}, required)
+}


### PR DESCRIPTION
Fixes #5427

## Summary
- Fix swagger generation to treat `"-"` tag names as ignored fields instead of emitting parameters/properties named `"-"`.
- Prevent invalid/duplicate OpenAPI parameter entries such as repeated `(in=query, name="-")` caused by multiple `form:"-"` fields.
- Add regression tests covering `form:"-"` in parameters and `json:"-"` in schema properties.

## What changed
- Updated `tools/goctl/api/swagger/parameter.go`
  - Added ignore handling for `header`, `path`, `form`, and `json` tags when tag name is `"-"`.
- Updated `tools/goctl/api/swagger/properties.go`
  - Skip schema property generation for `json:"-"`.
- Added tests:
  - `TestParametersFromType_IgnoreDashTagName` in `tools/goctl/api/swagger/parameter_test.go`
  - `TestPropertiesFromType_IgnoresJsonDashTag` in `tools/goctl/api/swagger/swagger_test.go`
 