### PR TITLE
docs: fix model sql example link

### DIFF
--- a/tools/goctl/model/sql/README.MD
+++ b/tools/goctl/model/sql/README.MD
@@ -293,7 +293,7 @@ OPTIONS:
 
 	```
 
-	示例用法请参考[用法](./example/generator.sh)
+	示例用法请参考[用法](./example/makefile)
   
 	> NOTE: goctl model mysql ddl/datasource 均新增了一个`--style`参数，用于标记文件命名风格。
 


### PR DESCRIPTION
## What this PR does

Fixes a broken example link in `tools/goctl/model/sql/README.MD`.

The README currently points to `./example/generator.sh`, but that file does not exist. The available example entry is `./example/makefile`.

## How I checked

- Confirmed `tools/goctl/model/sql/example/generator.sh` does not exist
- Confirmed `tools/goctl/model/sql/example/makefile` exists
- Ran `git diff --check`