### PR TITLE
perf(collection): optimize queue growth

### DIFF
--- a/core/collection/fifo.go
+++ b/core/collection/fifo.go
@@ -2,11 +2,12 @@ package collection
 
 import "sync"
 
+const queueGrowThreshold = 256
+
 // A Queue is a FIFO queue.
 type Queue struct {
 	lock     sync.Mutex
 	elements []any
-	size     int
 	head     int
 	tail     int
 	count    int
@@ -14,9 +15,12 @@ type Queue struct {
 
 // NewQueue returns a Queue object.
 func NewQueue(size int) *Queue {
+	if size < 1 {
+		panic("size must be greater than 0")
+	}
+
 	return &Queue{
 		elements: make([]any, size),
-		size:     size,
 	}
 }
 
@@ -34,12 +38,12 @@ func (q *Queue) Put(element any) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	if q.head == q.tail && q.count > 0 {
-		nodes := make([]any, len(q.elements)+q.size)
-		copy(nodes, q.elements[q.head:])
-		copy(nodes[len(q.elements)-q.head:], q.elements[:q.head])
+	if q.count == len(q.elements) {
+		nodes := make([]any, nextQueueCapacity(len(q.elements)))
+		n := copy(nodes, q.elements[q.head:])
+		copy(nodes[n:], q.elements[:q.head])
 		q.head = 0
-		q.tail = len(q.elements)
+		q.tail = q.count
 		q.elements = nodes
 	}
 
@@ -58,8 +62,19 @@ func (q *Queue) Take() (any, bool) {
 	}
 
 	element := q.elements[q.head]
+	q.elements[q.head] = nil
 	q.head = (q.head + 1) % len(q.elements)
 	q.count--
 
 	return element, true
+}
+
+func nextQueueCapacity(capacity int) int {
+	if capacity < queueGrowThreshold {
+		return capacity << 1
+	}
+
+	// Use a growth curve similar to Go slices: double small queues, then
+	// transition smoothly toward 1.25x growth for larger queues.
+	return capacity + ((capacity + 3*queueGrowThreshold) >> 2)
 }

--- a/core/collection/fifo_test.go
+++ b/core/collection/fifo_test.go
@@ -6,96 +6,263 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFifo(t *testing.T) {
-	elements := [][]byte{
-		[]byte("hello"),
-		[]byte("world"),
-		[]byte("again"),
-	}
-	queue := NewQueue(8)
-	for i := range elements {
-		queue.Put(elements[i])
+func TestQueueOrder(t *testing.T) {
+	tests := []struct {
+		name         string
+		size         int
+		initial      []int
+		takeBefore   int
+		additional   []int
+		wantCapacity int
+	}{
+		{
+			name:         "within initial capacity",
+			size:         8,
+			initial:      []int{1, 2, 3},
+			wantCapacity: 8,
+		},
+		{
+			name:         "grow from beginning",
+			size:         2,
+			initial:      []int{1, 2, 3},
+			wantCapacity: 4,
+		},
+		{
+			name:         "grow after wrapping",
+			size:         4,
+			initial:      []int{1, 2, 3, 4},
+			takeBefore:   1,
+			additional:   []int{5, 6},
+			wantCapacity: 8,
+		},
+		{
+			name:         "grow repeatedly",
+			size:         1,
+			initial:      sequence(20),
+			wantCapacity: 32,
+		},
+		{
+			name:         "grow above threshold",
+			size:         queueGrowThreshold,
+			initial:      sequence(queueGrowThreshold + 1),
+			wantCapacity: queueGrowThreshold * 2,
+		},
+		{
+			name:         "grow well above threshold",
+			size:         1024,
+			initial:      sequence(1025),
+			wantCapacity: 1472,
+		},
 	}
 
-	for _, element := range elements {
-		body, ok := queue.Take()
-		assert.True(t, ok)
-		assert.Equal(t, string(element), string(body.([]byte)))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queue := NewQueue(test.size)
+			assert.True(t, queue.Empty())
+
+			for _, value := range test.initial {
+				queue.Put(value)
+			}
+			for i := 0; i < test.takeBefore; i++ {
+				value, ok := queue.Take()
+				assert.True(t, ok)
+				assert.Equal(t, test.initial[i], value)
+			}
+			for _, value := range test.additional {
+				queue.Put(value)
+			}
+
+			want := append([]int(nil), test.initial[test.takeBefore:]...)
+			want = append(want, test.additional...)
+			for _, expected := range want {
+				actual, ok := queue.Take()
+				assert.True(t, ok)
+				assert.Equal(t, expected, actual)
+			}
+
+			assert.Equal(t, test.wantCapacity, len(queue.elements))
+			assert.True(t, queue.Empty())
+			_, ok := queue.Take()
+			assert.False(t, ok)
+		})
 	}
 }
 
-func TestTakeTooMany(t *testing.T) {
-	elements := [][]byte{
-		[]byte("hello"),
-		[]byte("world"),
-		[]byte("again"),
-	}
-	queue := NewQueue(8)
-	for i := range elements {
-		queue.Put(elements[i])
+func TestQueueTakeClearsElement(t *testing.T) {
+	tests := []struct {
+		name       string
+		size       int
+		operations string
+	}{
+		{
+			name:       "take from beginning",
+			size:       2,
+			operations: "ppt",
+		},
+		{
+			name:       "take after wrapping",
+			size:       2,
+			operations: "pptptt",
+		},
+		{
+			name:       "take after growing",
+			size:       2,
+			operations: "pppt",
+		},
 	}
 
-	for range elements {
-		queue.Take()
-	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queue := NewQueue(test.size)
+			value := 0
 
-	assert.True(t, queue.Empty())
-	_, ok := queue.Take()
-	assert.False(t, ok)
+			for _, operation := range test.operations {
+				switch operation {
+				case 'p':
+					value++
+					element := new(int)
+					*element = value
+					queue.Put(element)
+				case 't':
+					index := queue.head
+					_, ok := queue.Take()
+					assert.True(t, ok)
+					assert.Nil(t, queue.elements[index])
+				default:
+					t.Fatalf("unknown operation: %q", operation)
+				}
+			}
+		})
+	}
 }
 
-func TestPutMore(t *testing.T) {
-	elements := [][]byte{
-		[]byte("hello"),
-		[]byte("world"),
-		[]byte("again"),
-	}
-	queue := NewQueue(2)
-	for i := range elements {
-		queue.Put(elements[i])
+func TestNewQueueWithInvalidSize(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+	}{
+		{
+			name: "zero",
+		},
+		{
+			name: "negative",
+			size: -1,
+		},
 	}
 
-	for _, element := range elements {
-		body, ok := queue.Take()
-		assert.True(t, ok)
-		assert.Equal(t, string(element), string(body.([]byte)))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Panics(t, func() {
+				NewQueue(test.size)
+			})
+		})
 	}
 }
 
-func TestPutMoreWithHeaderNotZero(t *testing.T) {
-	elements := [][]byte{
-		[]byte("hello"),
-		[]byte("world"),
-		[]byte("again"),
-	}
-	queue := NewQueue(4)
-	for i := range elements {
-		queue.Put(elements[i])
+func BenchmarkQueueGrowth(b *testing.B) {
+	tests := []struct {
+		name  string
+		size  int
+		count int
+	}{
+		{
+			name:  "initial_1_count_256",
+			size:  1,
+			count: 256,
+		},
+		{
+			name:  "initial_1_count_4096",
+			size:  1,
+			count: 4096,
+		},
+		{
+			name:  "initial_1_count_65536",
+			size:  1,
+			count: 65536,
+		},
+		{
+			name:  "initial_8_count_4096",
+			size:  8,
+			count: 4096,
+		},
+		{
+			name:  "initial_256_count_4096",
+			size:  256,
+			count: 4096,
+		},
 	}
 
-	// take 1
-	body, ok := queue.Take()
-	assert.True(t, ok)
-	element, ok := body.([]byte)
-	assert.True(t, ok)
-	assert.Equal(t, element, []byte("hello"))
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			elements := make([]any, test.count)
+			for i := range elements {
+				elements[i] = i
+			}
 
-	// put more
-	queue.Put([]byte("b4"))
-	queue.Put([]byte("b5")) // will store in elements[0]
-	queue.Put([]byte("b6")) // cause expansion
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				queue := NewQueue(test.size)
+				for _, element := range elements {
+					queue.Put(element)
+				}
+			}
+		})
+	}
+}
 
-	results := [][]byte{
-		[]byte("world"),
-		[]byte("again"),
-		[]byte("b4"),
-		[]byte("b5"),
-		[]byte("b6"),
+func BenchmarkQueueWrappedGrowth(b *testing.B) {
+	tests := []struct {
+		name string
+		size int
+	}{
+		{
+			name: "capacity_8",
+			size: 8,
+		},
+		{
+			name: "capacity_256",
+			size: 256,
+		},
+		{
+			name: "capacity_4096",
+			size: 4096,
+		},
 	}
 
-	for _, element := range results {
-		body, ok := queue.Take()
-		assert.True(t, ok)
-		assert.Equal(t, string(element), string(body.([]byte)))
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			elements := make([]any, test.size)
+			for i := range elements {
+				elements[i] = i
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				queue := NewQueue(test.size)
+				for _, element := range elements {
+					queue.Put(element)
+				}
+				for j := 0; j < test.size/2; j++ {
+					queue.Take()
+				}
+				for j := 0; j < test.size/2; j++ {
+					queue.Put(elements[j])
+				}
+
+				// The queue is full and wrapped. One more Put triggers growth
+				// and copies both sides of the ring into FIFO order.
+				queue.Put(elements[0])
+			}
+		})
 	}
+}
+
+func sequence(size int) []int {
+	values := make([]int, size)
+	for i := range values {
+		values[i] = i
+	}
+	return values
 }


### PR DESCRIPTION
# perf(collection): optimize Queue growth and release dequeued references

## Summary

This MR improves the performance and memory behavior of `core/collection.Queue`.

The previous implementation increased the backing slice by the initial queue size whenever the queue became full. For small initial capacities, repeated growth required copying an increasing number of elements and resulted in O(n²) total copy work.

The new implementation:

- Uses a growth curve similar to Go slices:
  - doubles small queues;
  - transitions smoothly toward 1.25x growth for larger queues.
- Preserves FIFO order when growing a wrapped ring buffer.
- Clears dequeued slots so referenced objects can be reclaimed by the GC.
- Rejects non-positive initial capacities immediately.
- Adds table-driven correctness tests and dedicated growth benchmarks.

## Root Cause

Queue capacity previously grew by a fixed amount:

```go
newCapacity := len(q.elements) + q.size
```

For `NewQueue(1)`, capacity grew as follows:

```text
1 → 2 → 3 → 4 → ... → n
```

Growing to `n` elements copied approximately:

```text
1 + 2 + 3 + ... + n
```

This results in O(n²) total copy work and excessive temporary allocations.

Additionally, `Take` advanced the queue head without clearing the consumed slot. The backing slice therefore continued to retain references until those slots were overwritten.

## Implementation

Queue growth now uses geometric capacity increases:

```text
Small queues: 2x growth
Large queues: smooth transition toward 1.25x growth
```

When the ring has wrapped, growth copies both physical segments into logical FIFO order:

```text
Wrapped storage: E F _ _ A B C D
FIFO order:      A B C D E F
After growth:    A B C D E F _ _ ...
```

`Take` now clears the consumed slot before advancing the head:

```go
element := q.elements[q.head]
q.elements[q.head] = nil
```

This releases the queue's reference to the dequeued value without shrinking the backing slice.

## Benchmark Results

Environment:

```text
CPU: Apple M4
Go: 1.25.5
benchtime: 500ms
count: 5
Result: median of five runs
```

### Sequential Growth

| Benchmark | Before | After | Improvement | Before B/op | After B/op | Before allocs/op | After allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Initial 1, 256 elements | 49.49 µs | 1.968 µs | 25.1x faster | 563,333 | 9,392 | 257 | 10 |
| Initial 1, 4,096 elements | 10.463 ms | 36.20 µs | 289x faster | 144,430,743 | 253,617 | 4,099 | 17 |

For the 4,096-element case:

- Execution time decreased by approximately 99.65%.
- Allocated bytes decreased by approximately 99.82%.
- Allocation count decreased by approximately 99.59%.

### Wrapped Growth

| Benchmark | Before | After | Time change | Before B/op | After B/op | Allocation change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Capacity 8 | 145.0 ns | 145.9 ns | No meaningful change | 448 | 448 | 3 → 3 |
| Capacity 256 | 3.324 µs | 3.230 µs | 2.8% faster | 14,400 | 14,400 | 3 → 3 |
| Capacity 4,096 | 50.087 µs | 47.713 µs | 4.7% faster | 196,672 | 155,712 | 3 → 3 |

For a wrapped queue with capacity 4,096, allocated bytes decreased by approximately 20.8%.

Small wrapped queues remain effectively unchanged because both the old and new implementations double capacity at that size.

## Test Coverage

The table-driven tests cover:

- Operations within the initial capacity;
- Growth from a non-wrapped queue;
- Growth after the ring buffer has wrapped;
- Repeated growth from a small initial capacity;
- Growth at and above the capacity threshold;
- FIFO ordering after growth;
- Clearing dequeued slots;
- Zero and negative initial capacities.

The benchmarks cover:

- Sequential growth at 256, 4,096, and 65,536 elements;
- Initial capacities of 1, 8, and 256;
- Wrapped growth at capacities 8, 256, and 4,096.

## Validation

```bash
go test ./core/collection
go test -race ./core/collection
go test ./core/collection \
  -run '^$' \
  -bench '^BenchmarkQueue(Growth|WrappedGrowth)$' \
  -benchmem
```

All tests and race checks pass.
