### PR TITLE
fix(mapping): support unmarshaling into interface{} fields for mixed types (fix #5721)

### DIFF
--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -648,11 +648,25 @@ func (u *Unmarshaler) processFieldPrimitive(fieldType reflect.Type, value reflec
 	switch v := mapValue.(type) {
 	case json.Number:
 		if typeKind == reflect.Interface {
+			if err := validateValueInOptions(mapValue, opts.options()); err != nil {
+				return err
+			}
+			if err := validateJsonNumberRange(v, opts); err != nil {
+				return err
+			}
+			if opts != nil && opts.Range != nil {
+				optionsCopy := *opts
+				optionsCopy.Range = nil
+				opts = &optionsCopy
+			}
 			return fillWithSameType(fieldType, value, mapValue, opts)
 		}
 		return u.processFieldPrimitiveWithJSONNumber(fieldType, value, v, opts, fullName)
 	default:
 		if typeKind == reflect.Interface {
+			if err := validateValueInOptions(mapValue, opts.options()); err != nil {
+				return err
+			}
 			return fillWithSameType(fieldType, value, mapValue, opts)
 		}
 		if typeKind == valueKind {

--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -647,8 +647,14 @@ func (u *Unmarshaler) processFieldPrimitive(fieldType reflect.Type, value reflec
 
 	switch v := mapValue.(type) {
 	case json.Number:
+		if typeKind == reflect.Interface {
+			return fillWithSameType(fieldType, value, mapValue, opts)
+		}
 		return u.processFieldPrimitiveWithJSONNumber(fieldType, value, v, opts, fullName)
 	default:
+		if typeKind == reflect.Interface {
+			return fillWithSameType(fieldType, value, mapValue, opts)
+		}
 		if typeKind == valueKind {
 			if err := validateValueInOptions(mapValue, opts.options()); err != nil {
 				return err
@@ -1231,6 +1237,10 @@ func readKeys(key string, opaque bool) []string {
 }
 
 func setSameKindValue(targetType reflect.Type, target reflect.Value, value any) {
+	if targetType.Kind() == reflect.Interface {
+		target.Set(reflect.ValueOf(value))
+		return
+	}
 	if reflect.ValueOf(value).Type().AssignableTo(targetType) {
 		target.Set(reflect.ValueOf(value))
 	} else {

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -6312,3 +6312,33 @@ type mockUnmarshalerWithError struct {
 func (m *mockUnmarshalerWithError) UnmarshalJSON(b []byte) error {
 	return errors.New("foo")
 }
+
+func TestUnmarshalInterfaceField(t *testing.T) {
+	type DataItem struct {
+		Value     any `json:"value,optional"`
+		ValueType int `json:"valueType"`
+	}
+	type UpdateReq struct {
+		Id    string     `json:"id"`
+		Items []DataItem `json:"datas,optional"`
+	}
+
+	content := []byte(`{
+		"id": "123",
+		"datas": [
+			{"value": "string_val", "valueType": 0},
+			{"value": 100, "valueType": 1}
+		]
+	}`)
+
+	var req UpdateReq
+	err := UnmarshalJsonBytes(content, &req)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", req.Id)
+	assert.Equal(t, 2, len(req.Items))
+	assert.Equal(t, "string_val", req.Items[0].Value)
+	assert.Equal(t, 0, req.Items[0].ValueType)
+	assert.Equal(t, json.Number("100"), req.Items[1].Value)
+	assert.Equal(t, 1, req.Items[1].ValueType)
+}
+

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -6342,3 +6342,29 @@ func TestUnmarshalInterfaceField(t *testing.T) {
 	assert.Equal(t, 1, req.Items[1].ValueType)
 }
 
+func TestUnmarshalInterfaceFieldHonorsOptionsAndRange(t *testing.T) {
+	t.Run("options", func(t *testing.T) {
+		type payload struct {
+			Value any `key:"value,options=[allowed]"`
+		}
+
+		var got payload
+		err := UnmarshalKey(map[string]any{"value": "denied"}, &got)
+		assert.Error(t, err)
+	})
+
+	t.Run("json number range", func(t *testing.T) {
+		type payload struct {
+			Value any `key:"number_value,range=[1:3]"`
+		}
+
+		var valid payload
+		err := UnmarshalKey(map[string]any{"number_value": json.Number("2")}, &valid)
+		assert.NoError(t, err)
+		assert.Equal(t, json.Number("2"), valid.Value)
+
+		var invalid payload
+		err = UnmarshalKey(map[string]any{"number_value": json.Number("4")}, &invalid)
+		assert.ErrorIs(t, err, errNumberRange)
+	})
+}


### PR DESCRIPTION
Fixes #5721

### Problem
httpx.Parse (and mapping.UnmarshalJsonBytes) failed with 	ype mismatch for field "..." when unmarshaling into a struct field of type interface{} / ny whose JSON value is a primitive string, number (json.Number), or bool. This occurred because processFieldPrimitive checked 	ypeKind == valueKind without handling eflect.Interface.

### Solution
- In core/mapping/unmarshaler.go processFieldPrimitive: Check if 	ypeKind == reflect.Interface, and if so directly invoke illWithSameType.
- In setSameKindValue: Handle 	argetType.Kind() == reflect.Interface with 	arget.Set(reflect.ValueOf(value)).
- Added unit test TestUnmarshalInterfaceField covering structs with ny fields containing mixed strings and numbers.
