### PR TITLE
fix(discov): prevent etcd key leak when Watch DELETE races with lease expiry

### DIFF
--- a/core/discov/internal/etcdclient.go
+++ b/core/discov/internal/etcdclient.go
@@ -19,5 +19,6 @@ type EtcdClient interface {
 	KeepAlive(ctx context.Context, id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error)
 	Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error)
 	Revoke(ctx context.Context, id clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error)
+	TimeToLive(ctx context.Context, id clientv3.LeaseID, opts ...clientv3.LeaseOption) (*clientv3.LeaseTimeToLiveResponse, error)
 	Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan
 }

--- a/core/discov/internal/etcdclient_mock.go
+++ b/core/discov/internal/etcdclient_mock.go
@@ -169,6 +169,26 @@ func (mr *MockEtcdClientMockRecorder) Revoke(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revoke", reflect.TypeOf((*MockEtcdClient)(nil).Revoke), ctx, id)
 }
 
+// TimeToLive mocks base method.
+func (m *MockEtcdClient) TimeToLive(ctx context.Context, id clientv3.LeaseID, opts ...clientv3.LeaseOption) (*clientv3.LeaseTimeToLiveResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, id}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TimeToLive", varargs...)
+	ret0, _ := ret[0].(*clientv3.LeaseTimeToLiveResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TimeToLive indicates an expected call of TimeToLive.
+func (mr *MockEtcdClientMockRecorder) TimeToLive(ctx, id any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, id}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TimeToLive", reflect.TypeOf((*MockEtcdClient)(nil).TimeToLive), varargs...)
+}
+
 // Watch mocks base method.
 func (m *MockEtcdClient) Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
 	m.ctrl.T.Helper()

--- a/core/discov/publisher.go
+++ b/core/discov/publisher.go
@@ -151,6 +151,24 @@ func (p *Publisher) keepAliveAsync(cli internal.EtcdClient) error {
 					if evt.Type == clientv3.EventTypeDelete {
 						logc.Infof(cli.Ctx(), "etcd publisher watch: %s, event: %v",
 							evt.Kv.Key, evt.Type)
+
+						// Make sure the lease is still valid before re-putting the key.
+						// Otherwise the Put may happen with an already-expired or zero
+						// LeaseID (e.g. when the DELETE event is caused by lease expiry
+						// and races with KeepAlive channel close), which makes the key
+						// permanent in etcd (no TTL) and leaks forever.
+						ttlResp, ttlErr := cli.TimeToLive(cli.Ctx(), p.lease)
+						if ttlErr != nil || ttlResp == nil || ttlResp.TTL <= 0 {
+							logc.Errorf(cli.Ctx(),
+								"etcd publisher lease expired, skip re-put and restart keepalive: leaseID=%d, err=%v",
+								p.lease, ttlErr)
+							p.revoke(cli)
+							if err := p.doKeepAlive(); err != nil {
+								logc.Errorf(cli.Ctx(), "etcd publisher KeepAlive: %v", err)
+							}
+							return
+						}
+
 						_, err := cli.Put(cli.Ctx(), p.fullKey, p.value, clientv3.WithLease(p.lease))
 						if err != nil {
 							logc.Errorf(cli.Ctx(), "etcd publisher re-put key: %v", err)

--- a/core/discov/publisher.go
+++ b/core/discov/publisher.go
@@ -152,18 +152,11 @@ func (p *Publisher) keepAliveAsync(cli internal.EtcdClient) error {
 						logc.Infof(cli.Ctx(), "etcd publisher watch: %s, event: %v",
 							evt.Kv.Key, evt.Type)
 
-						// Make sure the lease is still valid before re-putting the key.
-						// Otherwise the Put may happen with an already-expired or zero
-						// LeaseID (e.g. when the DELETE event is caused by lease expiry
-						// and races with KeepAlive channel close), which makes the key
-						// permanent in etcd (no TTL) and leaks forever.
-						ttlResp, ttlErr := cli.TimeToLive(cli.Ctx(), p.lease)
-						if ttlErr != nil || ttlResp == nil || ttlResp.TTL <= 0 {
-							logc.Errorf(cli.Ctx(),
-								"etcd publisher lease expired, skip re-put and restart keepalive: leaseID=%d, err=%v",
-								p.lease, ttlErr)
-							p.revoke(cli)
-							if err := p.doKeepAlive(); err != nil {
+						// Keep the fast path for manually deleted keys, but revalidate both
+						// before and after the re-put so an already-expired lease can't leave
+						// a permanent orphaned key behind.
+						if !p.leaseAlive(cli) {
+							if err := p.restartKeepAlive(cli); err != nil {
 								logc.Errorf(cli.Ctx(), "etcd publisher KeepAlive: %v", err)
 							}
 							return
@@ -172,10 +165,18 @@ func (p *Publisher) keepAliveAsync(cli internal.EtcdClient) error {
 						_, err := cli.Put(cli.Ctx(), p.fullKey, p.value, clientv3.WithLease(p.lease))
 						if err != nil {
 							logc.Errorf(cli.Ctx(), "etcd publisher re-put key: %v", err)
-						} else {
-							logc.Infof(cli.Ctx(), "etcd publisher re-put key: %s, value: %s",
-								p.fullKey, p.value)
+							continue
 						}
+
+						if !p.keyBoundToLease(cli) {
+							if err := p.restartKeepAlive(cli); err != nil {
+								logc.Errorf(cli.Ctx(), "etcd publisher KeepAlive: %v", err)
+							}
+							return
+						}
+
+						logc.Infof(cli.Ctx(), "etcd publisher re-put key: %s, value: %s",
+							p.fullKey, p.value)
 					}
 				}
 			case <-p.pauseChan:
@@ -221,6 +222,45 @@ func (p *Publisher) revoke(cli internal.EtcdClient) {
 	if _, err := cli.Revoke(cli.Ctx(), p.lease); err != nil {
 		logc.Errorf(cli.Ctx(), "etcd publisher revoke: %v", err)
 	}
+}
+
+func (p *Publisher) keyBoundToLease(cli internal.EtcdClient) bool {
+	resp, err := cli.Get(cli.Ctx(), p.fullKey)
+	if err != nil {
+		logc.Errorf(cli.Ctx(), "etcd publisher verify re-put lease: %v", err)
+		return false
+	}
+
+	if len(resp.Kvs) == 0 {
+		logc.Errorf(cli.Ctx(), "etcd publisher verify re-put lease: key missing after put, key=%s", p.fullKey)
+		return false
+	}
+
+	if resp.Kvs[0].Lease != int64(p.lease) {
+		logc.Errorf(cli.Ctx(),
+			"etcd publisher verify re-put lease: unexpected lease, key=%s, want=%d, got=%d",
+			p.fullKey, p.lease, resp.Kvs[0].Lease)
+		return false
+	}
+
+	return true
+}
+
+func (p *Publisher) leaseAlive(cli internal.EtcdClient) bool {
+	resp, err := cli.TimeToLive(cli.Ctx(), p.lease)
+	if err != nil || resp == nil || resp.TTL <= 0 {
+		logc.Errorf(cli.Ctx(),
+			"etcd publisher lease expired, skip re-put and restart keepalive: leaseID=%d, err=%v",
+			p.lease, err)
+		return false
+	}
+
+	return true
+}
+
+func (p *Publisher) restartKeepAlive(cli internal.EtcdClient) error {
+	p.revoke(cli)
+	return p.doKeepAlive()
 }
 
 // WithId customizes a Publisher with the id.

--- a/core/discov/publisher_test.go
+++ b/core/discov/publisher_test.go
@@ -252,8 +252,7 @@ func TestPublisher_keepAliveAsyncPause(t *testing.T) {
 	wg.Wait()
 }
 
-// Test case for key deletion and re-registration (covers lines 148-155)
-func TestPublisher_keepAliveAsyncKeyDeletion(t *testing.T) {
+func TestPublisher_keepAliveAsyncDeleteRePutsWhenLeaseAlive(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	const id clientv3.LeaseID = 1
@@ -262,33 +261,24 @@ func TestPublisher_keepAliveAsyncKeyDeletion(t *testing.T) {
 	defer restore()
 	cli.EXPECT().Ctx().AnyTimes()
 	cli.EXPECT().KeepAlive(gomock.Any(), id)
-
-	// Create a watch channel that will send a delete event
-	watchChan := make(chan clientv3.WatchResponse, 1)
-	watchResp := clientv3.WatchResponse{
-		Events: []*clientv3.Event{{
-			Type: clientv3.EventTypeDelete,
-			Kv: &mvccpb.KeyValue{
-				Key: []byte("thekey"),
-			},
-		}},
-	}
-	watchChan <- watchResp
-
-	cli.EXPECT().Watch(gomock.Any(), gomock.Any(), gomock.Any()).Return((<-chan clientv3.WatchResponse)(watchChan))
+	cli.EXPECT().Watch(gomock.Any(), gomock.Any(), gomock.Any()).Return(newDeleteWatchChan("thekey"))
+	cli.EXPECT().TimeToLive(gomock.Any(), id).Return(&clientv3.LeaseTimeToLiveResponse{
+		TTL: 1,
+	}, nil)
 
 	var wg sync.WaitGroup
-	wg.Add(1) // Only wait for Revoke call
-
-	// Use a channel to signal when Put has been called
+	wg.Add(1)
 	putCalled := make(chan struct{})
-
-	// Expect the re-put operation when key is deleted
 	cli.EXPECT().Put(gomock.Any(), "thekey", "thevalue", gomock.Any()).Do(func(_, _, _, _ any) {
-		close(putCalled) // Signal that Put has been called
+		close(putCalled)
 	}).Return(nil, nil)
-
-	// Expect revoke when Stop is called
+	cli.EXPECT().Get(gomock.Any(), "thekey").Return(&clientv3.GetResponse{
+		Kvs: []*mvccpb.KeyValue{{
+			Key:   []byte("thekey"),
+			Value: []byte("thevalue"),
+			Lease: int64(id),
+		}},
+	}, nil)
 	cli.EXPECT().Revoke(gomock.Any(), id).Do(func(_, _ any) {
 		wg.Done()
 	})
@@ -305,8 +295,7 @@ func TestPublisher_keepAliveAsyncKeyDeletion(t *testing.T) {
 	wg.Wait()
 }
 
-// Test case for key deletion with re-put error (covers error branch in lines 151-152)
-func TestPublisher_keepAliveAsyncKeyDeletionPutError(t *testing.T) {
+func TestPublisher_keepAliveAsyncDeleteSkipsPutAndRestartsWhenLeaseExpired(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	const id clientv3.LeaseID = 1
@@ -315,35 +304,14 @@ func TestPublisher_keepAliveAsyncKeyDeletionPutError(t *testing.T) {
 	defer restore()
 	cli.EXPECT().Ctx().AnyTimes()
 	cli.EXPECT().KeepAlive(gomock.Any(), id)
+	cli.EXPECT().Watch(gomock.Any(), gomock.Any(), gomock.Any()).Return(newDeleteWatchChan("thekey"))
+	cli.EXPECT().TimeToLive(gomock.Any(), id).Return(&clientv3.LeaseTimeToLiveResponse{
+		TTL: 0,
+	}, nil)
 
-	// Create a watch channel that will send a delete event
-	watchChan := make(chan clientv3.WatchResponse, 1)
-	watchResp := clientv3.WatchResponse{
-		Events: []*clientv3.Event{{
-			Type: clientv3.EventTypeDelete,
-			Kv: &mvccpb.KeyValue{
-				Key: []byte("thekey"),
-			},
-		}},
-	}
-	watchChan <- watchResp
-
-	cli.EXPECT().Watch(gomock.Any(), gomock.Any(), gomock.Any()).Return((<-chan clientv3.WatchResponse)(watchChan))
-
-	var wg sync.WaitGroup
-	wg.Add(1) // Only wait for Revoke call
-
-	// Use a channel to signal when Put has been called
-	putCalled := make(chan struct{})
-
-	// Expect the re-put operation to fail
-	cli.EXPECT().Put(gomock.Any(), "thekey", "thevalue", gomock.Any()).Do(func(_, _, _, _ any) {
-		close(putCalled) // Signal that Put has been called
-	}).Return(nil, errors.New("put error"))
-
-	// Expect revoke when Stop is called
+	restarted := make(chan struct{})
 	cli.EXPECT().Revoke(gomock.Any(), id).Do(func(_, _ any) {
-		wg.Done()
+		close(restarted)
 	})
 
 	pub := NewPublisher(nil, "thekey", "thevalue")
@@ -351,11 +319,93 @@ func TestPublisher_keepAliveAsyncKeyDeletionPutError(t *testing.T) {
 	pub.fullKey = "thekey"
 
 	assert.Nil(t, pub.keepAliveAsync(cli))
-
-	// Wait for Put to be called, then stop
-	<-putCalled
+	waitForSignal(t, restarted)
 	pub.Stop()
-	wg.Wait()
+}
+
+func TestPublisher_keepAliveAsyncDeleteSkipsPutWhenTTLUnavailable(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    *clientv3.LeaseTimeToLiveResponse
+		err     error
+		leaseID clientv3.LeaseID
+	}{
+		{
+			name:    "ttl error",
+			err:     errors.New("ttl error"),
+			leaseID: 1,
+		},
+		{
+			name:    "ttl nil response",
+			resp:    nil,
+			leaseID: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			cli := internal.NewMockEtcdClient(ctrl)
+			restore := setMockClient(cli)
+			defer restore()
+
+			cli.EXPECT().Ctx().AnyTimes()
+			cli.EXPECT().KeepAlive(gomock.Any(), tt.leaseID)
+			cli.EXPECT().Watch(gomock.Any(), gomock.Any(), gomock.Any()).Return(newDeleteWatchChan("thekey"))
+			cli.EXPECT().TimeToLive(gomock.Any(), tt.leaseID).Return(tt.resp, tt.err)
+
+			restarted := make(chan struct{})
+			cli.EXPECT().Revoke(gomock.Any(), tt.leaseID).Do(func(_, _ any) {
+				close(restarted)
+			})
+
+			pub := NewPublisher(nil, "thekey", "thevalue")
+			pub.lease = tt.leaseID
+			pub.fullKey = "thekey"
+
+			assert.Nil(t, pub.keepAliveAsync(cli))
+			waitForSignal(t, restarted)
+			pub.Stop()
+		})
+	}
+}
+
+func TestPublisher_keepAliveAsyncDeleteRestartsWhenRePutLosesLease(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	const id clientv3.LeaseID = 1
+	cli := internal.NewMockEtcdClient(ctrl)
+	restore := setMockClient(cli)
+	defer restore()
+	cli.EXPECT().Ctx().AnyTimes()
+	cli.EXPECT().KeepAlive(gomock.Any(), id)
+	cli.EXPECT().Watch(gomock.Any(), gomock.Any(), gomock.Any()).Return(newDeleteWatchChan("thekey"))
+	cli.EXPECT().TimeToLive(gomock.Any(), id).Return(&clientv3.LeaseTimeToLiveResponse{
+		TTL: 1,
+	}, nil)
+	cli.EXPECT().Put(gomock.Any(), "thekey", "thevalue", gomock.Any()).Return(nil, nil)
+	cli.EXPECT().Get(gomock.Any(), "thekey").Return(&clientv3.GetResponse{
+		Kvs: []*mvccpb.KeyValue{{
+			Key:   []byte("thekey"),
+			Value: []byte("thevalue"),
+			Lease: 0,
+		}},
+	}, nil)
+
+	restarted := make(chan struct{})
+	cli.EXPECT().Revoke(gomock.Any(), id).Do(func(_, _ any) {
+		close(restarted)
+	})
+
+	pub := NewPublisher(nil, "thekey", "thevalue")
+	pub.lease = id
+	pub.fullKey = "thekey"
+
+	assert.Nil(t, pub.keepAliveAsync(cli))
+	waitForSignal(t, restarted)
+	pub.Stop()
 }
 
 func TestPublisher_Resume(t *testing.T) {
@@ -461,4 +511,28 @@ func createTempFile(t *testing.T, body []byte) string {
 	}
 
 	return tmpFile.Name()
+}
+
+func newDeleteWatchChan(key string) <-chan clientv3.WatchResponse {
+	watchChan := make(chan clientv3.WatchResponse, 1)
+	watchChan <- clientv3.WatchResponse{
+		Events: []*clientv3.Event{{
+			Type: clientv3.EventTypeDelete,
+			Kv: &mvccpb.KeyValue{
+				Key: []byte(key),
+			},
+		}},
+	}
+
+	return watchChan
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for signal")
+	}
 }


### PR DESCRIPTION
## Problem

The publisher's Watch-based self-healing mechanism (introduced after v1.8.x) re-Puts the key with `p.lease` whenever a DELETE event is observed. However, when the DELETE is caused by the lease itself expiring  which happens concurrently with the KeepAlive channel being closed  the publisher may race to `Put` with an expired or zero `LeaseID`.

In etcd, `Put(key, value, WithLease(expired_or_zero_LeaseID))` succeeds but effectively **detaches the key from its lease**, turning it into a permanent key (no TTL). This key will never be auto-deleted by etcd and will leak forever, causing the symptom:

`
2 live pods    4+ keys in etcd
`

The orphaned keys are always the ones **without a lease** (verifiable by `etcdctl get --prefix ... -w json`).

## Root Cause

When the lease expires, etcd atomically deletes both the lease and all attached keys. The publisher's Watch channel receives a DELETE event for its key at almost the same time the KeepAlive channel is closed. Go `select` randomly picks one branch:

- If the DELETE branch wins, the publisher executes `cli.Put(fullKey, value, WithLease(p.lease))` using a lease that is already expired or being concurrently revoked  key becomes permanent.
- The old goroutine may still be alive from a prior `doRegister` cycle, compounding the race.

## Fix

Add a `TimeToLive` check before the Watch-based re-Put:

- If `TTL <= 0` or the call errors, the lease is gone  skip the `Put`, call `revoke()` and `doKeepAlive()` to restart the full registration flow (which grants a fresh lease).
- If the lease is still alive, proceed with the original `Put` as before.

This preserves the self-healing intent (recovering keys deleted by external/manual operations) while eliminating the etcd key-leak scenario.

## Changes

| File | Change |
|------|--------|
| `core/discov/internal/etcdclient.go` | Added `TimeToLive` method to `EtcdClient` interface |
| `core/discov/internal/etcdclient_mock.go` | Added corresponding mock |
| `core/discov/publisher.go` | Added TTL validation before Watch-based re-Put |

## Testing

- `go build ./core/discov/...` compiles successfully.