### PR TITLE
feat: support redis sentinel mode #2381

### DIFF
--- a/core/stores/redis/conf.go
+++ b/core/stores/redis/conf.go
@@ -12,6 +12,8 @@ var (
 	ErrEmptyType = errors.New("empty redis type")
 	// ErrEmptyKey is an error that indicates no redis key is set.
 	ErrEmptyKey = errors.New("empty redis key")
+	// ErrEmptyMasterName is an error that indicates no master name is set when type is sentinel
+	ErrEmptyMasterName = errors.New("empty redis master name")
 )
 
 type (
@@ -25,6 +27,8 @@ type (
 		NonBlock bool   `json:",default=true"`
 		// PingTimeout is the timeout for ping redis.
 		PingTimeout time.Duration `json:",default=1s"`
+		// MasterName is used by sentinel as the indicator of redis master.
+		MasterName string `json:",optional"`
 	}
 
 	// A RedisKeyConf is a redis config with key.
@@ -38,8 +42,11 @@ type (
 // Deprecated: use MustNewRedis or NewRedis instead.
 func (rc RedisConf) NewRedis() *Redis {
 	var opts []Option
-	if rc.Type == ClusterType {
+	switch rc.Type {
+	case ClusterType:
 		opts = append(opts, Cluster())
+	case SentinelType:
+		opts = append(opts, Sentinel(), WithMasterName(rc.MasterName))
 	}
 	if len(rc.User) > 0 {
 		opts = append(opts, WithUser(rc.User))
@@ -62,6 +69,10 @@ func (rc RedisConf) Validate() error {
 
 	if len(rc.Type) == 0 {
 		return ErrEmptyType
+	}
+
+	if rc.Type == SentinelType && len(rc.MasterName) == 0 {
+		return ErrEmptyMasterName
 	}
 
 	return nil

--- a/core/stores/redis/conf_test.go
+++ b/core/stores/redis/conf_test.go
@@ -50,6 +50,24 @@ func TestRedisConf(t *testing.T) {
 			},
 			ok: true,
 		},
+		{
+			name: "sentinel ok",
+			RedisConf: RedisConf{
+				Host:       "localhost:26379",
+				Type:       SentinelType,
+				MasterName: "mymaster",
+			},
+			ok: true,
+		},
+		{
+			name: "sentinel missing master name",
+			RedisConf: RedisConf{
+				Host:       "localhost:26379",
+				Type:       SentinelType,
+				MasterName: "",
+			},
+			ok: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -20,6 +20,8 @@ const (
 	ClusterType = "cluster"
 	// NodeType means redis node.
 	NodeType = "node"
+	// SentinelType means redis sentinel.
+	SentinelType = "sentinel"
 	// Nil is an alias of redis.Nil.
 	Nil = red.Nil
 
@@ -51,15 +53,16 @@ type (
 		Score float64
 	}
 
-	// Redis defines a redis node/cluster. It is thread-safe.
+	// Redis defines a redis node/cluster/sentinel. It is thread-safe.
 	Redis struct {
-		Addr  string
-		Type  string
-		User  string
-		Pass  string
-		tls   bool
-		brk   breaker.Breaker
-		hooks []red.Hook
+		Addr       string
+		Type       string
+		User       string
+		Pass       string
+		tls        bool
+		brk        breaker.Breaker
+		hooks      []red.Hook
+		MasterName string
 	}
 
 	// RedisNode interface represents a redis node.
@@ -123,9 +126,11 @@ func NewRedis(conf RedisConf, opts ...Option) (*Redis, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, err
 	}
-
-	if conf.Type == ClusterType {
+	switch conf.Type {
+	case ClusterType:
 		opts = append([]Option{Cluster()}, opts...)
+	case SentinelType:
+		opts = append([]Option{Sentinel(), WithMasterName(conf.MasterName)}, opts...)
 	}
 	if len(conf.User) > 0 {
 		opts = append([]Option{WithUser(conf.User)}, opts...)
@@ -2678,6 +2683,13 @@ func Cluster() Option {
 	}
 }
 
+// Sentinel customizes the given Redis as monitored by sentinel
+func Sentinel() Option {
+	return func(r *Redis) {
+		r.Type = SentinelType
+	}
+}
+
 // SetSlowThreshold sets the slow threshold.
 func SetSlowThreshold(threshold time.Duration) {
 	slowThreshold.Set(threshold)
@@ -2711,6 +2723,12 @@ func WithUser(user string) Option {
 	}
 }
 
+func WithMasterName(masterName string) Option {
+	return func(r *Redis) {
+		r.MasterName = masterName
+	}
+}
+
 func acceptable(err error) bool {
 	return err == nil || errorx.In(err, red.Nil, context.Canceled)
 }
@@ -2721,6 +2739,8 @@ func getRedis(r *Redis) (RedisNode, error) {
 		return getCluster(r)
 	case NodeType:
 		return getClient(r)
+	case SentinelType:
+		return getSentinel(r)
 	default:
 		return nil, fmt.Errorf("redis type '%s' is not supported", r.Type)
 	}

--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -130,6 +130,25 @@ func TestNewRedis(t *testing.T) {
 			ok:       true,
 			redisErr: true,
 		},
+		{
+			name: "sentinel error",
+			RedisConf: RedisConf{
+				Host:       r2.Addr(),
+				Type:       SentinelType,
+				MasterName: "mymaster",
+			},
+			ok:       true,
+			redisErr: true,
+		},
+		{
+			name: "sentinel missing master name",
+			RedisConf: RedisConf{
+				Host:       r1.Addr(),
+				Type:       SentinelType,
+				MasterName: "",
+			},
+			ok: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/core/stores/redis/redissentinelmanager.go
+++ b/core/stores/redis/redissentinelmanager.go
@@ -1,0 +1,56 @@
+package redis
+
+import (
+	"crypto/tls"
+	"io"
+	"runtime"
+
+	red "github.com/redis/go-redis/v9"
+	"github.com/zeromicro/go-zero/core/syncx"
+)
+
+var (
+	sentinelManager  = syncx.NewResourceManager()
+	sentinelPoolSize = 5 * runtime.GOMAXPROCS(0)
+)
+
+func getSentinel(r *Redis) (*red.Client, error) {
+	val, err := sentinelManager.GetResource(r.Addr, func() (io.Closer, error) {
+		var tlsConfig *tls.Config
+		if r.tls {
+			tlsConfig = &tls.Config{
+				InsecureSkipVerify: true,
+			}
+		}
+		store := red.NewFailoverClient(&red.FailoverOptions{
+			SentinelAddrs: splitClusterAddrs(r.Addr),
+			MasterName:    r.MasterName,
+			Username:      r.User,
+			Password:      r.Pass,
+			MaxRetries:    maxRetries,
+			MinIdleConns:  idleConns,
+			TLSConfig:     tlsConfig,
+		})
+
+		hooks := append([]red.Hook{defaultDurationHook, breakerHook{
+			brk: r.brk,
+		}}, r.hooks...)
+		for _, hook := range hooks {
+			store.AddHook(hook)
+		}
+		connCollector.registerClient(&statGetter{
+			clientType: SentinelType,
+			key:        r.Addr,
+			poolSize:   sentinelPoolSize,
+			poolStats: func() *red.PoolStats {
+				return store.PoolStats()
+			},
+		})
+
+		return store, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return val.(*red.Client), nil
+}

--- a/core/stores/redis/redissentinelmanager_test.go
+++ b/core/stores/redis/redissentinelmanager_test.go
@@ -1,0 +1,36 @@
+package redis
+
+import (
+	"testing"
+
+	"github.com/Bose/minisentinel"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSentinel(t *testing.T) {
+	m := miniredis.RunT(t)
+	defer m.Close()
+
+	masterName := "redis-master"
+
+	replicaOpts := []minisentinel.Option{minisentinel.WithMasterName(masterName)}
+	for range 2 {
+		s := miniredis.RunT(t)
+		defer s.Close()
+
+		replicaOpts = append(replicaOpts, minisentinel.WithReplica(s))
+	}
+
+	s := minisentinel.NewSentinel(m, replicaOpts...)
+	defer s.Close()
+	require.NoError(t, s.Start())
+
+	c, err := getSentinel(&Redis{
+		MasterName: masterName,
+		Addr:       s.Addr(),
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/zeromicro/go-zero
 go 1.24.0
 
 require (
+	github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/fatih/color v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,13 @@
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
+github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb h1:ZVN4Iat3runWOFLaBCDVU5a9X/XikSRBosye++6gojw=
+github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb/go.mod h1:WsAABbY4HQBgd3mGuG4KMNTbHJCPvx9IVBHzysbknss=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/FZambia/sentinel v1.0.0 h1:KJ0ryjKTZk5WMp0dXvSdNqp3lFaW1fNFuEYfrkLOYIc=
+github.com/FZambia/sentinel v1.0.0/go.mod h1:ytL1Am/RLlAoAXG6Kj5LNuw/TRRQrv2rt2FT26vP5gI=
+github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
+github.com/alicebob/miniredis/v2 v2.11.1/go.mod h1:UA48pmi7aSazcGAvcdKcBB49z521IC9VjTTRz2nIaJE=
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -18,6 +24,9 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
@@ -69,6 +78,8 @@ github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9v
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3 h1:6amM4HsNPOvMLVc2ZnyqrjeQ92YAVWn7T4WBKK87inY=
+github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -78,6 +89,7 @@ github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbc
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grafana/pyroscope-go v1.3.0 h1:t3Jehad8vvqN4oRAB0LdmfQ5ZSUXQw3asoft+K4GAT8=
@@ -122,6 +134,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
+github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -214,6 +228,8 @@ github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfS
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v0.0.0-20190206043414-8bfc7677f583/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
+github.com/yuin/gopher-lua v0.0.0-20191213034115-f46add6fdb5c/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
@@ -291,6 +307,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Issue [#2381](https://github.com/zeromicro/go-zero/issues/2381)

This PR introduces Redis Sentinel support in go-zero by leveraging `redis.NewFailoverClient` from go-redis/v9, enabling high availability without requiring Redis Cluster.

Key changes:
- Added new `SentinelType` constant to distinguish Sentinel mode
- Updated client creation logic to use `NewFailoverClient` when `Type: SentinelType`
- Configuration now accepts comma-separated Sentinel addresses in `Host` and requires `MasterName`
- Added unit tests for Sentinel client initialization

Example usage:
```go
	c := redis.MustNewRedis(redis.RedisConf{
		Type: redis.SentinelType,
		Host: strings.Join([]string{
			"10.244.2.24:26379", // the addresses of sentinel instances
			"10.244.1.15:26379",
			"10.244.2.26:26379",
		}, ","),
		MasterName: "mymaster",
	})
```

The returned *redis.Client remains fully compatible with the existing RedisNode interface.

This is a recreated PR of #5438