### PR TITLE
fix(mapping): support interface{} fields in json unmarshal

### DIFF
--- a/core/mapping/jsonunmarshaler_test.go
+++ b/core/mapping/jsonunmarshaler_test.go
@@ -2,6 +2,7 @@ package mapping
 
 import (
 	"bytes"
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -1046,4 +1047,30 @@ func TestUnmarshalJsonBytesError(t *testing.T) {
 
 	assert.Error(t, UnmarshalJsonBytes([]byte((``)), &v))
 	assert.Error(t, UnmarshalJsonReader(strings.NewReader(``), &v))
+}
+
+func TestUnmarshalJsonInterfaceFieldMixedStringNumber(t *testing.T) {
+	type dataItem struct {
+		Value     interface{} `json:"value,omitempty"`
+		ValueType int         `json:"valueType"`
+	}
+
+	var req struct {
+		ID    uint64     `json:"id"`
+		Items []dataItem `json:"datas,optional"`
+	}
+
+	body := `{
+		"id": 123,
+		"datas": [
+			{"value": "1", "valueType": 0},
+			{"value": 2, "valueType": 1}
+		]
+	}`
+
+	assert.NoError(t, UnmarshalJsonReader(strings.NewReader(body), &req))
+	assert.Equal(t, uint64(123), req.ID)
+	assert.Len(t, req.Items, 2)
+	assert.Equal(t, "1", req.Items[0].Value)
+	assert.Equal(t, json.Number("2"), req.Items[1].Value)
 }

--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -31,6 +31,7 @@ var (
 	errValueNotStruct   = errors.New("value type is not struct")
 	keyUnmarshaler      = NewUnmarshaler(defaultKeyName)
 	durationType        = reflect.TypeOf(time.Duration(0))
+	emptyInterfaceType  = reflect.TypeOf((*any)(nil)).Elem()
 	cacheKeys           = make(map[string][]string)
 	cacheKeysLock       sync.Mutex
 	defaultCache        = make(map[string]any)
@@ -587,6 +588,8 @@ func (u *Unmarshaler) processFieldNotFromString(fieldType reflect.Type, value re
 	valueKind := reflect.TypeOf(mapValue).Kind()
 
 	switch {
+	case derefedFieldType == emptyInterfaceType:
+		return fillWithSameType(fieldType, value, mapValue, opts)
 	case valueKind == reflect.Map && typeKind == reflect.Struct:
 		mv, ok := mapValue.(map[string]any)
 		if !ok {


### PR DESCRIPTION
Fixes #5721

## Problem

`httpx.Parse` fails to unmarshal a request body when a struct field is `interface{}` and the JSON value can be either a string or a number. The mapping unmarshaler returns:

```
type mismatch for field "datas[0].value"
```

while `json.NewDecoder(r.Body).Decode(&req)` handles the same payload.

## Root cause

In `core/mapping/unmarshaler.go`, `processFieldPrimitive` only handles values whose kind matches the target kind, plus a dedicated `json.Number` branch. An `interface{}` field has kind `Interface`, so neither branch matches and it always falls through to `newTypeMismatchError`.

## Change

Treat empty-interface fields as accepting the raw decoded JSON value:

- strings stay `string`
- numbers stay `json.Number` (jsonx decodes with `UseNumber`)
- objects, arrays and booleans are preserved as decoded

## Test

Added `TestUnmarshalJsonInterfaceFieldMixedStringNumber` in `core/mapping/jsonunmarshaler_test.go`, covering a slice of items whose `interface{}` value is a string in one element and a number in another.

## Verification

- `go test ./core/mapping/ ./rest/httpx/ -count=1` passes
- `go test -race ./core/mapping/ ./rest/httpx/ -count=1` passes
- `gofmt` and `git diff --check` are clean