### PR TITLE
fix(discov): prevent etcd key leak when Watch DELETE races with lease expiry

### DIFF
--- a/core/discov/internal/etcdclient.go
+++ b/core/discov/internal/etcdclient.go
@@ -19,5 +19,6 @@ type EtcdClient interface {
 	KeepAlive(ctx context.Context, id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error)
 	Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error)
 	Revoke(ctx context.Context, id clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error)
+	TimeToLive(ctx context.Context, id clientv3.LeaseID, opts ...clientv3.LeaseOption) (*clientv3.LeaseTimeToLiveResponse, error)
 	Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan
 }

--- a/core/discov/internal/etcdclient_mock.go
+++ b/core/discov/internal/etcdclient_mock.go
@@ -169,6 +169,26 @@ func (mr *MockEtcdClientMockRecorder) Revoke(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revoke", reflect.TypeOf((*MockEtcdClient)(nil).Revoke), ctx, id)
 }
 
+// TimeToLive mocks base method.
+func (m *MockEtcdClient) TimeToLive(ctx context.Context, id clientv3.LeaseID, opts ...clientv3.LeaseOption) (*clientv3.LeaseTimeToLiveResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, id}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TimeToLive", varargs...)
+	ret0, _ := ret[0].(*clientv3.LeaseTimeToLiveResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TimeToLive indicates an expected call of TimeToLive.
+func (mr *MockEtcdClientMockRecorder) TimeToLive(ctx, id any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, id}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TimeToLive", reflect.TypeOf((*MockEtcdClient)(nil).TimeToLive), varargs...)
+}
+
 // Watch mocks base method.
 func (m *MockEtcdClient) Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
 	m.ctrl.T.Helper()

--- a/core/discov/publisher.go
+++ b/core/discov/publisher.go
@@ -151,6 +151,24 @@ func (p *Publisher) keepAliveAsync(cli internal.EtcdClient) error {
 					if evt.Type == clientv3.EventTypeDelete {
 						logc.Infof(cli.Ctx(), "etcd publisher watch: %s, event: %v",
 							evt.Kv.Key, evt.Type)
+
+						// Make sure the lease is still valid before re-putting the key.
+						// Otherwise the Put may happen with an already-expired or zero
+						// LeaseID (e.g. when the DELETE event is caused by lease expiry
+						// and races with KeepAlive channel close), which makes the key
+						// permanent in etcd (no TTL) and leaks forever.
+						ttlResp, ttlErr := cli.TimeToLive(cli.Ctx(), p.lease)
+						if ttlErr != nil || ttlResp == nil || ttlResp.TTL <= 0 {
+							logc.Errorf(cli.Ctx(),
+								"etcd publisher lease expired, skip re-put and restart keepalive: leaseID=%d, err=%v",
+								p.lease, ttlErr)
+							p.revoke(cli)
+							if err := p.doKeepAlive(); err != nil {
+								logc.Errorf(cli.Ctx(), "etcd publisher KeepAlive: %v", err)
+							}
+							return
+						}
+
 						_, err := cli.Put(cli.Ctx(), p.fullKey, p.value, clientv3.WithLease(p.lease))
 						if err != nil {
 							logc.Errorf(cli.Ctx(), "etcd publisher re-put key: %v", err)


### PR DESCRIPTION
## Problem

When a Watch DELETE event fires at the same time the KeepAlive channel closes — both triggered by the same lease expiry — the subsequent re-`Put` call uses an already-expired `LeaseID`. etcd accepts the `Put` but silently strips the TTL, making the key permanent in etcd. The key leaks forever and is never cleaned up.

This is a race between two concurrent signal paths:
1. `KeepAlive` channel closes → `revoke()` + `doKeepAlive()` restarts registration
2. `Watch` DELETE event fires → re-`Put` with the old (expired) `LeaseID`

If (2) wins the race, the key is re-put without a TTL.

## Solution

Before re-putting the key on a DELETE event, call `TimeToLive` to verify the lease is still alive. If TTL ≤ 0 or the call errors, skip the `Put` and restart the full registration flow via `revoke()` + `doKeepAlive()` instead.

## Changes

- `core/discov/internal/etcdclient.go`: Add `TimeToLive` to the `EtcdClient` interface
- `core/discov/internal/etcdclient_mock.go`: Add gomock implementation for `TimeToLive`
- `core/discov/publisher.go`: Guard the re-`Put` with a `TimeToLive` check in the Watch DELETE handler

Closes #5545