### PR TITLE
fix(dartgen): convert mapped list fields to lists in toJson

### DIFF
--- a/tools/goctl/api/dartgen/gendata.go
+++ b/tools/goctl/api/dartgen/gendata.go
@@ -26,7 +26,7 @@ class {{.Name}}{
 	}
 	Map<String,dynamic> toJson() {
 		return { {{range .Members}}
-			'{{getPropertyFromMember .}}': {{if isDirectType .Type.Name}}{{lowCamelCase .Name}}{{else if isClassListType .Type.Name}}{{lowCamelCase .Name}}.map((i) => i.toJson()){{else}}{{lowCamelCase .Name}}.toJson(){{end}},{{end}}
+			'{{getPropertyFromMember .}}': {{if isDirectType .Type.Name}}{{lowCamelCase .Name}}{{else if isClassListType .Type.Name}}{{lowCamelCase .Name}}.map((i) => i.toJson()).toList(){{else}}{{lowCamelCase .Name}}.toJson(){{end}},{{end}}
 		};
 	}
 
@@ -71,7 +71,7 @@ class {{.Name}} {
 				{{else if isMapType .Type.Name}}
 					{{lowCamelCase .Name}}
 				{{else if isClassListType .Type.Name}}
-					{{lowCamelCase .Name}}{{if isNullableType .Type.Name}}?{{end}}.map((i) => i{{if isListItemsNullable .Type.Name}}?{{end}}.toJson())
+					{{lowCamelCase .Name}}{{if isNullableType .Type.Name}}?{{end}}.map((i) => i{{if isListItemsNullable .Type.Name}}?{{end}}.toJson()).toList()
 				{{else}}
 					{{lowCamelCase .Name}}{{if isNullableType .Type.Name}}?{{end}}.toJson()
 				{{end}}

--- a/tools/goctl/api/dartgen/gendata_test.go
+++ b/tools/goctl/api/dartgen/gendata_test.go
@@ -1,0 +1,91 @@
+package dartgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
+)
+
+func TestGenDataClassListToJsonUsesToList(t *testing.T) {
+	tests := []struct {
+		name        string
+		legacy      bool
+		wantSnippet string
+	}{
+		{
+			name:        "v2",
+			wantSnippet: "items.map((i) => i?.toJson()).toList()",
+		},
+		{
+			name:        "legacy",
+			legacy:      true,
+			wantSnippet: "'items': items.map((i) => i.toJson()).toList()",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "data") + string(os.PathSeparator)
+
+			if err := genData(dir, newClassListApiSpec(), tt.legacy); err != nil {
+				t.Fatal(err)
+			}
+
+			data, err := os.ReadFile(filepath.Join(dir, "test.dart"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := string(data)
+			if !strings.Contains(got, tt.wantSnippet) {
+				t.Fatalf("generated Dart does not contain %q:\n%s", tt.wantSnippet, got)
+			}
+		})
+	}
+}
+
+func newClassListApiSpec() *spec.ApiSpec {
+	return &spec.ApiSpec{
+		Info: spec.Info{
+			Title: "test",
+		},
+		Service: spec.Service{
+			Name: "Test",
+		},
+		Types: []spec.Type{
+			spec.DefineStruct{
+				RawName: "GetTopUpProductsResponse",
+				Members: []spec.Member{
+					{
+						Name: "Items",
+						Type: spec.ArrayType{
+							RawName: "[]*TopUpProductItem",
+							Value: spec.PointerType{
+								RawName: "*TopUpProductItem",
+								Type: spec.DefineStruct{
+									RawName: "TopUpProductItem",
+								},
+							},
+						},
+						Tag: "`json:\"items\"`",
+					},
+				},
+			},
+			spec.DefineStruct{
+				RawName: "TopUpProductItem",
+				Members: []spec.Member{
+					{
+						Name: "ProductId",
+						Type: spec.PrimitiveType{
+							RawName: "string",
+						},
+						Tag: "`json:\"productId\"`",
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## What this PR does

This fixes Dart code generated by `goctl api dartgen` for class list fields in `toJson()`.

Previously, generated `toJson()` returned a `MappedListIterable` for fields such as `List<Foo>` / `List<Foo?>`:

```dart
'items': items.map((i) => i?.toJson())
```

That value cannot be encoded by `dart:convert` when calling `jsonEncode(obj.toJson())`.

This PR appends `.toList()` in both the current and legacy dart data templates:

```dart
'items': items.map((i) => i?.toJson()).toList()
```

Fixes #5629.

## Tests

```bash
cd tools/goctl
go test ./api/dartgen
go test ./api/...
```
