### PR TITLE
test(mcp): avoid relying on header map order

### DIFF
--- a/mcp/request_metadata_test.go
+++ b/mcp/request_metadata_test.go
@@ -181,5 +181,5 @@ func TestRequestMetadataFromContextWithEmptyAndCanonicalizedHeaders(t *testing.T
 
 	metadata, ok := RequestMetadataFromContext(ctx)
 	assert.True(t, ok)
-	assert.Equal(t, []string{"a", "b"}, metadata.Headers["X-Tenant-Id"])
+	assert.ElementsMatch(t, []string{"a", "b"}, metadata.Headers["X-Tenant-Id"])
 }


### PR DESCRIPTION
## What this does

Makes `TestRequestMetadataFromContextWithEmptyAndCanonicalizedHeaders` order-insensitive when checking values merged from differently-cased header map keys.

Go map iteration order is unspecified, so the test could observe either `[a, b]` or `[b, a]`. The production behavior preserves the values, but the test incorrectly required one cross-key merge order.

Failure observed in: https://github.com/zeromicro/go-zero/actions/runs/27890489358/attempts/2

## Validation

- `go test ./mcp -run '^TestRequestMetadataFromContextWithEmptyAndCanonicalizedHeaders$' -count=10000`
- `go test -race ./mcp`
- `git diff --check`