### PR TITLE
fix(rest): handle HTTP parsing edge cases

### DIFF
--- a/rest/httpc/requests.go
+++ b/rest/httpc/requests.go
@@ -123,22 +123,41 @@ func fillHeader(r *http.Request, val map[string]any) {
 func fillPath(u *nurl.URL, val map[string]any) error {
 	used := make(map[string]lang.PlaceholderType)
 	fields := strings.Split(u.Path, slash)
+	rawFields := strings.Split(u.EscapedPath(), slash)
 
-	for i := range fields {
-		field := fields[i]
-		if len(field) > 0 && field[0] == colon {
-			name := field[1:]
-			ival, ok := val[name]
-			if !ok {
-				return fmt.Errorf("missing path variable %q", name)
+	fill := func(parts []string, escaped bool) error {
+		for i := range parts {
+			field := parts[i]
+			if len(field) > 0 && field[0] == colon {
+				name := field[1:]
+				ival, ok := val[name]
+				if !ok {
+					return fmt.Errorf("missing path variable %q", name)
+				}
+				value := fmt.Sprint(ival)
+				if len(value) == 0 {
+					return fmt.Errorf("empty path variable %q", name)
+				}
+				if strings.Contains(value, slash) {
+					return fmt.Errorf("path variable %q cannot contain '/'", name)
+				}
+				if escaped {
+					parts[i] = nurl.PathEscape(value)
+				} else {
+					parts[i] = value
+				}
+				used[name] = lang.Placeholder
 			}
-			value := fmt.Sprint(ival)
-			if len(value) == 0 {
-				return fmt.Errorf("empty path variable %q", name)
-			}
-			fields[i] = value
-			used[name] = lang.Placeholder
 		}
+
+		return nil
+	}
+
+	if err := fill(fields, false); err != nil {
+		return err
+	}
+	if err := fill(rawFields, true); err != nil {
+		return err
 	}
 
 	if len(val) != len(used) {
@@ -155,6 +174,7 @@ func fillPath(u *nurl.URL, val map[string]any) error {
 	}
 
 	u.Path = strings.Join(fields, slash)
+	u.RawPath = strings.Join(rawFields, slash)
 	return nil
 }
 

--- a/rest/httpc/requests_test.go
+++ b/rest/httpc/requests_test.go
@@ -134,6 +134,19 @@ func TestDo_Ptr(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestDo_RejectsSlashInPathVariables(t *testing.T) {
+	type Data struct {
+		Key string `path:"key"`
+	}
+
+	_, err := Do(context.Background(), http.MethodGet, "http://example.com/nodes/:key", Data{
+		Key: "foo/bar baz?qux#frag%zap",
+	})
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "path variable")
+	}
+}
+
 func TestDo_BadRequest(t *testing.T) {
 	_, err := Do(context.Background(), http.MethodPost, ":/nodes/:key", nil)
 	assert.NotNil(t, err)
@@ -331,4 +344,34 @@ func TestBuildRequestWithBody(t *testing.T) {
 			assert.Equal(t, tc.wantedErr, err)
 		})
 	}
+}
+
+func TestBuildRequest_EscapesReservedPathCharacters(t *testing.T) {
+	type payload struct {
+		Key string `path:"key"`
+	}
+
+	httpReq, err := buildRequest(context.Background(), http.MethodGet,
+		"http://example.com/nodes/:key", payload{Key: "foo bar?baz#qux%zap"})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "/nodes/foo bar?baz#qux%zap", httpReq.URL.Path)
+		assert.Equal(t, "/nodes/foo%20bar%3Fbaz%23qux%25zap", httpReq.URL.EscapedPath())
+		assert.Equal(t, "http://example.com/nodes/foo%20bar%3Fbaz%23qux%25zap", httpReq.URL.String())
+	}
+}
+
+func TestBuildRequest_AllowsEncodedSlashInLiteralPath(t *testing.T) {
+	type payload struct {
+		Key string `path:"key"`
+	}
+
+	assert.NotPanics(t, func() {
+		httpReq, err := buildRequest(context.Background(), http.MethodGet,
+			"http://example.com/a%2Fb/:key", payload{Key: "ok"})
+		if assert.NoError(t, err) {
+			assert.Equal(t, "/a/b/ok", httpReq.URL.Path)
+			assert.Equal(t, "/a%2Fb/ok", httpReq.URL.EscapedPath())
+			assert.Equal(t, "http://example.com/a%2Fb/ok", httpReq.URL.String())
+		}
+	})
 }

--- a/rest/httpc/responses.go
+++ b/rest/httpc/responses.go
@@ -14,6 +14,7 @@ import (
 // Parse parses the response.
 func Parse(resp *http.Response, val any) error {
 	if err := ParseHeaders(resp, val); err != nil {
+		_ = resp.Body.Close()
 		return err
 	}
 

--- a/rest/httpc/responses_test.go
+++ b/rest/httpc/responses_test.go
@@ -2,6 +2,7 @@ package httpc
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zeromicro/go-zero/rest/internal/header"
 )
+
+type closingMockedReader struct {
+	closed bool
+	err    error
+}
 
 func TestParse(t *testing.T) {
 	var val struct {
@@ -46,6 +52,22 @@ func TestParseHeaderError(t *testing.T) {
 	resp, err := DoRequest(req)
 	assert.Nil(t, err)
 	assert.NotNil(t, Parse(resp, &val))
+}
+
+func TestParseHeaderErrorClosesBody(t *testing.T) {
+	var val struct {
+		Foo int `header:"foo"`
+	}
+	body := &closingMockedReader{}
+	resp := &http.Response{
+		Header: http.Header{
+			"Foo": []string{"bar"},
+		},
+		Body: body,
+	}
+
+	assert.Error(t, Parse(resp, &val))
+	assert.True(t, body.closed)
 }
 
 func TestParseNoBody(t *testing.T) {
@@ -177,4 +199,16 @@ func (m mockedReader) Close() error {
 
 func (m mockedReader) Read(_ []byte) (n int, err error) {
 	return 0, errors.New("dummy")
+}
+
+func (m *closingMockedReader) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *closingMockedReader) Read(_ []byte) (n int, err error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	return 0, io.EOF
 }

--- a/rest/httpx/requests.go
+++ b/rest/httpx/requests.go
@@ -117,6 +117,18 @@ func ParseHeader(headerValue string) map[string]string {
 func ParseJsonBody(r *http.Request, v any) error {
 	if withJsonBody(r) {
 		reader := io.LimitReader(r.Body, maxBodyLen)
+		if r.ContentLength < 0 {
+			data, err := io.ReadAll(reader)
+			if err != nil {
+				return err
+			}
+			if len(data) == 0 {
+				return mapping.UnmarshalJsonMap(nil, v)
+			}
+
+			return mapping.UnmarshalJsonBytes(data, v)
+		}
+
 		return mapping.UnmarshalJsonReader(reader, v)
 	}
 
@@ -151,5 +163,5 @@ func getValidator() Validator {
 }
 
 func withJsonBody(r *http.Request) bool {
-	return r.ContentLength > 0 && strings.Contains(r.Header.Get(header.ContentType), header.ApplicationJson)
+	return r.ContentLength != 0 && strings.Contains(r.Header.Get(header.ContentType), header.ApplicationJson)
 }

--- a/rest/httpx/requests_test.go
+++ b/rest/httpx/requests_test.go
@@ -497,6 +497,38 @@ func TestParseJsonBody(t *testing.T) {
 		assert.Error(t, Parse(r, &v))
 	})
 
+	t.Run("chunked body", func(t *testing.T) {
+		var v struct {
+			Name string `json:"name"`
+			Age  int    `json:"age"`
+		}
+
+		body := `{"name":"kevin", "age": 18}`
+		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+		r.Header.Set(ContentType, header.ContentTypeJson)
+		r.ContentLength = -1
+
+		if assert.NoError(t, ParseJsonBody(r, &v)) {
+			assert.Equal(t, "kevin", v.Name)
+			assert.Equal(t, 18, v.Age)
+		}
+	})
+
+	t.Run("empty chunked body", func(t *testing.T) {
+		var v struct {
+			Name string `json:"name,optional"`
+			Age  int    `json:"age,optional"`
+		}
+
+		r := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+		r.Header.Set(ContentType, header.ContentTypeJson)
+		r.ContentLength = -1
+
+		assert.NoError(t, ParseJsonBody(r, &v))
+		assert.Equal(t, "", v.Name)
+		assert.Equal(t, 0, v.Age)
+	})
+
 	t.Run("hasn't body", func(t *testing.T) {
 		var v struct {
 			Name string `json:"name,optional"`


### PR DESCRIPTION
## Summary
- handle unknown-length JSON bodies in rest/httpx while preserving empty-body behavior
- close response bodies when rest/httpc header parsing fails
- harden rest/httpc path handling for reserved characters, slash-containing variables, and encoded literal path segments

## Test Plan
- go test ./rest/httpc -run 'Test(Do_RejectsSlashInPathVariables|BuildRequest_EscapesReservedPathCharacters|BuildRequest_AllowsEncodedSlashInLiteralPath|ParseHeaderErrorClosesBody)'
- go test ./rest/httpx -run 'TestParseJsonBody/(chunked_body|empty_chunked_body)'
- go test ./rest/httpc ./rest/httpx