### PR TITLE
fix: force refresh every call when refresh interval is 0

### DIFF
--- a/core/syncx/immutableresource.go
+++ b/core/syncx/immutableresource.go
@@ -70,6 +70,9 @@ func (ir *ImmutableResource) Get() (any, error) {
 }
 
 func (ir *ImmutableResource) shouldRefresh() bool {
+	if ir.refreshInterval <= 0 {
+		return true
+	}
 	lastTime := ir.lastTime.Load()
 	return lastTime == 0 || lastTime+ir.refreshInterval < timex.Now()
 }

--- a/core/syncx/immutableresource.go
+++ b/core/syncx/immutableresource.go
@@ -73,6 +73,7 @@ func (ir *ImmutableResource) shouldRefresh() bool {
 	if ir.refreshInterval <= 0 {
 		return true
 	}
+
 	lastTime := ir.lastTime.Load()
 	return lastTime == 0 || lastTime+ir.refreshInterval < timex.Now()
 }

--- a/core/syncx/immutableresource_test.go
+++ b/core/syncx/immutableresource_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -121,4 +122,36 @@ func TestImmutableResourceErrorRefreshAlways(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, "any", err.Error())
 	assert.Equal(t, 2, count)
+}
+
+func TestImmutableResourceErrorRefreshWithoutClockAdvance(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var count int
+		fetchErr := errors.New("fetch failed")
+		r := NewImmutableResource(func() (any, error) {
+			count++
+			if count == 1 {
+				return nil, fetchErr
+			}
+
+			return "hello", nil
+		}, WithRefreshIntervalOnFailure(0))
+
+		res, err := r.Get()
+		assert.Nil(t, res)
+		assert.ErrorIs(t, err, fetchErr)
+		assert.Equal(t, 1, count)
+
+		// The synctest clock stays fixed between calls, reproducing identical clock readings.
+		res, err = r.Get()
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", res)
+		assert.Equal(t, 2, count)
+
+		// A successful fetch stays cached even with a zero refresh interval.
+		res, err = r.Get()
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", res)
+		assert.Equal(t, 2, count)
+	})
 }


### PR DESCRIPTION
Fixes #5745

`ImmutableResource.shouldRefresh()` computes `lastTime+ir.refreshInterval < timex.Now()`. When `WithRefreshIntervalOnFailure(0)` is used, the expression degenerates to `lastTime < timex.Now()`.

On coarse-grained clocks (e.g. Windows), two `Get()` calls in close succession can observe identical `timex.Now()` values, so the failed fetch is never retried even though the doc says interval 0 must "enforce refresh every time if not succeeded".

Fix: short-circuit when `refreshInterval <= 0` and always refresh, matching the documented semantics and the existing `TestImmutableResourceErrorRefreshAlways` expectation.