### PR TITLE
fix(zrpc): filter terminating/unready endpoints in kube resolver (#5647)

### DIFF
--- a/zrpc/resolver/internal/kube/eventhandler.go
+++ b/zrpc/resolver/internal/kube/eventhandler.go
@@ -39,6 +39,10 @@ func (h *EventHandler) OnAdd(obj any, _ bool) {
 
 	var changed bool
 	for _, point := range endpoints.Endpoints {
+		if !isValidEndpoint(point) {
+			continue
+		}
+
 		for _, address := range point.Addresses {
 			if _, ok := h.endpoints[address]; !ok {
 				h.endpoints[address] = lang.Placeholder
@@ -107,6 +111,10 @@ func (h *EventHandler) Update(endpoints *v1.EndpointSlice) {
 	old := h.endpoints
 	h.endpoints = make(map[string]lang.PlaceholderType)
 	for _, point := range endpoints.Endpoints {
+		if !isValidEndpoint(point) {
+			continue
+		}
+
 		for _, address := range point.Addresses {
 			h.endpoints[address] = lang.Placeholder
 		}
@@ -139,4 +147,18 @@ func diff(o, n map[string]lang.PlaceholderType) bool {
 	}
 
 	return false
+}
+
+func isValidEndpoint(point v1.Endpoint) bool {
+	if point.Conditions.Ready != nil && !*point.Conditions.Ready {
+		return false
+	}
+	if point.Conditions.Terminating != nil && *point.Conditions.Terminating {
+		return false
+	}
+	if point.Conditions.Serving != nil && !*point.Conditions.Serving {
+		return false
+	}
+
+	return true
 }

--- a/zrpc/resolver/internal/kube/eventhandler_test.go
+++ b/zrpc/resolver/internal/kube/eventhandler_test.go
@@ -14,6 +14,7 @@ func TestAdd(t *testing.T) {
 		endpoints = change
 	})
 	h.OnAdd("bad", false)
+	falseVal := false
 	h.OnAdd(&discoveryv1.EndpointSlice{
 		Endpoints: []discoveryv1.Endpoint{
 			{
@@ -24,6 +25,12 @@ func TestAdd(t *testing.T) {
 			},
 			{
 				Addresses: []string{"0.0.0.3"},
+			},
+			{
+				Addresses: []string{"0.0.0.4"},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: &falseVal,
+				},
 			},
 		},
 	}, false)
@@ -67,6 +74,7 @@ func TestUpdate(t *testing.T) {
 	h := NewEventHandler(func(change []string) {
 		endpoints = change
 	})
+	falseVal := false
 	h.OnUpdate(&discoveryv1.EndpointSlice{
 		Endpoints: []discoveryv1.Endpoint{
 			{
@@ -89,6 +97,12 @@ func TestUpdate(t *testing.T) {
 			},
 			{
 				Addresses: []string{"0.0.0.3"},
+			},
+			{
+				Addresses: []string{"0.0.0.4"},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: &falseVal,
+				},
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -227,4 +241,81 @@ func TestUpdateNoChangeWithDifferentVersion(t *testing.T) {
 		},
 	})
 	assert.ElementsMatch(t, []string{"0.0.0.1", "0.0.0.2"}, endpoints)
+}
+
+func TestIsValidEndpoint(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name     string
+		point    discoveryv1.Endpoint
+		expected bool
+	}{
+		{
+			name:     "all nil conditions",
+			point:    discoveryv1.Endpoint{},
+			expected: true,
+		},
+		{
+			name: "ready true",
+			point: discoveryv1.Endpoint{
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: &trueVal,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "ready false",
+			point: discoveryv1.Endpoint{
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: &falseVal,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "terminating true",
+			point: discoveryv1.Endpoint{
+				Conditions: discoveryv1.EndpointConditions{
+					Terminating: &trueVal,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "terminating false",
+			point: discoveryv1.Endpoint{
+				Conditions: discoveryv1.EndpointConditions{
+					Terminating: &falseVal,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "serving false",
+			point: discoveryv1.Endpoint{
+				Conditions: discoveryv1.EndpointConditions{
+					Serving: &falseVal,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "serving true",
+			point: discoveryv1.Endpoint{
+				Conditions: discoveryv1.EndpointConditions{
+					Serving: &trueVal,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isValidEndpoint(test.point))
+		})
+	}
 }


### PR DESCRIPTION
**Problem**

The current `go-zero` Kubernetes resolver in `zrpc/resolver/internal/kube` collects addresses directly from `EndpointSlice` resources without properly filtering their endpoints by lifecycle or readiness conditions. During a Kubernetes rolling update, this causes the resolver to continue sending traffic to terminating or unready Pod IPs. This leads to transient client-side gRPC errors (e.g., `connection refused` / `Unavailable`) and can prematurely trigger circuit breakers. 

Fixes #5647

**Solution**

Added an explicit filtering check to ensure that only healthy, serving endpoints are added to the resolver's target map.

| Update | File | Purpose |
|------|------|---------|
| Added `isValidEndpoint` | `zrpc/resolver/internal/kube/eventhandler.go` | Helper that verifies `conditions.ready != false`, `conditions.terminating != true`, and `conditions.serving != false` |
| Updated `OnAdd` & `Update` | `zrpc/resolver/internal/kube/eventhandler.go` | Calls `isValidEndpoint` to bypass any unready or terminating endpoints before they are tracked |

**Impact**
- Avoids transient connection drops during Pod rolling updates.
- Better alignment with standard Kubernetes `EndpointSlice` semantics.
- Non-breaking change (endpoints missing condition fields gracefully default to `nil` and are still accepted).

**Testing performed**
```bash
go test -v -count=1 ./zrpc/resolver/internal/kube/...    # PASS
go vet ./zrpc/resolver/internal/kube/...                 # PASS
