### PR TITLE
Feat/support x extension swagger

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,52 @@
+# feat(api/swagger): 在 `.api` 文件中支持自定义 `x-` 扩展字段并生成 Swagger
+
+关联 issue：go-zero/go-zero#5628
+
+## 摘要
+本改动让 API 作者可以直接在 `.api` 文件里声明自定义 Swagger 扩展字段（`x-*`），语法是在路由的 `@handler` 之前添加 `@x-<key>` 注解：
+
+```api
+service order {
+    @doc "Create Order"
+    @x-log-enabled true
+    @x-rate-limit "100/min"
+    @x-owners `["alice","bob"]`
+    @handler createOrder
+    post /order/create (CreateOrderRequest) returns (CreateOrderResponse)
+}
+```
+
+生成的 Swagger JSON 会在 operation 上带上这些扩展字段：
+
+```json
+"post": {
+    "x-log-enabled": true,
+    "x-rate-limit": "100/min",
+    "x-owners": ["alice", "bob"]
+}
+```
+
+## 改动内容
+- **词法扫描**（`tools/goctl/pkg/parser/api/scanner/scanner.go`）：识别 `@x-<key>` 词法单元。
+- **Token / AST**（`tools/goctl/pkg/parser/api/token/token.go`、`tools/goctl/pkg/parser/api/ast/servicestatement.go`）：新增 `AT_X` token 类型，以及 `AtXStmt` / `AtXAnnotations` AST 节点。
+- **解析器**（`tools/goctl/pkg/parser/api/parser/parser.go`）：在 `@handler` 前解析零个或多个 `@x-*` 注解，并在 `ParseForUintTest` 中暴露该能力。
+- **分析器 / spec**（`tools/goctl/pkg/parser/api/parser/analyzer.go`、`tools/goctl/api/spec/spec.go`）：将注解写入 `spec.Route.Extensions`，并移除一处重复的 `@doc` 转换。
+- **Swagger 生成**（`tools/goctl/api/swagger/swagger.go`、`tools/goctl/api/swagger/path.go`）：将扩展值解析为布尔值、数字、字符串或 JSON 数组/对象，并写入 `spec.Operation.Extensions`。
+- **测试**（`tools/goctl/pkg/parser/api/parser/parser_test.go`、`tools/goctl/api/swagger/swagger_test.go`）：覆盖独立 `@x-*` 解析、service 级解析以及端到端 Swagger 生成，包括字符串、布尔、数字、JSON 数组/对象等取值。
+
+## 扩展字段值解析规则
+按以下顺序解析值：
+1. JSON 数组或对象（支持双引号字符串和反引号 raw string）。
+2. 带引号或反引号的字符串字面量。
+3. 布尔字面量（`true` / `false`）。
+4. 数字字面量（如 `30`、`3.14`）。
+5. 其它情况按普通字符串返回。
+
+## 验证
+```bash
+cd tools/goctl
+go test ./pkg/parser/api/... ./api/swagger/...
+go build ./...
+```
+
+所有测试通过，构建成功。

--- a/tools/goctl/api/spec/spec.go
+++ b/tools/goctl/api/spec/spec.go
@@ -83,6 +83,8 @@ type (
 		HandlerComment     Doc
 		Doc                Doc
 		Comment            Doc
+		// Extensions holds custom Swagger x- extension fields declared via @x-* annotations.
+		Extensions map[string]string
 	}
 
 	// Service describes api service

--- a/tools/goctl/api/swagger/path.go
+++ b/tools/goctl/api/swagger/path.go
@@ -105,6 +105,14 @@ func spec2Path(ctx Context, group apiSpec.Group, route apiSpec.Route) spec.PathI
 		}
 
 	}
+	if len(route.Extensions) > 0 {
+		if op.Extensions == nil {
+			op.Extensions = spec.Extensions{}
+		}
+		for k, v := range route.Extensions {
+			op.Extensions.Add(k, parseExtensionValue(v))
+		}
+	}
 	item := spec.PathItem{}
 	switch strings.ToUpper(route.Method) {
 	case http.MethodGet:

--- a/tools/goctl/api/swagger/swagger.go
+++ b/tools/goctl/api/swagger/swagger.go
@@ -2,6 +2,7 @@ package swagger
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 
@@ -287,6 +288,46 @@ func wrapCodeMsgProps(ctx Context, properties spec.SchemaProps, atDoc apiSpec.At
 			},
 		},
 	}
+}
+
+func parseExtensionValue(raw string) any {
+	if raw == "" {
+		return raw
+	}
+
+	inner, quoted := unquoteExtensionValue(raw)
+	trimmed := strings.TrimSpace(inner)
+	if len(trimmed) > 0 && ((trimmed[0] == '[' && trimmed[len(trimmed)-1] == ']') || (trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}')) {
+		var result any
+		if err := json.Unmarshal([]byte(trimmed), &result); err == nil {
+			return result
+		}
+	}
+	if quoted {
+		return inner
+	}
+
+	if b, err := strconv.ParseBool(raw); err == nil {
+		return b
+	}
+	if n, err := strconv.ParseFloat(raw, 64); err == nil {
+		return n
+	}
+	return raw
+}
+
+func unquoteExtensionValue(raw string) (string, bool) {
+	if len(raw) < 2 {
+		return raw, false
+	}
+	if raw[0] == '"' && raw[len(raw)-1] == '"' {
+		if v, err := strconv.Unquote(raw); err == nil {
+			return v, true
+		}
+	} else if raw[0] == '`' && raw[len(raw)-1] == '`' {
+		return raw[1 : len(raw)-1], true
+	}
+	return raw, false
 }
 
 func specExtensions(api apiSpec.Info) (spec.Extensions, *spec.Info) {

--- a/tools/goctl/api/swagger/swagger_test.go
+++ b/tools/goctl/api/swagger/swagger_test.go
@@ -1,10 +1,12 @@
 package swagger
 
 import (
+	"encoding/json"
 	"testing"
 
-	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
 	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
+	"github.com/zeromicro/go-zero/tools/goctl/pkg/parser/api/parser"
 )
 
 func Test_pathVariable2SwaggerVariable(t *testing.T) {
@@ -84,6 +86,82 @@ func TestArrayDefinitionsBug(t *testing.T) {
 	assert.Nil(t, arrayField.Items.Schema.Properties, "Items with $ref should not have properties")
 	assert.Empty(t, arrayField.Items.Schema.Required, "Items with $ref should not have required")
 	assert.Empty(t, arrayField.Items.Schema.Type, "Items with $ref should not have type")
+}
+
+func TestParseExtensionValue(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected any
+	}{
+		{input: "true", expected: true},
+		{input: "false", expected: false},
+		{input: "30", expected: float64(30)},
+		{input: "3.14", expected: 3.14},
+		{input: `"100/min"`, expected: "100/min"},
+		{input: "`business`", expected: "business"},
+		{input: "[\"alice\",\"bob\"]", expected: []interface{}{"alice", "bob"}},
+		{input: "{\"foo\":\"bar\"}", expected: map[string]interface{}{"foo": "bar"}},
+		{input: "`[\"alice\",\"bob\"]`", expected: []interface{}{"alice", "bob"}},
+		{input: "`{\"foo\":\"bar\"}`", expected: map[string]interface{}{"foo": "bar"}},
+		{input: "\"[\\\"alice\\\",\\\"bob\\\"]\"", expected: []interface{}{"alice", "bob"}},
+		{input: "\"{\\\"foo\\\":\\\"bar\\\"}\"", expected: map[string]interface{}{"foo": "bar"}},
+		{input: "plain", expected: "plain"},
+	}
+	for _, tt := range tests {
+		actual := parseExtensionValue(tt.input)
+		assert.Equal(t, tt.expected, actual)
+	}
+}
+
+func TestSpec2SwaggerWithRouteExtensions(t *testing.T) {
+	src := `syntax = "v1"
+
+type LoginRequest {
+	Name string
+}
+
+type LoginResponse {
+	Token string
+}
+
+service user {
+	@doc "User Login"
+	@x-log-enabled true
+	@x-log-type business
+	@x-sensitive true
+	@x-rate-limit "100/min"
+	@x-timeout 30
+	@x-owners ` + "`" + `["alice","bob"]` + "`" + `
+	@handler Login
+	post /user/login (LoginRequest) returns (LoginResponse)
+}`
+
+	spec, err := parser.Parse("", src)
+	assert.NoError(t, err)
+
+	swagger, err := spec2Swagger(spec)
+	assert.NoError(t, err)
+
+	pathItem := swagger.Paths.Paths["/user/login"]
+	assert.NotNil(t, pathItem.Post)
+	op := pathItem.Post
+
+	assert.Equal(t, true, op.Extensions["x-log-enabled"])
+	assert.Equal(t, "business", op.Extensions["x-log-type"])
+	assert.Equal(t, true, op.Extensions["x-sensitive"])
+	assert.Equal(t, "100/min", op.Extensions["x-rate-limit"])
+	assert.Equal(t, float64(30), op.Extensions["x-timeout"])
+	assert.Equal(t, []interface{}{"alice", "bob"}, op.Extensions["x-owners"])
+
+	// Also ensure the generated JSON really contains the x- fields.
+	data, err := json.Marshal(swagger)
+	assert.NoError(t, err)
+	var m map[string]interface{}
+	assert.NoError(t, json.Unmarshal(data, &m))
+	paths := m["paths"].(map[string]interface{})
+	post := paths["/user/login"].(map[string]interface{})["post"].(map[string]interface{})
+	assert.Equal(t, true, post["x-log-enabled"])
+	assert.Equal(t, "business", post["x-log-type"])
 }
 
 func TestArrayWithoutDefinitions(t *testing.T) {

--- a/tools/goctl/pkg/parser/api/ast/servicestatement.go
+++ b/tools/goctl/pkg/parser/api/ast/servicestatement.go
@@ -305,15 +305,54 @@ func (a *AtHandlerStmt) Pos() token.Position {
 
 func (a *AtHandlerStmt) stmtNode() {}
 
+type AtXStmt struct {
+	AtX   *TokenNode
+	Value *TokenNode
+}
+
+func (a *AtXStmt) HasHeadCommentGroup() bool {
+	return a.AtX.HasHeadCommentGroup()
+}
+
+func (a *AtXStmt) HasLeadingCommentGroup() bool {
+	return a.Value.HasLeadingCommentGroup()
+}
+
+func (a *AtXStmt) CommentGroup() (head, leading CommentGroup) {
+	return a.AtX.HeadCommentGroup, a.Value.LeadingCommentGroup
+}
+
+func (a *AtXStmt) Format(prefix ...string) string {
+	w := NewBufferWriter()
+	atXNode := transferTokenNode(a.AtX, withTokenNodePrefix(prefix...), ignoreLeadingComment())
+	valueNode := transferTokenNode(a.Value, ignoreHeadComment())
+	w.Write(withNode(atXNode, valueNode), expectSameLine())
+	return w.String()
+}
+
+func (a *AtXStmt) End() token.Position {
+	return a.Value.End()
+}
+
+func (a *AtXStmt) Pos() token.Position {
+	return a.AtX.Pos()
+}
+
+func (a *AtXStmt) stmtNode() {}
+
 type ServiceItemStmt struct {
-	AtDoc     AtDocStmt
-	AtHandler *AtHandlerStmt
-	Route     *RouteStmt
+	AtDoc          AtDocStmt
+	AtXAnnotations []*AtXStmt
+	AtHandler      *AtHandlerStmt
+	Route          *RouteStmt
 }
 
 func (s *ServiceItemStmt) HasHeadCommentGroup() bool {
 	if s.AtDoc != nil {
 		return s.AtDoc.HasHeadCommentGroup()
+	}
+	if len(s.AtXAnnotations) > 0 {
+		return s.AtXAnnotations[0].HasHeadCommentGroup()
 	}
 	return s.AtHandler.HasHeadCommentGroup()
 }
@@ -328,6 +367,10 @@ func (s *ServiceItemStmt) CommentGroup() (head, leading CommentGroup) {
 		head, _ = s.AtDoc.CommentGroup()
 		return head, leading
 	}
+	if len(s.AtXAnnotations) > 0 {
+		head, _ = s.AtXAnnotations[0].CommentGroup()
+		return head, leading
+	}
 	head, _ = s.AtHandler.CommentGroup()
 	return head, leading
 }
@@ -336,6 +379,10 @@ func (s *ServiceItemStmt) Format(prefix ...string) string {
 	w := NewBufferWriter()
 	if s.AtDoc != nil {
 		w.WriteText(s.AtDoc.Format(prefix...))
+		w.NewLine()
+	}
+	for _, atX := range s.AtXAnnotations {
+		w.WriteText(atX.Format(prefix...))
 		w.NewLine()
 	}
 	w.WriteText(s.AtHandler.Format(prefix...))
@@ -353,6 +400,9 @@ func (s *ServiceItemStmt) End() token.Position {
 func (s *ServiceItemStmt) Pos() token.Position {
 	if s.AtDoc != nil {
 		return s.AtDoc.Pos()
+	}
+	if len(s.AtXAnnotations) > 0 {
+		return s.AtXAnnotations[0].Pos()
 	}
 	return s.AtHandler.Pos()
 }

--- a/tools/goctl/pkg/parser/api/parser/analyzer.go
+++ b/tools/goctl/pkg/parser/api/parser/analyzer.go
@@ -256,15 +256,22 @@ func (a *Analyzer) fillService() error {
 			if astRoute.AtDoc != nil {
 				route.AtDoc = a.convertAtDoc(astRoute.AtDoc)
 			}
-			if astRoute.AtHandler != nil {
-				route.AtDoc = a.convertAtDoc(astRoute.AtDoc)
-				route.Handler = astRoute.AtHandler.Name.Token.Text
-				head, leading := astRoute.AtHandler.CommentGroup()
-				route.HandlerDoc = head.List()
-				route.HandlerComment = leading.List()
-			}
+		if astRoute.AtHandler != nil {
+			route.Handler = astRoute.AtHandler.Name.Token.Text
+			head, leading := astRoute.AtHandler.CommentGroup()
+			route.HandlerDoc = head.List()
+			route.HandlerComment = leading.List()
+		}
 
-			if astRoute.Route.Request != nil && astRoute.Route.Request.Body != nil {
+		if len(astRoute.AtXAnnotations) > 0 {
+			route.Extensions = make(map[string]string)
+			for _, atX := range astRoute.AtXAnnotations {
+				key := strings.TrimPrefix(atX.AtX.Token.Text, "@")
+				route.Extensions[key] = atX.Value.Token.Text
+			}
+		}
+
+		if astRoute.Route.Request != nil && astRoute.Route.Request.Body != nil {
 				requestType, err := a.getType(astRoute.Route.Request, true)
 				if err != nil {
 					return err

--- a/tools/goctl/pkg/parser/api/parser/parser.go
+++ b/tools/goctl/pkg/parser/api/parser/parser.go
@@ -163,7 +163,7 @@ func (p *Parser) parseServiceItemsStmt() []*ast.ServiceItemStmt {
 			break
 		}
 
-		if p.notExpectPeekToken(token.AT_DOC, token.AT_HANDLER, token.RBRACE) {
+		if p.notExpectPeekToken(token.AT_DOC, token.AT_X, token.AT_HANDLER, token.RBRACE) {
 			return nil
 		}
 	}
@@ -185,6 +185,20 @@ func (p *Parser) parseServiceItemStmt() *ast.ServiceItemStmt {
 		}
 
 		stmt.AtDoc = atDocStmt
+	}
+
+	// statement @x-*
+	for p.peekTokenIs(token.AT_X) {
+		if !p.nextToken() {
+			return nil
+		}
+
+		atXStmt := p.parseAtXStmt()
+		if atXStmt == nil {
+			return nil
+		}
+
+		stmt.AtXAnnotations = append(stmt.AtXAnnotations, atXStmt)
 	}
 
 	// statement @handler
@@ -590,14 +604,23 @@ func (p *Parser) parseAtDocLiteralStmt() ast.AtDocStmt {
 func (p *Parser) parseAtHandlerStmt() *ast.AtHandlerStmt {
 	var stmt = &ast.AtHandlerStmt{}
 	stmt.AtHandler = p.curTokenNode()
-
 	// token IDENT
 	if !p.advanceIfPeekTokenIs(token.IDENT) {
 		return nil
 	}
 
 	stmt.Name = p.curTokenNode()
+	return stmt
+}
 
+func (p *Parser) parseAtXStmt() *ast.AtXStmt {
+	var stmt = &ast.AtXStmt{}
+	stmt.AtX = p.curTokenNode()
+	if !p.advanceIfPeekTokenIs(token.STRING, token.RAW_STRING, token.IDENT, token.INT, token.DURATION) {
+		return nil
+	}
+
+	stmt.Value = p.curTokenNode()
 	return stmt
 }
 
@@ -1720,6 +1743,8 @@ func (p *Parser) parseStmtForUniTest() ast.Stmt {
 		return p.parseAtHandlerStmt()
 	case token.AT_DOC:
 		return p.parseAtDocStmt()
+	case token.AT_X:
+		return p.parseAtXStmt()
 	}
 	return nil
 }

--- a/tools/goctl/pkg/parser/api/parser/parser_test.go
+++ b/tools/goctl/pkg/parser/api/parser/parser_test.go
@@ -499,6 +499,80 @@ func TestParser_Parse_atDocGroup(t *testing.T) {
 //go:embed testdata/service_test.api
 var serviceTestAPI string
 
+func TestParser_Parse_atX(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		var testData = []struct {
+			input    string
+			expected string
+			value    string
+		}{
+			{input: `@x-log-enabled true`, expected: "@x-log-enabled", value: "true"},
+			{input: `@x-rate-limit "100/min"`, expected: "@x-rate-limit", value: `"100/min"`},
+			{input: `@x-timeout 30`, expected: "@x-timeout", value: "30"},
+		{input: "@x-owners `[\"alice\",\"bob\"]`", expected: "@x-owners", value: "`[\"alice\",\"bob\"]`"},
+			{input: "@x-foo `bar`", expected: "@x-foo", value: "`bar`"},
+		}
+		for _, v := range testData {
+			p := New("foo.api", v.input)
+			result := p.ParseForUintTest()
+			assert.True(t, p.hasNoErrors())
+			stmt := result.Stmts[0]
+			atXStmt, ok := stmt.(*ast.AtXStmt)
+			assert.True(t, ok)
+			assert.Equal(t, v.expected, atXStmt.AtX.Token.Text)
+			assert.Equal(t, v.value, atXStmt.Value.Token.Text)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		var testData = []string{
+			`@x`,
+			`@x-`,
+			`@x-log-enabled`,
+			`@x-log-enabled @`,
+		}
+		for _, v := range testData {
+			p := New("foo.api", v)
+			_ = p.ParseForUintTest()
+			assertx.ErrorOrigin(t, v, p.errors...)
+		}
+	})
+}
+
+func TestParser_Parse_serviceWithAtX(t *testing.T) {
+	input := `type OrderReq {
+	Name string
+}
+type OrderResp {
+	Id int
+}
+service order {
+	@doc "Create Order"
+	@x-log-enabled true
+	@x-rate-limit "100/min"
+	@handler createOrder
+	post /order/create (OrderReq) returns (OrderResp)
+}`
+	p := New("order.api", input)
+	result := p.Parse()
+	assert.True(t, p.hasNoErrors())
+	var serviceStmt *ast.ServiceStmt
+	for _, stmt := range result.Stmts {
+		if s, ok := stmt.(*ast.ServiceStmt); ok {
+			serviceStmt = s
+			break
+		}
+	}
+	assert.NotNil(t, serviceStmt)
+	assert.Equal(t, 1, len(serviceStmt.Routes))
+	item := serviceStmt.Routes[0]
+	assert.Equal(t, 2, len(item.AtXAnnotations))
+	assert.Equal(t, "@x-log-enabled", item.AtXAnnotations[0].AtX.Token.Text)
+	assert.Equal(t, "true", item.AtXAnnotations[0].Value.Token.Text)
+	assert.Equal(t, "@x-rate-limit", item.AtXAnnotations[1].AtX.Token.Text)
+	assert.Equal(t, `"100/min"`, item.AtXAnnotations[1].Value.Token.Text)
+}
+
 func TestParser_Parse_service(t *testing.T) {
 	assertEqual := func(t *testing.T, expected, actual *ast.ServiceStmt) {
 		if expected.AtServerStmt == nil {

--- a/tools/goctl/pkg/parser/api/scanner/scanner.go
+++ b/tools/goctl/pkg/parser/api/scanner/scanner.go
@@ -215,14 +215,27 @@ func (s *Scanner) scanAt() (token.Token, error) {
 			Text:     "@doc",
 			Position: s.newPosition(position),
 		}, nil
+	case "x":
+		if s.ch == '-' && (s.isLetter(s.peekRune()) || s.isDigit(s.peekRune()) || s.peekRune() == '_') {
+			s.readRune() // consume '-'
+			for s.isLetter(s.ch) || s.isDigit(s.ch) || s.ch == '_' || s.ch == '-' {
+				s.readRune()
+			}
+			return token.Token{
+				Type:     token.AT_X,
+				Text:     string(s.data[position:s.position]),
+				Position: s.newPosition(position),
+			}, nil
+		}
 	default:
-
-		return token.ErrorToken, s.assertExpectedString(
-			"@"+letters,
-			token.AT_DOC.String(),
-			token.AT_HANDLER.String(),
-			token.AT_SERVER.String())
 	}
+
+	return token.ErrorToken, s.assertExpectedString(
+		"@"+letters,
+		token.AT_DOC.String(),
+		token.AT_HANDLER.String(),
+		token.AT_SERVER.String(),
+		token.AT_X.String())
 }
 
 func (s *Scanner) scanIntOrDuration() token.Token {

--- a/tools/goctl/pkg/parser/api/token/token.go
+++ b/tools/goctl/pkg/parser/api/token/token.go
@@ -185,6 +185,7 @@ const (
 	AT_DOC
 	AT_HANDLER
 	AT_SERVER
+	AT_X
 	ANY
 
 	api_keyword_end
@@ -264,6 +265,7 @@ var tokens = [...]string{
 	AT_DOC:     "@doc",
 	AT_HANDLER: "@handler",
 	AT_SERVER:  "@server",
+	AT_X:       "x-annotation",
 	ANY:        "interface{}",
 }
 


### PR DESCRIPTION
# feat(api/swagger): 在 `.api` 文件中支持自定义 `x-` 扩展字段并生成 Swagger

关联 issue：go-zero/go-zero#5628

## 摘要
本改动让 API 作者可以直接在 `.api` 文件里声明自定义 Swagger 扩展字段（`x-*`），语法是在路由的 `@handler` 之前添加 `@x-<key>` 注解：

```api
service order {
    @doc "Create Order"
    @x-log-enabled true
    @x-rate-limit "100/min"
    @x-owners `["alice","bob"]`
    @handler createOrder
    post /order/create (CreateOrderRequest) returns (CreateOrderResponse)
}
```

生成的 Swagger JSON 会在 operation 上带上这些扩展字段：

```json
"post": {
    "x-log-enabled": true,
    "x-rate-limit": "100/min",
    "x-owners": ["alice", "bob"]
}
```

## 改动内容
- **词法扫描**（`tools/goctl/pkg/parser/api/scanner/scanner.go`）：识别 `@x-<key>` 词法单元。
- **Token / AST**（`tools/goctl/pkg/parser/api/token/token.go`、`tools/goctl/pkg/parser/api/ast/servicestatement.go`）：新增 `AT_X` token 类型，以及 `AtXStmt` / `AtXAnnotations` AST 节点。
- **解析器**（`tools/goctl/pkg/parser/api/parser/parser.go`）：在 `@handler` 前解析零个或多个 `@x-*` 注解，并在 `ParseForUintTest` 中暴露该能力。
- **分析器 / spec**（`tools/goctl/pkg/parser/api/parser/analyzer.go`、`tools/goctl/api/spec/spec.go`）：将注解写入 `spec.Route.Extensions`，并移除一处重复的 `@doc` 转换。
- **Swagger 生成**（`tools/goctl/api/swagger/swagger.go`、`tools/goctl/api/swagger/path.go`）：将扩展值解析为布尔值、数字、字符串或 JSON 数组/对象，并写入 `spec.Operation.Extensions`。
- **测试**（`tools/goctl/pkg/parser/api/parser/parser_test.go`、`tools/goctl/api/swagger/swagger_test.go`）：覆盖独立 `@x-*` 解析、service 级解析以及端到端 Swagger 生成，包括字符串、布尔、数字、JSON 数组/对象等取值。

## 扩展字段值解析规则
按以下顺序解析值：
1. JSON 数组或对象（支持双引号字符串和反引号 raw string）。
2. 带引号或反引号的字符串字面量。
3. 布尔字面量（`true` / `false`）。
4. 数字字面量（如 `30`、`3.14`）。
5. 其它情况按普通字符串返回。

## 验证
```bash
cd tools/goctl
go test ./pkg/parser/api/... ./api/swagger/...
go build ./...
```

所有测试通过，构建成功。