### PR TITLE
fix(goctl): resolve pb imports across sibling modules (#5511)

### DIFF
--- a/tools/goctl/rpc/generator/mkdir.go
+++ b/tools/goctl/rpc/generator/mkdir.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -82,9 +84,7 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 				return "", err
 			}
 		}
-		childPath = strings.TrimPrefix(abs, ctx.Dir)
-		pkg := filepath.Join(ctx.Path, childPath)
-		return filepath.ToSlash(pkg), nil
+		return resolveDirPackage(ctx, abs, ""), nil
 	}
 
 	var callClientDir string
@@ -106,9 +106,8 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 	if c.IsGenClient {
 		inner[call] = Dir{
 			Filename: callClientDir,
-			Package: filepath.ToSlash(filepath.Join(ctx.Path,
-				strings.TrimPrefix(callClientDir, ctx.Dir))),
-			Base: filepath.Base(callClientDir),
+			Package:  resolveDirPackage(ctx, callClientDir, ""),
+			Base:     filepath.Base(callClientDir),
 			GetChildPackage: func(childPath string) (string, error) {
 				return getChildPackage(callClientDir, childPath)
 			},
@@ -117,16 +116,15 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 
 	inner[wd] = Dir{
 		Filename: ctx.WorkDir,
-		Package: filepath.ToSlash(filepath.Join(ctx.Path,
-			strings.TrimPrefix(ctx.WorkDir, ctx.Dir))),
-		Base: filepath.Base(ctx.WorkDir),
+		Package:  resolveDirPackage(ctx, ctx.WorkDir, ""),
+		Base:     filepath.Base(ctx.WorkDir),
 		GetChildPackage: func(childPath string) (string, error) {
 			return getChildPackage(ctx.WorkDir, childPath)
 		},
 	}
 	inner[etc] = Dir{
 		Filename: etcDir,
-		Package:  filepath.ToSlash(filepath.Join(ctx.Path, strings.TrimPrefix(etcDir, ctx.Dir))),
+		Package:  resolveDirPackage(ctx, etcDir, ""),
 		Base:     filepath.Base(etcDir),
 		GetChildPackage: func(childPath string) (string, error) {
 			return getChildPackage(etcDir, childPath)
@@ -134,16 +132,15 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 	}
 	inner[internal] = Dir{
 		Filename: internalDir,
-		Package: filepath.ToSlash(filepath.Join(ctx.Path,
-			strings.TrimPrefix(internalDir, ctx.Dir))),
-		Base: filepath.Base(internalDir),
+		Package:  resolveDirPackage(ctx, internalDir, ""),
+		Base:     filepath.Base(internalDir),
 		GetChildPackage: func(childPath string) (string, error) {
 			return getChildPackage(internalDir, childPath)
 		},
 	}
 	inner[config] = Dir{
 		Filename: configDir,
-		Package:  filepath.ToSlash(filepath.Join(ctx.Path, strings.TrimPrefix(configDir, ctx.Dir))),
+		Package:  resolveDirPackage(ctx, configDir, ""),
 		Base:     filepath.Base(configDir),
 		GetChildPackage: func(childPath string) (string, error) {
 			return getChildPackage(configDir, childPath)
@@ -151,7 +148,7 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 	}
 	inner[logic] = Dir{
 		Filename: logicDir,
-		Package:  filepath.ToSlash(filepath.Join(ctx.Path, strings.TrimPrefix(logicDir, ctx.Dir))),
+		Package:  resolveDirPackage(ctx, logicDir, ""),
 		Base:     filepath.Base(logicDir),
 		GetChildPackage: func(childPath string) (string, error) {
 			return getChildPackage(logicDir, childPath)
@@ -159,7 +156,7 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 	}
 	inner[server] = Dir{
 		Filename: serverDir,
-		Package:  filepath.ToSlash(filepath.Join(ctx.Path, strings.TrimPrefix(serverDir, ctx.Dir))),
+		Package:  resolveDirPackage(ctx, serverDir, ""),
 		Base:     filepath.Base(serverDir),
 		GetChildPackage: func(childPath string) (string, error) {
 			return getChildPackage(serverDir, childPath)
@@ -167,7 +164,7 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 	}
 	inner[svc] = Dir{
 		Filename: svcDir,
-		Package:  filepath.ToSlash(filepath.Join(ctx.Path, strings.TrimPrefix(svcDir, ctx.Dir))),
+		Package:  resolveDirPackage(ctx, svcDir, ""),
 		Base:     filepath.Base(svcDir),
 		GetChildPackage: func(childPath string) (string, error) {
 			return getChildPackage(svcDir, childPath)
@@ -176,7 +173,7 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 
 	inner[pb] = Dir{
 		Filename: pbDir,
-		Package:  filepath.ToSlash(filepath.Join(ctx.Path, strings.TrimPrefix(pbDir, ctx.Dir))),
+		Package:  resolveDirPackage(ctx, pbDir, proto.GoPackage),
 		Base:     filepath.Base(pbDir),
 		GetChildPackage: func(childPath string) (string, error) {
 			return getChildPackage(pbDir, childPath)
@@ -185,9 +182,8 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 
 	inner[protoGo] = Dir{
 		Filename: protoGoDir,
-		Package: filepath.ToSlash(filepath.Join(ctx.Path,
-			strings.TrimPrefix(protoGoDir, ctx.Dir))),
-		Base: filepath.Base(protoGoDir),
+		Package:  resolveDirPackage(ctx, protoGoDir, proto.GoPackage),
+		Base:     filepath.Base(protoGoDir),
 		GetChildPackage: func(childPath string) (string, error) {
 			return getChildPackage(protoGoDir, childPath)
 		},
@@ -212,16 +208,111 @@ func mkdir(ctx *ctx.ProjectContext, proto parser.Proto, conf *conf.Config, c *ZR
 func (d *defaultDirContext) SetPbDir(pbDir, grpcDir string) {
 	d.inner[pb] = Dir{
 		Filename: pbDir,
-		Package:  filepath.ToSlash(filepath.Join(d.ctx.Path, strings.TrimPrefix(pbDir, d.ctx.Dir))),
+		Package:  resolveDirPackage(d.ctx, pbDir, d.inner[pb].Package),
 		Base:     filepath.Base(pbDir),
 	}
 
 	d.inner[protoGo] = Dir{
 		Filename: grpcDir,
-		Package: filepath.ToSlash(filepath.Join(d.ctx.Path,
-			strings.TrimPrefix(grpcDir, d.ctx.Dir))),
-		Base: filepath.Base(grpcDir),
+		Package:  resolveDirPackage(d.ctx, grpcDir, d.inner[protoGo].Package),
+		Base:     filepath.Base(grpcDir),
 	}
+}
+
+func resolveDirPackage(project *ctx.ProjectContext, dir, fallback string) string {
+	dir = filepath.Clean(dir)
+	projectDir := filepath.Clean(project.Dir)
+
+	if rel, ok := relativeImportPath(projectDir, dir); ok {
+		return joinImportPath(project.Path, rel)
+	}
+
+	if modulePath, moduleDir, ok := resolveModuleForDir(dir); ok {
+		if rel, ok := relativeImportPath(moduleDir, dir); ok {
+			return joinImportPath(modulePath, rel)
+		}
+	}
+
+	if isImportPath(fallback) {
+		return filepath.ToSlash(fallback)
+	}
+
+	return filepath.ToSlash(filepath.Base(dir))
+}
+
+func relativeImportPath(baseDir, targetDir string) (string, bool) {
+	rel, err := filepath.Rel(baseDir, targetDir)
+	if err != nil {
+		return "", false
+	}
+	if rel == "." {
+		return "", true
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", false
+	}
+
+	return filepath.ToSlash(rel), true
+}
+
+func joinImportPath(basePath, rel string) string {
+	if rel == "" || rel == "." {
+		return filepath.ToSlash(basePath)
+	}
+
+	return path.Join(filepath.ToSlash(basePath), filepath.ToSlash(rel))
+}
+
+func isImportPath(value string) bool {
+	if value == "" || strings.HasPrefix(value, ".") || strings.HasPrefix(value, "/") || filepath.IsAbs(value) {
+		return false
+	}
+
+	if len(value) >= 3 && value[1] == ':' {
+		switch value[2] {
+		case '/', '\\':
+			return false
+		}
+	}
+
+	return true
+}
+
+func resolveModuleForDir(dir string) (modulePath, moduleDir string, ok bool) {
+	current := filepath.Clean(dir)
+	for {
+		goMod := filepath.Join(current, "go.mod")
+		if info, err := os.Stat(goMod); err == nil && !info.IsDir() {
+			modulePath, err := readModulePath(goMod)
+			if err == nil && modulePath != "" {
+				return modulePath, current, true
+			}
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", "", false
+		}
+		current = parent
+	}
+}
+
+func readModulePath(goMod string) (string, error) {
+	data, err := os.ReadFile(goMod)
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		line, _, _ = strings.Cut(line, "//")
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "module" {
+			return fields[1], nil
+		}
+	}
+
+	return "", nil
 }
 
 func (d *defaultDirContext) GetCall() Dir {

--- a/tools/goctl/rpc/generator/mkdir_test.go
+++ b/tools/goctl/rpc/generator/mkdir_test.go
@@ -1,11 +1,14 @@
 package generator
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/emicklei/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/zeromicro/go-zero/tools/goctl/rpc/parser"
+	ctxpkg "github.com/zeromicro/go-zero/tools/goctl/util/ctx"
 )
 
 func TestServiceNameDetermination(t *testing.T) {
@@ -144,4 +147,269 @@ func TestServiceNameFallbackWithEmptyPackage(t *testing.T) {
 	// Should fall back to filename when package name is empty
 	serviceName := determineServiceName(p, ctx)
 	assert.Equal(t, "myservice", serviceName)
+}
+
+func TestJoinImportPathNormalizesSeparators(t *testing.T) {
+	got := joinImportPath("sales-center", filepath.Join("pb", "admin"))
+	assert.Equal(t, "sales-center/pb/admin", got)
+}
+
+func TestResolveDirPackageWithinCurrentModule(t *testing.T) {
+	tmp := t.TempDir()
+	mainDir := filepath.Join(tmp, "sales-admin")
+
+	err := os.MkdirAll(filepath.Join(mainDir, "internal", "logic"), 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(mainDir, "go.mod"), []byte("module sales-admin\n\ngo 1.25.5\n"), 0o644)
+	assert.NoError(t, err)
+
+	project := &ctxpkg.ProjectContext{
+		Path: "sales-admin",
+		Dir:  mainDir,
+	}
+
+	got := resolveDirPackage(project, filepath.Join(mainDir, "internal", "logic"), "")
+	assert.Equal(t, "sales-admin/internal/logic", got)
+}
+
+func TestResolveDirPackageForSiblingModule(t *testing.T) {
+	tmp := t.TempDir()
+	mainDir := filepath.Join(tmp, "sales-admin")
+	siblingDir := filepath.Join(tmp, "sales-center")
+	targetDir := filepath.Join(siblingDir, "pb", "admin")
+
+	err := os.MkdirAll(mainDir, 0o755)
+	assert.NoError(t, err)
+	err = os.MkdirAll(siblingDir, 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(mainDir, "go.mod"), []byte("module sales-admin\n\ngo 1.25.5\n"), 0o644)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(siblingDir, "go.mod"), []byte("module sales-center\n\ngo 1.25.5\n"), 0o644)
+	assert.NoError(t, err)
+
+	project := &ctxpkg.ProjectContext{
+		Path: "sales-admin",
+		Dir:  mainDir,
+	}
+
+	got := resolveDirPackage(project, targetDir, "")
+	assert.Equal(t, "sales-center/pb/admin", got)
+}
+
+func TestResolveDirPackageFallsBackToProvidedImportPath(t *testing.T) {
+	tmp := t.TempDir()
+	mainDir := filepath.Join(tmp, "sales-admin")
+	targetDir := filepath.Join(tmp, "generated", "admin")
+
+	err := os.MkdirAll(mainDir, 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(mainDir, "go.mod"), []byte("module sales-admin\n\ngo 1.25.5\n"), 0o644)
+	assert.NoError(t, err)
+
+	project := &ctxpkg.ProjectContext{
+		Path: "sales-admin",
+		Dir:  mainDir,
+	}
+
+	got := resolveDirPackage(project, targetDir, "sales-center/pb/admin")
+	assert.Equal(t, "sales-center/pb/admin", got)
+}
+
+func TestResolveModuleForDirStopsAtRoot(t *testing.T) {
+	tmp := t.TempDir()
+	targetDir := filepath.Join(tmp, "generated", "admin")
+
+	modulePath, moduleDir, ok := resolveModuleForDir(targetDir)
+	assert.False(t, ok)
+	assert.Empty(t, modulePath)
+	assert.Empty(t, moduleDir)
+}
+
+func TestResolveModuleForDirWithNonExistentDirectory(t *testing.T) {
+	// Should not panic when the directory doesn't exist on disk
+	modulePath, moduleDir, ok := resolveModuleForDir(filepath.Join("Z:", "nonexistent", "deep", "path"))
+	assert.False(t, ok)
+	assert.Empty(t, modulePath)
+	assert.Empty(t, moduleDir)
+}
+
+func TestResolveModuleForDirFindsGoModInParent(t *testing.T) {
+	tmp := t.TempDir()
+	moduleRoot := filepath.Join(tmp, "mymodule")
+	deepDir := filepath.Join(moduleRoot, "a", "b", "c", "d")
+
+	err := os.MkdirAll(deepDir, 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(moduleRoot, "go.mod"), []byte("module example.com/mymodule\n\ngo 1.21\n"), 0o644)
+	assert.NoError(t, err)
+
+	modulePath, moduleDir, ok := resolveModuleForDir(deepDir)
+	assert.True(t, ok)
+	assert.Equal(t, "example.com/mymodule", modulePath)
+	assert.Equal(t, moduleRoot, moduleDir)
+}
+
+func TestRelativeImportPathRejectsParentTraversal(t *testing.T) {
+	base := filepath.Join("a", "b", "c")
+	target := filepath.Join("a", "b")
+
+	_, ok := relativeImportPath(base, target)
+	assert.False(t, ok)
+}
+
+func TestRelativeImportPathSameDir(t *testing.T) {
+	dir := filepath.Join("a", "b", "c")
+	rel, ok := relativeImportPath(dir, dir)
+	assert.True(t, ok)
+	assert.Equal(t, "", rel)
+}
+
+func TestRelativeImportPathChild(t *testing.T) {
+	base := filepath.Join("a", "b")
+	target := filepath.Join("a", "b", "c", "d")
+
+	rel, ok := relativeImportPath(base, target)
+	assert.True(t, ok)
+	assert.Equal(t, "c/d", rel)
+}
+
+func TestIsImportPathVariousCases(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"", false},
+		{".", false},
+		{"./relative", false},
+		{"../parent", false},
+		{"/absolute/unix", false},
+		{"C:/windows/path", false},
+		{"C:\\windows\\path", false},
+		{"D:/some/path", false},
+		{"github.com/user/repo", true},
+		{"sales-center/pb/admin", true},
+		{"mypackage", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isImportPath(tt.input))
+		})
+	}
+}
+
+func TestReadModulePathWithComments(t *testing.T) {
+	tmp := t.TempDir()
+	goMod := filepath.Join(tmp, "go.mod")
+
+	content := "// this is a comment\nmodule example.com/commented // inline comment\n\ngo 1.21\n"
+	err := os.WriteFile(goMod, []byte(content), 0o644)
+	assert.NoError(t, err)
+
+	modulePath, err := readModulePath(goMod)
+	assert.NoError(t, err)
+	assert.Equal(t, "example.com/commented", modulePath)
+}
+
+func TestReadModulePathEmptyFile(t *testing.T) {
+	tmp := t.TempDir()
+	goMod := filepath.Join(tmp, "go.mod")
+
+	err := os.WriteFile(goMod, []byte(""), 0o644)
+	assert.NoError(t, err)
+
+	modulePath, err := readModulePath(goMod)
+	assert.NoError(t, err)
+	assert.Empty(t, modulePath)
+}
+
+func TestReadModulePathNoModuleDirective(t *testing.T) {
+	tmp := t.TempDir()
+	goMod := filepath.Join(tmp, "go.mod")
+
+	err := os.WriteFile(goMod, []byte("go 1.21\n\nrequire (\n)\n"), 0o644)
+	assert.NoError(t, err)
+
+	modulePath, err := readModulePath(goMod)
+	assert.NoError(t, err)
+	assert.Empty(t, modulePath)
+}
+
+func TestResolveDirPackageFallsBackToBasename(t *testing.T) {
+	tmp := t.TempDir()
+	mainDir := filepath.Join(tmp, "sales-admin")
+	targetDir := filepath.Join(tmp, "orphan-dir", "sub")
+
+	err := os.MkdirAll(mainDir, 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(mainDir, "go.mod"), []byte("module sales-admin\n\ngo 1.21\n"), 0o644)
+	assert.NoError(t, err)
+
+	project := &ctxpkg.ProjectContext{
+		Path: "sales-admin",
+		Dir:  mainDir,
+	}
+
+	// No go.mod in orphan-dir, no valid fallback → should use basename
+	got := resolveDirPackage(project, targetDir, "")
+	assert.Equal(t, "sub", got)
+}
+
+func TestResolveDirPackageWhenDirEqualsProjectDir(t *testing.T) {
+	tmp := t.TempDir()
+	mainDir := filepath.Join(tmp, "myproject")
+
+	err := os.MkdirAll(mainDir, 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(mainDir, "go.mod"), []byte("module example.com/myproject\n\ngo 1.21\n"), 0o644)
+	assert.NoError(t, err)
+
+	project := &ctxpkg.ProjectContext{
+		Path: "example.com/myproject",
+		Dir:  mainDir,
+	}
+
+	got := resolveDirPackage(project, mainDir, "")
+	assert.Equal(t, "example.com/myproject", got)
+}
+
+func TestJoinImportPathWithEmptyRel(t *testing.T) {
+	assert.Equal(t, "example.com/mod", joinImportPath("example.com/mod", ""))
+	assert.Equal(t, "example.com/mod", joinImportPath("example.com/mod", "."))
+}
+
+func TestSetPbDirKeepsExistingPackageWhenSiblingModuleHasNoGoMod(t *testing.T) {
+	tmp := t.TempDir()
+	mainDir := filepath.Join(tmp, "sales-admin")
+	pbDir := filepath.Join(tmp, "generated", "admin")
+
+	err := os.MkdirAll(mainDir, 0o755)
+	assert.NoError(t, err)
+	err = os.MkdirAll(pbDir, 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(mainDir, "go.mod"), []byte("module sales-admin\n\ngo 1.25.5\n"), 0o644)
+	assert.NoError(t, err)
+
+	project := &ctxpkg.ProjectContext{
+		Path: "sales-admin",
+		Dir:  mainDir,
+	}
+	dirCtx := &defaultDirContext{
+		ctx: project,
+		inner: map[string]Dir{
+			pb: {
+				Package: "sales-center/pb/admin",
+			},
+			protoGo: {
+				Package: "sales-center/pb/admin",
+			},
+		},
+	}
+
+	dirCtx.SetPbDir(pbDir, pbDir)
+
+	assert.Equal(t, "sales-center/pb/admin", dirCtx.GetPb().Package)
+	assert.Equal(t, "sales-center/pb/admin", dirCtx.GetProtoGo().Package)
+	assert.Equal(t, pbDir, dirCtx.GetPb().Filename)
+	assert.Equal(t, pbDir, dirCtx.GetProtoGo().Filename)
 }


### PR DESCRIPTION
## Summary

Fix `goctl rpc protoc` import generation when `--go_out` / `--go-grpc_out` point to a sibling Go module instead of the current module.

Previously, `goctl` derived the generated pb import path by joining the current project module path with the pb output directory on disk. On Windows, when the pb output directory lived outside the current module, this could produce invalid imports such as:

```go
"sales-admin/F:/coding/learn/zero-rpc/sales-center/pb/admin"
