### PR TITLE
fix(stringx): return empty string from FirstN when n is negative

### DIFF
--- a/core/stringx/strings.go
+++ b/core/stringx/strings.go
@@ -34,6 +34,10 @@ func Filter(s string, remove func(r rune) bool) string {
 
 // FirstN returns first n runes from s.
 func FirstN(s string, n int, ellipsis ...string) string {
+	if n < 0 {
+		return ""
+	}
+
 	var i int
 
 	for j := range s {

--- a/core/stringx/strings_test.go
+++ b/core/stringx/strings_test.go
@@ -190,6 +190,18 @@ func TestFirstN(t *testing.T) {
 			n:      10,
 			expect: "我是中国人",
 		},
+		{
+			name:   "negative n returns empty string",
+			input:  "hello world",
+			n:      -1,
+			expect: "",
+		},
+		{
+			name:   "negative n with utf8 returns empty string",
+			input:  "我是中国人",
+			n:      -5,
+			expect: "",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #5614.

`FirstN` uses a rune-iteration loop where `i` counts up from `0` and
exits early when `i == n`. When `n` is a negative integer, `i` can
never equal `n`, so the entire string is returned instead of an empty
string. Negative lengths are not meaningful, and returning the full
input silently is surprising to callers.

The fix adds an early-return guard at the top of the function:

```go
if n < 0 {
    return ""
}
```

Two regression test cases are added covering ASCII and UTF-8 inputs
with negative `n`.