### PR TITLE
optimize bloom filter location generation using double hashing

### DIFF
--- a/core/bloom/bloom.go
+++ b/core/bloom/bloom.go
@@ -82,9 +82,15 @@ func (f *Filter) ExistsCtx(ctx context.Context, data []byte) (bool, error) {
 
 func (f *Filter) getLocations(data []byte) []uint {
 	locations := make([]uint, maps)
+
+	hashVal := hash.Hash(data)
+
+	h1 := hashVal
+	h2 := (hashVal >> 33) | 1
+
 	for i := uint(0); i < maps; i++ {
-		hashValue := hash.Hash(append(data, byte(i)))
-		locations[i] = uint(hashValue % uint64(f.bits))
+		combined := h1 + uint64(i)*h2
+		locations[i] = uint(combined % uint64(f.bits))
 	}
 
 	return locations


### PR DESCRIPTION
## Overview

This PR replaces repeated hashing in bloom filter location generation
with double hashing.

Previous implementation generated locations by repeatedly hashing:

    hash(data + i)

This approach had two issues:

1. Repeated hashing introduces unnecessary CPU overhead.
2. append(data, byte(i)) may mutate the underlying slice when capacity permits.

The new implementation uses standard double hashing:

    h_i(x) = h1(x) + i*h2(x)

Benefits:

- Reduces hash computations from O(k) to O(1)
- Avoids temporary slice allocations
- Prevents potential underlying array mutation
- Follows common bloom filter implementations used in practice