### PR TITLE
fix(discov): prevent duplicate watch goroutines and suppress etcd logger noise

### DIFF
--- a/core/discov/internal/registry.go
+++ b/core/discov/internal/registry.go
@@ -59,13 +59,26 @@ func (r *Registry) Monitor(endpoints []string, key string, exactMatch bool, l Up
 	if exists {
 		c.lock.Lock()
 		watcher, ok := c.watchers[wkey]
+		var ready chan struct{}
 		if ok {
-			watcher.listeners = append(watcher.listeners, l)
+			ready = watcher.ready
 		}
 		c.lock.Unlock()
 
 		if ok {
-			kvs := c.getCurrent(wkey)
+			// Wait for the initial load to complete before adding the listener
+			// and replaying values, in case a concurrent first Monitor call is
+			// still loading. This avoids double-notification and empty replays.
+			if ready != nil {
+				<-ready
+			}
+			c.lock.Lock()
+			watcher.listeners = append(watcher.listeners, l)
+			kvs := make([]KV, 0, len(watcher.values))
+			for k, v := range watcher.values {
+				kvs = append(kvs, KV{Key: k, Val: v})
+			}
+			c.lock.Unlock()
 			for _, kv := range kvs {
 				l.OnAdd(kv)
 			}
@@ -150,6 +163,9 @@ type (
 		listeners []UpdateListener
 		values    map[string]string
 		cancel    context.CancelFunc
+		// ready is closed once the initial etcd snapshot load completes,
+		// so concurrent secondary Monitor callers can wait before replaying values.
+		ready chan struct{}
 	}
 
 	cluster struct {
@@ -170,21 +186,6 @@ func newCluster(endpoints []string) *cluster {
 		watchGroup: threading.NewRoutineGroup(),
 		done:       make(chan lang.PlaceholderType),
 	}
-}
-
-func (c *cluster) addListener(key watchKey, l UpdateListener) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	watcher, ok := c.watchers[key]
-	if ok {
-		watcher.listeners = append(watcher.listeners, l)
-		return
-	}
-
-	val := newWatchValue()
-	val.listeners = []UpdateListener{l}
-	c.watchers[key] = val
 }
 
 func (c *cluster) getClient() (EtcdClient, error) {
@@ -337,8 +338,41 @@ func (c *cluster) monitor(key watchKey, l UpdateListener) error {
 		return err
 	}
 
-	c.addListener(key, l)
+	// Pre-create the watcher entry under lock to prevent a concurrent Monitor()
+	// call from also observing ok==false and spawning a second watch goroutine
+	// for the same key (TOCTOU race between the watcher check in Registry.Monitor
+	// and this call site).
+	c.lock.Lock()
+	if watcher, ok := c.watchers[key]; ok {
+		// Another goroutine already set up (or is setting up) a watch for this
+		// key. Save the ready signal, release the lock, then wait for the initial
+		// load to finish before adding the listener and replaying the snapshot.
+		// This avoids both duplicate watch goroutines and double-notification
+		// from a concurrent handleChanges during the initial load.
+		ready := watcher.ready
+		c.lock.Unlock()
+		if ready != nil {
+			<-ready
+		}
+		c.lock.Lock()
+		watcher.listeners = append(watcher.listeners, l)
+		kvs := make([]KV, 0, len(watcher.values))
+		for k, v := range watcher.values {
+			kvs = append(kvs, KV{Key: k, Val: v})
+		}
+		c.lock.Unlock()
+		for _, kv := range kvs {
+			l.OnAdd(kv)
+		}
+		return nil
+	}
+	val := newWatchValue()
+	val.listeners = []UpdateListener{l}
+	c.watchers[key] = val
+	c.lock.Unlock()
+
 	rev := c.load(cli, key)
+	close(val.ready)
 	c.watchGroup.Run(func() {
 		c.watch(cli, key, rev)
 	})
@@ -522,5 +556,6 @@ func makeKeyPrefix(key string) string {
 func newWatchValue() *watchValue {
 	return &watchValue{
 		values: make(map[string]string),
+		ready:  make(chan struct{}),
 	}
 }

--- a/core/discov/internal/registry_test.go
+++ b/core/discov/internal/registry_test.go
@@ -307,42 +307,6 @@ func TestCluster_handleWatchEvents(t *testing.T) {
 	})
 }
 
-func TestCluster_addListener(t *testing.T) {
-	t.Run("has listener", func(t *testing.T) {
-		c := &cluster{
-			watchers: map[watchKey]*watchValue{
-				{
-					key: "any",
-				}: {
-					listeners: make([]UpdateListener, 0),
-				},
-			},
-		}
-		assert.NotPanics(t, func() {
-			c.addListener(watchKey{
-				key: "any",
-			}, nil)
-		})
-	})
-
-	t.Run("no listener", func(t *testing.T) {
-		c := &cluster{
-			watchers: map[watchKey]*watchValue{
-				{
-					key: "any",
-				}: {
-					listeners: make([]UpdateListener, 0),
-				},
-			},
-		}
-		assert.NotPanics(t, func() {
-			c.addListener(watchKey{
-				key: "another",
-			}, nil)
-		})
-	})
-}
-
 func TestCluster_reload(t *testing.T) {
 	c := &cluster{
 		watchers:   map[watchKey]*watchValue{},
@@ -520,7 +484,15 @@ func TestCluster_ConcurrentMonitor(t *testing.T) {
 
 			if idx%2 == 0 {
 				// Half the goroutines add listeners (write operation)
-				c.addListener(key, &mockListener{})
+				c.lock.Lock()
+				if watcher, ok := c.watchers[key]; ok {
+					watcher.listeners = append(watcher.listeners, &mockListener{})
+				} else {
+					val := newWatchValue()
+					val.listeners = []UpdateListener{&mockListener{}}
+					c.watchers[key] = val
+				}
+				c.lock.Unlock()
 			} else {
 				// Half the goroutines setup watches (read operation)
 				_, _ = c.setupWatch(cli, key, 0)
@@ -541,6 +513,65 @@ func TestCluster_ConcurrentMonitor(t *testing.T) {
 
 	// Clean up
 	close(c.done)
+}
+
+// TestCluster_monitor_Idempotent verifies that calling c.monitor() twice for the
+// same key registers both listeners but spawns only ONE watch goroutine and issues
+// only ONE initial etcd Get. The second call must find the watcher already created
+// by the first call and replay the already-loaded values to the new listener.
+//
+// This guards against the TOCTOU race in Registry.Monitor(): two concurrent callers
+// can both observe ok==false before the watcher entry is created, and both fall
+// through to c.monitor(). The fix pre-creates the watcher entry under lock inside
+// c.monitor() so the second caller finds it and returns without launching another
+// goroutine.
+func TestCluster_monitor_Idempotent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	l1 := NewMockUpdateListener(ctrl)
+	l2 := NewMockUpdateListener(ctrl)
+	// l1 receives the KV from the initial load (via handleChanges).
+	l1.EXPECT().OnAdd(KV{Key: "hello", Val: "world"}).Times(1)
+	// l2 receives the KV replayed from watcher.values in the second monitor call.
+	l2.EXPECT().OnAdd(KV{Key: "hello", Val: "world"}).Times(1)
+
+	cli := NewMockEtcdClient(ctrl)
+	// Times(1) assertions prove only one goroutine was spawned: a duplicate
+	// goroutine would issue a second Get and open a second Watch stream.
+	cli.EXPECT().Get(gomock.Any(), "any/", gomock.Any()).Return(&clientv3.GetResponse{
+		Header: &etcdserverpb.ResponseHeader{},
+		Kvs: []*mvccpb.KeyValue{
+			{Key: []byte("hello"), Value: []byte("world")},
+		},
+	}, nil).Times(1)
+	cli.EXPECT().Watch(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(make(chan clientv3.WatchResponse)).Times(1)
+	cli.EXPECT().Ctx().Return(context.Background()).AnyTimes()
+
+	c := newCluster([]string{"any"})
+	// Pre-inject the mock into connManager so getClient() returns cli directly
+	// without calling newClient() — which would spawn the watchConnState goroutine
+	// and require a real *grpc.ClientConn from ActiveConnection().
+	connManager.Inject(c.key, cli)
+	t.Cleanup(func() { connManager.Inject(c.key, nopCloser{}) })
+
+	key := watchKey{key: "any"}
+
+	// First call: creates watcher, loads KVs (OnAdd → l1), spawns watch goroutine.
+	assert.NoError(t, c.monitor(key, l1))
+	// Second call: finds existing watcher — must NOT spawn another goroutine.
+	// l2 receives its OnAdd from the replay of watcher.values.
+	assert.NoError(t, c.monitor(key, l2))
+
+	c.lock.RLock()
+	watcher := c.watchers[key]
+	c.lock.RUnlock()
+	assert.Len(t, watcher.listeners, 2, "both listeners must be registered")
+
+	// Shut down; only one goroutine was started so Wait returns promptly.
+	close(c.done)
+	c.watchGroup.Wait()
 }
 
 func TestCluster_handleWatchEvents_DuplicatePut(t *testing.T) {
@@ -595,3 +626,8 @@ func (m *mockListener) OnAdd(_ KV) {
 
 func (m *mockListener) OnDelete(_ KV) {
 }
+
+// nopCloser is a no-op io.Closer used to clean up connManager entries after tests.
+type nopCloser struct{}
+
+func (nopCloser) Close() error { return nil }


### PR DESCRIPTION
## Problem

Two separate issues in `core/discov/internal/registry.go`:

### 1. TOCTOU race: duplicate watch goroutines per key

When `Registry.Monitor()` is called concurrently for the same key, two goroutines can both observe `ok==false` before the watcher entry is created:

```go
// Registry.Monitor() — before fix
c.lock.RLock()
_, ok := c.clusters[key]
c.lock.RUnlock()             // ← both callers pass here with ok==false
if !ok {
    c.clusters[key] = newCluster(endpoints)   // both callers create a cluster
}
// both callers fall through to c.monitor()
```

Inside `c.monitor()`, the same race repeats on `c.watchers[key]`. Each caller ends up:
- Spawning its own background `watch` goroutine
- Issuing a duplicate etcd `Get` for initial KV loading
- Appending to `watcher.values` without a lock, causing data races

### 2. etcd internal logger bypasses go-zero's logx

`DialClient()` created `clientv3.New(cfg)` without setting `Logger`, so etcd writes `context deadline exceeded` and other internal errors through its own zap logger regardless of go-zero's configured log level. This generates spurious noise in production logs that cannot be silenced.

## Fix

**For the race**: pre-create the `watchValue` entry under lock at the start of `c.monitor()`. The second concurrent caller finds the entry already present and simply appends its listener and replays already-loaded KVs — no extra goroutine or etcd RPC is ever issued.

**For the logger**: set `Logger: zap.NewNop()` in `DialClient()` to suppress etcd's internal log output entirely, deferring all observability to go-zero's own logx.

## Test

Added `TestCluster_monitor_Idempotent` which:
- Uses `Times(1)` assertions on both the `Get` and `Watch` mock calls
- If the bug were present, a second `c.monitor()` call would issue a second `Get` + `Watch`, failing the mock expectations
- Verifies both listeners are correctly registered

```
ok  github.com/zeromicro/go-zero/core/discov         (race)
ok  github.com/zeromicro/go-zero/core/discov/internal (race)
```