### PR TITLE
fix(redis): verify TLS server certificates

### DIFF
--- a/core/stores/redis/conf.go
+++ b/core/stores/redis/conf.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"crypto/tls"
 	"errors"
 	"time"
 )
@@ -53,7 +52,7 @@ func (rc RedisConf) NewRedis() *Redis {
 	}
 	if rc.Tls {
 		if rc.TlsInsecureSkipVerify {
-			opts = append(opts, WithTLSConfig(&tls.Config{InsecureSkipVerify: true}))
+			opts = append(opts, withInsecureTLS())
 		} else {
 			opts = append(opts, WithTLS())
 		}

--- a/core/stores/redis/conf.go
+++ b/core/stores/redis/conf.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"crypto/tls"
 	"errors"
 	"time"
 )
@@ -17,12 +18,15 @@ var (
 type (
 	// A RedisConf is a redis config.
 	RedisConf struct {
-		Host     string
-		Type     string `json:",default=node,options=node|cluster"`
-		User     string `json:",optional"`
-		Pass     string `json:",optional"`
-		Tls      bool   `json:",optional"`
-		NonBlock bool   `json:",default=true"`
+		Host string
+		Type string `json:",default=node,options=node|cluster"`
+		User string `json:",optional"`
+		Pass string `json:",optional"`
+		Tls  bool   `json:",optional"`
+		// TlsInsecureSkipVerify disables server certificate verification when Tls is true.
+		// It should be used only as a temporary migration aid.
+		TlsInsecureSkipVerify bool `json:",optional"`
+		NonBlock              bool `json:",default=true"`
 		// PingTimeout is the timeout for ping redis.
 		PingTimeout time.Duration `json:",default=1s"`
 	}
@@ -48,7 +52,11 @@ func (rc RedisConf) NewRedis() *Redis {
 		opts = append(opts, WithPass(rc.Pass))
 	}
 	if rc.Tls {
-		opts = append(opts, WithTLS())
+		if rc.TlsInsecureSkipVerify {
+			opts = append(opts, WithTLSConfig(&tls.Config{InsecureSkipVerify: true}))
+		} else {
+			opts = append(opts, WithTLS())
+		}
 	}
 
 	return newRedis(rc.Host, opts...)

--- a/core/stores/redis/conf_test.go
+++ b/core/stores/redis/conf_test.go
@@ -30,6 +30,15 @@ func TestRedisConfTLSVerification(t *testing.T) {
 		TlsInsecureSkipVerify: true,
 	}.NewRedis()
 	assert.Equal(t, insecure.tlsConfigKey, insecureAgain.tlsConfigKey)
+	insecurePrimary, err := NewRedis(RedisConf{
+		Host:                  "redis.example.com:6379",
+		Type:                  NodeType,
+		Tls:                   true,
+		TlsInsecureSkipVerify: true,
+		NonBlock:              true,
+	})
+	assert.NoError(t, err)
+	assert.True(t, insecurePrimary.tlsConfig.InsecureSkipVerify)
 
 	custom, err := NewRedis(RedisConf{
 		Host:     "redis.example.com:6379",

--- a/core/stores/redis/conf_test.go
+++ b/core/stores/redis/conf_test.go
@@ -1,11 +1,38 @@
 package redis
 
 import (
+	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zeromicro/go-zero/core/stringx"
 )
+
+func TestRedisConfTLSVerification(t *testing.T) {
+	secure := RedisConf{
+		Host: "redis.example.com:6379",
+		Type: NodeType,
+		Tls:  true,
+	}.NewRedis()
+	assert.False(t, secure.tlsConfig.InsecureSkipVerify)
+
+	insecure := RedisConf{
+		Host:                  "redis.example.com:6379",
+		Type:                  NodeType,
+		Tls:                   true,
+		TlsInsecureSkipVerify: true,
+	}.NewRedis()
+	assert.True(t, insecure.tlsConfig.InsecureSkipVerify)
+
+	custom, err := NewRedis(RedisConf{
+		Host:     "redis.example.com:6379",
+		Type:     NodeType,
+		Tls:      true,
+		NonBlock: true,
+	}, WithTLSConfig(&tls.Config{ServerName: "redis.internal"}))
+	assert.NoError(t, err)
+	assert.Equal(t, "redis.internal", custom.tlsConfig.ServerName)
+}
 
 func TestRedisConf(t *testing.T) {
 	tests := []struct {

--- a/core/stores/redis/conf_test.go
+++ b/core/stores/redis/conf_test.go
@@ -23,6 +23,13 @@ func TestRedisConfTLSVerification(t *testing.T) {
 		TlsInsecureSkipVerify: true,
 	}.NewRedis()
 	assert.True(t, insecure.tlsConfig.InsecureSkipVerify)
+	insecureAgain := RedisConf{
+		Host:                  "redis.example.com:6379",
+		Type:                  NodeType,
+		Tls:                   true,
+		TlsInsecureSkipVerify: true,
+	}.NewRedis()
+	assert.Equal(t, insecure.tlsConfigKey, insecureAgain.tlsConfigKey)
 
 	custom, err := NewRedis(RedisConf{
 		Host:     "redis.example.com:6379",

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	red "github.com/redis/go-redis/v9"
@@ -35,7 +34,6 @@ var (
 	// ErrNilNode is an error that indicates a nil redis node.
 	ErrNilNode    = errors.New("nil redis node")
 	slowThreshold = syncx.ForAtomicDuration(defaultSlowThreshold)
-	tlsConfigID   atomic.Uint64
 )
 
 type (
@@ -139,7 +137,7 @@ func NewRedis(conf RedisConf, opts ...Option) (*Redis, error) {
 	}
 	if conf.Tls {
 		if conf.TlsInsecureSkipVerify {
-			opts = append([]Option{WithTLSConfig(&tls.Config{InsecureSkipVerify: true})}, opts...)
+			opts = append([]Option{withInsecureTLS()}, opts...)
 		} else {
 			opts = append([]Option{WithTLS()}, opts...)
 		}
@@ -2711,7 +2709,8 @@ func WithTLS() Option {
 }
 
 // WithTLSConfig customizes the given Redis with TLS enabled using the given config.
-// A nil config uses the secure defaults from crypto/tls.
+// A nil config uses the secure defaults from crypto/tls. The config is cloned,
+// and callers should reuse the same immutable config pointer to share a client.
 func WithTLSConfig(config *tls.Config) Option {
 	return func(r *Redis) {
 		if config == nil {
@@ -2719,8 +2718,15 @@ func WithTLSConfig(config *tls.Config) Option {
 			r.tlsConfigKey = "default"
 		} else {
 			r.tlsConfig = config.Clone()
-			r.tlsConfigKey = "custom:" + strconv.FormatUint(tlsConfigID.Add(1), 10)
+			r.tlsConfigKey = fmt.Sprintf("custom:%p", config)
 		}
+	}
+}
+
+func withInsecureTLS() Option {
+	return func(r *Redis) {
+		r.tlsConfig = &tls.Config{InsecureSkipVerify: true}
+		r.tlsConfigKey = "insecure"
 	}
 }
 

--- a/core/stores/redis/redis.go
+++ b/core/stores/redis/redis.go
@@ -2,9 +2,11 @@ package redis
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	red "github.com/redis/go-redis/v9"
@@ -33,6 +35,7 @@ var (
 	// ErrNilNode is an error that indicates a nil redis node.
 	ErrNilNode    = errors.New("nil redis node")
 	slowThreshold = syncx.ForAtomicDuration(defaultSlowThreshold)
+	tlsConfigID   atomic.Uint64
 )
 
 type (
@@ -53,13 +56,14 @@ type (
 
 	// Redis defines a redis node/cluster. It is thread-safe.
 	Redis struct {
-		Addr  string
-		Type  string
-		User  string
-		Pass  string
-		tls   bool
-		brk   breaker.Breaker
-		hooks []red.Hook
+		Addr         string
+		Type         string
+		User         string
+		Pass         string
+		tlsConfig    *tls.Config
+		tlsConfigKey string
+		brk          breaker.Breaker
+		hooks        []red.Hook
 	}
 
 	// RedisNode interface represents a redis node.
@@ -134,7 +138,11 @@ func NewRedis(conf RedisConf, opts ...Option) (*Redis, error) {
 		opts = append([]Option{WithPass(conf.Pass)}, opts...)
 	}
 	if conf.Tls {
-		opts = append([]Option{WithTLS()}, opts...)
+		if conf.TlsInsecureSkipVerify {
+			opts = append([]Option{WithTLSConfig(&tls.Config{InsecureSkipVerify: true})}, opts...)
+		} else {
+			opts = append([]Option{WithTLS()}, opts...)
+		}
 	}
 
 	rds := newRedis(conf.Host, opts...)
@@ -2697,10 +2705,22 @@ func WithPass(pass string) Option {
 	}
 }
 
-// WithTLS customizes the given Redis with TLS enabled.
+// WithTLS customizes the given Redis with TLS enabled and server certificates verified.
 func WithTLS() Option {
+	return WithTLSConfig(nil)
+}
+
+// WithTLSConfig customizes the given Redis with TLS enabled using the given config.
+// A nil config uses the secure defaults from crypto/tls.
+func WithTLSConfig(config *tls.Config) Option {
 	return func(r *Redis) {
-		r.tls = true
+		if config == nil {
+			r.tlsConfig = &tls.Config{}
+			r.tlsConfigKey = "default"
+		} else {
+			r.tlsConfig = config.Clone()
+			r.tlsConfigKey = "custom:" + strconv.FormatUint(tlsConfigID.Add(1), 10)
+		}
 	}
 }
 
@@ -2724,6 +2744,16 @@ func getRedis(r *Redis) (RedisNode, error) {
 	default:
 		return nil, fmt.Errorf("redis type '%s' is not supported", r.Type)
 	}
+}
+
+func getRedisManagerKey(r *Redis) string {
+	if r.tlsConfig == nil {
+		return r.Addr
+	}
+
+	// A TLS client must never reuse a plaintext client or a client created with
+	// a different TLS policy for the same address.
+	return fmt.Sprintf("%s|tls:%s", r.Addr, r.tlsConfigKey)
 }
 
 func toPairs(vals []red.Z) []Pair {

--- a/core/stores/redis/redis_test.go
+++ b/core/stores/redis/redis_test.go
@@ -104,9 +104,10 @@ func TestNewRedis(t *testing.T) {
 		{
 			name: "tls",
 			RedisConf: RedisConf{
-				Host: r1.Addr(),
-				Type: NodeType,
-				Tls:  true,
+				Host:     r1.Addr(),
+				Type:     NodeType,
+				Tls:      true,
+				NonBlock: true,
 			},
 			ok: true,
 		},
@@ -2170,8 +2171,9 @@ func runOnRedisTLS(t *testing.T, fn func(client *Redis)) {
 		InsecureSkipVerify: true,
 	})
 	assert.Nil(t, err)
+	r := newRedis(s.Addr(), WithTLS())
 	defer func() {
-		client, err := clientManager.GetResource(s.Addr(), func() (io.Closer, error) {
+		client, err := clientManager.GetResource(getRedisManagerKey(r), func() (io.Closer, error) {
 			return nil, errors.New("should already exist")
 		})
 		if err != nil {
@@ -2181,7 +2183,7 @@ func runOnRedisTLS(t *testing.T, fn func(client *Redis)) {
 			_ = client.Close()
 		}
 	}()
-	fn(newRedis(s.Addr(), WithTLS()))
+	fn(r)
 }
 
 func badType() Option {

--- a/core/stores/redis/redisclientmanager.go
+++ b/core/stores/redis/redisclientmanager.go
@@ -22,12 +22,10 @@ var (
 )
 
 func getClient(r *Redis) (*red.Client, error) {
-	val, err := clientManager.GetResource(r.Addr, func() (io.Closer, error) {
+	val, err := clientManager.GetResource(getRedisManagerKey(r), func() (io.Closer, error) {
 		var tlsConfig *tls.Config
-		if r.tls {
-			tlsConfig = &tls.Config{
-				InsecureSkipVerify: true,
-			}
+		if r.tlsConfig != nil {
+			tlsConfig = r.tlsConfig.Clone()
 		}
 		store := red.NewClient(&red.Options{
 			Addr:         r.Addr,

--- a/core/stores/redis/redisclientmanager_test.go
+++ b/core/stores/redis/redisclientmanager_test.go
@@ -42,17 +42,19 @@ func TestWithTLSConfigClonesConfig(t *testing.T) {
 
 func TestGetClientDoesNotShareAcrossTLSPolicies(t *testing.T) {
 	const addr = "redis-tls-policy.example.com:6379"
+	config := &tls.Config{ServerName: "redis.internal"}
 	plainClient, err := getClient(newRedis(addr))
 	require.NoError(t, err)
 	tlsClient, err := getClient(newRedis(addr, WithTLS()))
 	require.NoError(t, err)
-	customTLSClient, err := getClient(newRedis(addr, WithTLSConfig(&tls.Config{
-		ServerName: "redis.internal",
-	})))
+	customTLSClient, err := getClient(newRedis(addr, WithTLSConfig(config)))
+	require.NoError(t, err)
+	reusedTLSClient, err := getClient(newRedis(addr, WithTLSConfig(config)))
 	require.NoError(t, err)
 
 	assert.NotSame(t, plainClient, tlsClient)
 	assert.NotSame(t, tlsClient, customTLSClient)
+	assert.Same(t, customTLSClient, reusedTLSClient)
 	assert.Nil(t, plainClient.Options().TLSConfig)
 	assert.NotNil(t, tlsClient.Options().TLSConfig)
 	assert.Equal(t, "redis.internal", customTLSClient.Options().TLSConfig.ServerName)

--- a/core/stores/redis/redisclientmanager_test.go
+++ b/core/stores/redis/redisclientmanager_test.go
@@ -1,0 +1,59 @@
+package redis
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClientTLSConfig(t *testing.T) {
+	config := &tls.Config{
+		ServerName:         "redis.example.com",
+		InsecureSkipVerify: false,
+	}
+	r := newRedis("redis.example.com:6379", WithTLSConfig(config))
+
+	client, err := getClient(r)
+	require.NoError(t, err)
+	actual := client.Options().TLSConfig
+	require.NotNil(t, actual)
+	assert.NotSame(t, config, actual)
+	assert.Equal(t, "redis.example.com", actual.ServerName)
+	assert.False(t, actual.InsecureSkipVerify)
+}
+
+func TestWithTLSUsesSecureDefaults(t *testing.T) {
+	r := newRedis("redis.example.com:6379", WithTLS())
+
+	require.NotNil(t, r.tlsConfig)
+	assert.False(t, r.tlsConfig.InsecureSkipVerify)
+}
+
+func TestWithTLSConfigClonesConfig(t *testing.T) {
+	config := &tls.Config{ServerName: "redis.example.com"}
+	r := newRedis("redis.example.com:6379", WithTLSConfig(config))
+	config.ServerName = "changed.example.com"
+
+	require.NotNil(t, r.tlsConfig)
+	assert.Equal(t, "redis.example.com", r.tlsConfig.ServerName)
+}
+
+func TestGetClientDoesNotShareAcrossTLSPolicies(t *testing.T) {
+	const addr = "redis-tls-policy.example.com:6379"
+	plainClient, err := getClient(newRedis(addr))
+	require.NoError(t, err)
+	tlsClient, err := getClient(newRedis(addr, WithTLS()))
+	require.NoError(t, err)
+	customTLSClient, err := getClient(newRedis(addr, WithTLSConfig(&tls.Config{
+		ServerName: "redis.internal",
+	})))
+	require.NoError(t, err)
+
+	assert.NotSame(t, plainClient, tlsClient)
+	assert.NotSame(t, tlsClient, customTLSClient)
+	assert.Nil(t, plainClient.Options().TLSConfig)
+	assert.NotNil(t, tlsClient.Options().TLSConfig)
+	assert.Equal(t, "redis.internal", customTLSClient.Options().TLSConfig.ServerName)
+}

--- a/core/stores/redis/redisclustermanager.go
+++ b/core/stores/redis/redisclustermanager.go
@@ -19,12 +19,10 @@ var (
 )
 
 func getCluster(r *Redis) (*red.ClusterClient, error) {
-	val, err := clusterManager.GetResource(r.Addr, func() (io.Closer, error) {
+	val, err := clusterManager.GetResource(getRedisManagerKey(r), func() (io.Closer, error) {
 		var tlsConfig *tls.Config
-		if r.tls {
-			tlsConfig = &tls.Config{
-				InsecureSkipVerify: true,
-			}
+		if r.tlsConfig != nil {
+			tlsConfig = r.tlsConfig.Clone()
 		}
 		store := red.NewClusterClient(&red.ClusterOptions{
 			Addrs:        splitClusterAddrs(r.Addr),

--- a/core/stores/redis/redisclustermanager_test.go
+++ b/core/stores/redis/redisclustermanager_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	red "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +51,6 @@ func TestGetCluster(t *testing.T) {
 		Addr:      r.Addr(),
 		Type:      ClusterType,
 		tlsConfig: &tls.Config{},
-		hooks:     []red.Hook{defaultDurationHook},
 	})
 	if assert.NoError(t, err) {
 		assert.NotNil(t, c)

--- a/core/stores/redis/redisclustermanager_test.go
+++ b/core/stores/redis/redisclustermanager_test.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"crypto/tls"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -48,12 +49,13 @@ func TestGetCluster(t *testing.T) {
 	r := miniredis.RunT(t)
 	defer r.Close()
 	c, err := getCluster(&Redis{
-		Addr:  r.Addr(),
-		Type:  ClusterType,
-		tls:   true,
-		hooks: []red.Hook{defaultDurationHook},
+		Addr:      r.Addr(),
+		Type:      ClusterType,
+		tlsConfig: &tls.Config{},
+		hooks:     []red.Hook{defaultDurationHook},
 	})
 	if assert.NoError(t, err) {
 		assert.NotNil(t, c)
+		assert.False(t, c.Options().TLSConfig.InsecureSkipVerify)
 	}
 }


### PR DESCRIPTION
## What this PR does

- enables Redis TLS with Go's secure certificate and hostname verification defaults
- adds `WithTLSConfig` for custom CA pools, server names, and client certificates
- clones caller-provided TLS configurations to prevent mutation and data races
- adds `TlsInsecureSkipVerify` as an explicit migration escape hatch for legacy self-signed deployments
- prevents plaintext and differently configured TLS clients for the same address from sharing a cached connection

## Compatibility

This intentionally changes `Tls: true` and `WithTLS()` to verify server certificates. Deployments using an untrusted self-signed certificate or a hostname mismatch must configure the appropriate CA through `WithTLSConfig`, or temporarily set `TlsInsecureSkipVerify: true`.

## Verification

- `go test ./core/stores/redis -count=1`
- `go test -race ./core/stores/redis -count=1`
- `go vet ./core/stores/redis`

Fixes #5644