### PR TITLE
feat: mapping.Marshal supports JSON omitempty keyword

### DIFF
--- a/core/mapping/fieldoptions.go
+++ b/core/mapping/fieldoptions.go
@@ -11,6 +11,7 @@ type (
 		Inherit    bool
 		FromString bool
 		Optional   bool
+		Omitempty  bool
 		Options    []string
 		Default    string
 		EnvVar     string

--- a/core/mapping/marshaler.go
+++ b/core/mapping/marshaler.go
@@ -45,6 +45,20 @@ func Marshal(val any) (map[string]map[string]any, error) {
 	return ret, nil
 }
 
+func isEmptyValue(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true
+	}
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		return v.IsNil()
+	case reflect.Slice, reflect.Map:
+		return v.Len() == 0
+	default:
+		return v.IsZero()
+	}
+}
+
 func getTag(field reflect.StructField) (string, bool) {
 	tag := string(field.Tag)
 	if i := strings.Index(tag, tagKVSeparator); i >= 0 {
@@ -77,6 +91,10 @@ func processMember(field reflect.StructField, value reflect.Value,
 		key, opt, err = parseKeyAndOptions(tag, field)
 		if err != nil {
 			return err
+		}
+
+		if opt != nil && opt.Omitempty && isEmptyValue(value) {
+			return nil
 		}
 
 		if err = validate(field, value, opt); err != nil {

--- a/core/mapping/marshaler_test.go
+++ b/core/mapping/marshaler_test.go
@@ -474,3 +474,168 @@ func TestMarshal_Array(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "[1]", m["json"]["h"].(string))
 }
+
+func TestMarshal_Omitempty(t *testing.T) {
+	t.Run("string zero value", func(t *testing.T) {
+		v := struct {
+			Name string `json:"name,omitempty"`
+		}{
+			Name: "",
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		_, ok := m["json"]["name"]
+		assert.False(t, ok)
+	})
+
+	t.Run("string with value", func(t *testing.T) {
+		v := struct {
+			Name string `json:"name,omitempty"`
+		}{
+			Name: "test",
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		assert.Equal(t, "test", m["json"]["name"])
+	})
+
+	t.Run("int zero value", func(t *testing.T) {
+		v := struct {
+			Age int `json:"age,omitempty"`
+		}{
+			Age: 0,
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		_, ok := m["json"]["age"]
+		assert.False(t, ok)
+	})
+
+	t.Run("int with value", func(t *testing.T) {
+		v := struct {
+			Age int `json:"age,omitempty"`
+		}{
+			Age: 18,
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		assert.Equal(t, 18, m["json"]["age"])
+	})
+
+	t.Run("bool zero value", func(t *testing.T) {
+		v := struct {
+			Active bool `json:"active,omitempty"`
+		}{
+			Active: false,
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		_, ok := m["json"]["active"]
+		assert.False(t, ok)
+	})
+
+	t.Run("bool with value", func(t *testing.T) {
+		v := struct {
+			Active bool `json:"active,omitempty"`
+		}{
+			Active: true,
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		assert.Equal(t, true, m["json"]["active"])
+	})
+
+	t.Run("slice nil value", func(t *testing.T) {
+		v := struct {
+			Items []string `json:"items,omitempty"`
+		}{
+			Items: nil,
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		_, ok := m["json"]["items"]
+		assert.False(t, ok)
+	})
+
+	t.Run("slice empty value", func(t *testing.T) {
+		v := struct {
+			Items []string `json:"items,omitempty"`
+		}{
+			Items: []string{},
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		_, ok := m["json"]["items"]
+		assert.False(t, ok)
+	})
+
+	t.Run("slice with value", func(t *testing.T) {
+		v := struct {
+			Items []string `json:"items,omitempty"`
+		}{
+			Items: []string{"a", "b"},
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"a", "b"}, m["json"]["items"])
+	})
+
+	t.Run("pointer nil value", func(t *testing.T) {
+		type Item struct {
+			Name string `json:"name"`
+		}
+		v := struct {
+			Item *Item `json:"item,omitempty"`
+		}{
+			Item: nil,
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		_, ok := m["json"]["item"]
+		assert.False(t, ok)
+	})
+
+	t.Run("pointer with value", func(t *testing.T) {
+		type Item struct {
+			Name string `json:"name"`
+		}
+		v := struct {
+			Item *Item `json:"item,omitempty"`
+		}{
+			Item: &Item{Name: "test"},
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		assert.Equal(t, "test", m["json"]["item"].(*Item).Name)
+	})
+
+	t.Run("mixed omitempty and non-omitempty", func(t *testing.T) {
+		v := struct {
+			Name    string `json:"name,omitempty"`
+			Age     int    `json:"age"`
+			Address string `json:"address,omitempty"`
+		}{
+			Name:    "",
+			Age:     20,
+			Address: "beijing",
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		_, ok := m["json"]["name"]
+		assert.False(t, ok)
+		assert.Equal(t, 20, m["json"]["age"])
+		assert.Equal(t, "beijing", m["json"]["address"])
+	})
+
+	t.Run("omitempty with other options", func(t *testing.T) {
+		v := struct {
+			Token string `json:"token,omitempty,options=[abc,xyz]"`
+		}{
+			Token: "",
+		}
+		m, err := Marshal(v)
+		assert.Nil(t, err)
+		_, ok := m["json"]["token"]
+		assert.False(t, ok)
+	})
+}

--- a/core/mapping/utils.go
+++ b/core/mapping/utils.go
@@ -23,6 +23,7 @@ const (
 	optionalOption     = "optional"
 	optionsOption      = "options"
 	rangeOption        = "range"
+	omitemptyOption    = "omitempty"
 	optionSeparator    = "|"
 	equalToken         = "="
 	escapeChar         = '\\'
@@ -386,6 +387,8 @@ func parseOption(fieldOpts *fieldOptions, fieldName, option string) error {
 		default:
 			return fmt.Errorf("field %q has wrong optional", fieldName)
 		}
+	case option == omitemptyOption:
+		fieldOpts.Omitempty = true
 	case strings.HasPrefix(option, optionsOption):
 		val, err := parseProperty(fieldName, optionsOption, option)
 		if err != nil {


### PR DESCRIPTION
使用框架中自带的http请求客户端的时候发现使用 Do 方法传参时，即便结构体中的字段设置了 `omitempty` 关键字，实际发送请求时即使这个字段没有被赋值也会被传输过去造成一些参数校验的错误。后面发现是srtuct转map的时候没有支持这个关键字，这个pr就是添加了这个关键字的支持。
当然除了使用Do方法外也可以使用DoRequest 自定义请求来解决这个问题。