### PR TITLE
fix(goctl): support hyphen-only api prefixes

### DIFF
--- a/tools/goctl/pkg/parser/api/parser/parser.go
+++ b/tools/goctl/pkg/parser/api/parser/parser.go
@@ -1172,12 +1172,12 @@ func (p *Parser) parseAtServerKVExpression() *ast.KVExpr {
 
 		slashTok := p.curTok
 		var pathText = slashTok.Text
-		if !p.advanceIfPeekTokenIs(token.IDENT) {
+		if !p.advanceIfPeekTokenIs(token.IDENT, token.SUB) {
 			return nil
 		}
 
 		pathText += p.curTok.Text
-		if p.peekTokenIs(token.SUB) { //  parse abc-efg format
+		if p.peekTokenIs(token.SUB) && p.curTokenIs(token.IDENT) { //  parse abc-efg format
 			if !p.nextToken() {
 				return nil
 			}
@@ -1303,12 +1303,21 @@ func (p *Parser) parseAtServerKVExpression() *ast.KVExpr {
 			slashTok := p.curTok
 			var pathText = valueTok.Text
 			pathText += slashTok.Text
-			if !p.advanceIfPeekTokenIs(token.IDENT) {
+			// Allow a trailing slash at the end of an @server path value.
+			if p.peekTok.Line() > p.curTok.Line() || p.peekTokenIs(token.RPAREN) {
+				valueTok = token.Token{
+					Text:     pathText,
+					Position: valueTok.Position,
+				}
+				leadingCommentGroup = p.curTokenNode().LeadingCommentGroup
+				break
+			}
+			if !p.advanceIfPeekTokenIs(token.IDENT, token.SUB) {
 				return nil
 			}
 
 			pathText += p.curTok.Text
-			if p.peekTokenIs(token.SUB) { //  parse abc-efg format
+			if p.peekTokenIs(token.SUB) && p.curTokenIs(token.IDENT) { //  parse abc-efg format
 				if !p.nextToken() {
 					return nil
 				}

--- a/tools/goctl/pkg/parser/api/parser/parser_test.go
+++ b/tools/goctl/pkg/parser/api/parser/parser_test.go
@@ -306,6 +306,9 @@ func TestParser_Parse_atServerStmt(t *testing.T) {
 			"prefix2":    "v1/v2_test/v2-beta",
 			"prefix3":    "v1/v2_",
 			"prefix4":    "a-b-c",
+			"prefix5":    "/-",
+			"prefix6":    "/-/",
+			"prefix7":    "/abc/",
 			"summary":    `"test"`,
 			"key":        `"bar"`,
 		}

--- a/tools/goctl/pkg/parser/api/parser/parser_test.go
+++ b/tools/goctl/pkg/parser/api/parser/parser_test.go
@@ -309,6 +309,7 @@ func TestParser_Parse_atServerStmt(t *testing.T) {
 			"prefix5":    "/-",
 			"prefix6":    "/-/",
 			"prefix7":    "/abc/",
+			"prefix8":    "/comment/",
 			"summary":    `"test"`,
 			"key":        `"bar"`,
 		}
@@ -362,6 +363,8 @@ func TestParser_Parse_atServerStmt(t *testing.T) {
 			`@server(foo: m1,`,
 			`@server(foo: m1,)`,
 			`@server(foo: v1/v2-)`,
+			`@server(prefix:/--)`,
+			`@server(prefix:/-abc)`,
 			`@server(foo:"test")`,
 		}
 		for _, v := range testData {

--- a/tools/goctl/pkg/parser/api/parser/testdata/atserver_test.api
+++ b/tools/goctl/pkg/parser/api/parser/testdata/atserver_test.api
@@ -21,6 +21,7 @@
     prefix5: /-
     prefix6: /-/
     prefix7: /abc/
+    prefix8: /comment/ // trailing slash before a comment and the next key
     summary:"test"
     key:"bar"
 )

--- a/tools/goctl/pkg/parser/api/parser/testdata/atserver_test.api
+++ b/tools/goctl/pkg/parser/api/parser/testdata/atserver_test.api
@@ -18,6 +18,9 @@
     prefix2: v1/v2_test/v2-beta
     prefix3: v1/v2_
     prefix4: a-b-c
+    prefix5: /-
+    prefix6: /-/
+    prefix7: /abc/
     summary:"test"
     key:"bar"
 )


### PR DESCRIPTION
## What does this PR do?

Fixes the goctl API parser so `@server` prefixes can contain a path segment consisting only of `-`.

It also allows a trailing slash in `@server` path values, which is needed for prefixes such as `/-/`.

Examples now supported:

```api
prefix: /-
prefix: /-/
prefix: /abc/
```

## Why?

The parser previously required each path segment after `/` to start with an identifier, causing valid prefixes such as `/-` to fail with:

```text
syntax error: expected 'IDENT', got '-'
```

It also treated a trailing `/` as the beginning of another required path segment.

## Tests

Added regression coverage for:

- `/-`
- `/-/`
- `/abc/`

Validated with:

```bash
go test ./pkg/parser/api/parser -count=1
go test ./pkg/parser/api/... -count=1
```

Fixes #4957