### PR TITLE
fix(goctl/swagger): populate required fields in top-level response sc…

### DIFF
--- a/tools/goctl/api/swagger/response.go
+++ b/tools/goctl/api/swagger/response.go
@@ -46,9 +46,10 @@ func jsonResponseFromType(ctx Context, atDoc apiSpec.AtDoc, tp apiSpec.Type) *sp
 		}
 	}
 
-	p, _ := propertiesFromType(ctx, tp)
+	p, r := propertiesFromType(ctx, tp)
 	props.Type = typeFromGoType(ctx, tp)
 	props.Properties = p
+	props.Required = r
 	return &spec.Responses{
 		ResponsesProps: spec.ResponsesProps{
 			StatusCodeResponses: map[int]spec.Response{

--- a/tools/goctl/api/swagger/swagger_test.go
+++ b/tools/goctl/api/swagger/swagger_test.go
@@ -3,8 +3,8 @@ package swagger
 import (
 	"testing"
 
-	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
 )
 
 func Test_pathVariable2SwaggerVariable(t *testing.T) {
@@ -137,4 +137,39 @@ func TestArrayWithoutDefinitions(t *testing.T) {
 	assert.Equal(t, "object", arrayField.Items.Schema.Type[0])
 	assert.Contains(t, arrayField.Items.Schema.Properties, "itemName")
 	assert.Equal(t, []string{"itemName"}, arrayField.Items.Schema.Required)
+}
+
+func TestResponseRequiredFields(t *testing.T) {
+	ctx := Context{
+		UseDefinitions: false,
+	}
+
+	respType := spec.DefineStruct{
+		RawName: "UserResponse",
+		Members: []spec.Member{
+			{
+				Name: "Id",
+				Type: spec.PrimitiveType{RawName: "int64"},
+				Tag:  `json:"id"`,
+			},
+			{
+				Name: "Name",
+				Type: spec.PrimitiveType{RawName: "string"},
+				Tag:  `json:"name"`,
+			},
+			{
+				Name: "Email",
+				Type: spec.PrimitiveType{RawName: "string"},
+				Tag:  `json:"email,optional"`,
+			},
+		},
+	}
+
+	responses := jsonResponseFromType(ctx, spec.AtDoc{}, respType)
+	resp := responses.StatusCodeResponses[200]
+
+	assert.NotNil(t, resp.Schema)
+	// optional fields should not appear in the required array
+	assert.Equal(t, []string{"id", "name"}, resp.Schema.Required)
+	assert.Contains(t, resp.Schema.Properties, "email")
 }


### PR DESCRIPTION
### Problem

`goctl api swagger` generates response schemas where the top-level object is always missing the `required` array, even when struct fields are non-pointer and not marked `optional`. This causes all response fields to appear as optional in tools like Apifox / Swagger UI.

Reported in #4955 (opened Jun 2025, stale, no assignee, no linked PR).

### Root Cause

`propertiesFromType` returns two values: `(properties, requiredFields)`. Every other call site correctly assigns `requiredFields` to `schema.Required`:

| Call site | Handles `requiredFields`? |
|---|---|
| `definition.go` (definitions section) | ✅ |
| `swagger.go` (array items via `itemFromGoType`) | ✅ |
| `properties.go` (nested objects) | ✅ |
| **`response.go` (top-level response)** | ❌ discarded with `_` |

In `response.go`:

```go
p, _ := propertiesFromType(ctx, tp)   // requiredFields discarded
props.Type = typeFromGoType(ctx, tp)
props.Properties = p
// props.Required never set
```

This is why nested objects (e.g. array items) correctly emit `required`, but the top-level response object never does.

### Fix

Capture the `requiredFields` return value and assign it to `props.Required`:

```go
p, r := propertiesFromType(ctx, tp)
props.Type = typeFromGoType(ctx, tp)
props.Properties = p
props.Required = r
```

### Test

Added `TestResponseRequiredFields` covering:
- Fields without `optional` tag → appear in `required` array
- Field with `optional` tag → excluded from `required` array, still present in `properties`

All existing tests pass, no regressions.

Closes #4955