### PR TITLE
fix(stringx): reject start > stop in Substr to prevent slice panic

### DIFF
--- a/core/stringx/strings.go
+++ b/core/stringx/strings.go
@@ -132,7 +132,7 @@ func Substr(str string, start, stop int) (string, error) {
 		return "", ErrInvalidStartPosition
 	}
 
-	if stop < 0 || stop > length {
+	if stop < 0 || stop > length || start > stop {
 		return "", ErrInvalidStopPosition
 	}
 

--- a/core/stringx/strings_test.go
+++ b/core/stringx/strings_test.go
@@ -356,6 +356,13 @@ func TestSubstr(t *testing.T) {
 			err:    ErrInvalidStopPosition,
 			expect: "",
 		},
+		{
+			input:  "hello",
+			start:  3,
+			stop:   2,
+			err:    ErrInvalidStopPosition,
+			expect: "",
+		},
 	}
 
 	for _, each := range cases {


### PR DESCRIPTION
Closes #5607.

`Substr` validates `start` and `stop` individually against `[0, length]` but never checks that `start <= stop`, so calls like `Substr("hello", 3, 2)` slip past both guards and panic on `rs[3:2]`. Treat `start > stop` as an invalid stop position so callers get `ErrInvalidStopPosition` instead of a runtime panic.