### PR TITLE
fix(goctl/swagger): emit items for nested interface arrays

### DIFF
--- a/tools/goctl/api/swagger/swagger.go
+++ b/tools/goctl/api/swagger/swagger.go
@@ -125,6 +125,14 @@ func itemFromGoType(ctx Context, tp apiSpec.Type) *spec.SchemaOrArray {
 				},
 			},
 		}
+	case apiSpec.InterfaceType:
+		return &spec.SchemaOrArray{
+			Schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: []string{swaggerTypeObject},
+				},
+			},
+		}
 	case apiSpec.PointerType:
 		return itemFromGoType(ctx, itemType.Type)
 	case apiSpec.ArrayType:
@@ -149,7 +157,7 @@ func typeFromGoType(ctx Context, tp apiSpec.Type) []string {
 		}
 	case apiSpec.ArrayType:
 		return []string{swaggerTypeArray}
-	case apiSpec.DefineStruct, apiSpec.MapType:
+	case apiSpec.DefineStruct, apiSpec.InterfaceType, apiSpec.MapType:
 		return []string{swaggerTypeObject}
 	case apiSpec.PointerType:
 		return typeFromGoType(ctx, val.Type)
@@ -163,7 +171,7 @@ func sampleTypeFromGoType(ctx Context, tp apiSpec.Type) string {
 		return tpMapper[val.RawName]
 	case apiSpec.ArrayType:
 		return swaggerTypeArray
-	case apiSpec.DefineStruct, apiSpec.MapType, apiSpec.NestedStruct:
+	case apiSpec.DefineStruct, apiSpec.InterfaceType, apiSpec.MapType, apiSpec.NestedStruct:
 		return swaggerTypeObject
 	case apiSpec.PointerType:
 		return sampleTypeFromGoType(ctx, val.Type)

--- a/tools/goctl/api/swagger/swagger_test.go
+++ b/tools/goctl/api/swagger/swagger_test.go
@@ -3,8 +3,8 @@ package swagger
 import (
 	"testing"
 
-	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
 )
 
 func Test_pathVariable2SwaggerVariable(t *testing.T) {
@@ -66,7 +66,7 @@ func TestArrayDefinitionsBug(t *testing.T) {
 
 	// Verify the array field has correct structure
 	assert.Equal(t, "array", arrayField.Type[0])
-	
+
 	// Check that we have items
 	assert.NotNil(t, arrayField.Items, "Array should have items defined")
 	assert.NotNil(t, arrayField.Items.Schema, "Array items should have schema")
@@ -74,7 +74,7 @@ func TestArrayDefinitionsBug(t *testing.T) {
 	// The FIX: $ref should be inside items, not at schema level
 	hasRef := arrayField.Ref.String() != ""
 	assert.False(t, hasRef, "Schema level should NOT have $ref")
-	
+
 	// The $ref should be in the items
 	hasItemsRef := arrayField.Items.Schema.Ref.String() != ""
 	assert.True(t, hasItemsRef, "Items should have $ref")
@@ -137,4 +137,34 @@ func TestArrayWithoutDefinitions(t *testing.T) {
 	assert.Equal(t, "object", arrayField.Items.Schema.Type[0])
 	assert.Contains(t, arrayField.Items.Schema.Properties, "itemName")
 	assert.Equal(t, []string{"itemName"}, arrayField.Items.Schema.Required)
+}
+
+func TestNestedArrayInterfaceItems(t *testing.T) {
+	ctx := testingContext(t)
+	testStruct := spec.DefineStruct{
+		RawName: "TestStruct",
+		Members: []spec.Member{
+			{
+				Name: "Data",
+				Type: spec.ArrayType{
+					Value: spec.ArrayType{
+						Value: spec.InterfaceType{RawName: "interface{}"},
+					},
+				},
+				Tag: `json:"data"`,
+			},
+		},
+	}
+
+	properties, _ := propertiesFromType(ctx, testStruct)
+	arrayField := properties["data"]
+
+	assert.Equal(t, "array", arrayField.Type[0])
+	assert.NotNil(t, arrayField.Items)
+	assert.NotNil(t, arrayField.Items.Schema)
+	assert.Equal(t, "array", arrayField.Items.Schema.Type[0])
+	if assert.NotNil(t, arrayField.Items.Schema.Items) &&
+		assert.NotNil(t, arrayField.Items.Schema.Items.Schema) {
+		assert.Equal(t, "object", arrayField.Items.Schema.Items.Schema.Type[0])
+	}
 }


### PR DESCRIPTION
Fixes #5426

Summary
- Map API `interface{}` types to Swagger object schemas when building array item schemas.
- Preserve nested array item chains for shapes like `[][]interface{}` so generated Swagger 2.0 includes the required nested `items` field.

Test Plan
- `GOWORK=/tmp/go-zero-swagger-work/go.work GOCACHE=/tmp/go-build GOPROXY=https://goproxy.cn,direct go test ./api/swagger`