### PR TITLE
fix(timingwheel): allow resetting timers after drain

### DIFF
--- a/core/collection/timingwheel.go
+++ b/core/collection/timingwheel.go
@@ -170,6 +170,12 @@ func (tw *TimingWheel) drainAll(fn func(key, value any)) {
 			task := e.Value.(*timingEntry)
 			next := e.Next()
 			slot.Remove(e)
+			if val, ok := tw.timers.Get(task.key); ok {
+				timer := val.(*positionEntry)
+				if timer.item == task {
+					tw.timers.Del(task.key)
+				}
+			}
 			e = next
 			if !task.removed {
 				runner.Schedule(func() {

--- a/core/collection/timingwheel_test.go
+++ b/core/collection/timingwheel_test.go
@@ -59,6 +59,35 @@ func TestTimingWheel_Drain(t *testing.T) {
 	assert.Equal(t, ErrClosed, tw.Drain(func(key, value any) {}))
 }
 
+func TestTimingWheel_SetTimerAfterDrain(t *testing.T) {
+	ticker := timex.NewFakeTicker()
+	var count int32
+	tw, _ := NewTimingWheelWithTicker(testStep, 10, func(key, value any) {
+		assert.Equal(t, "foo", key)
+		assert.Equal(t, 2, value)
+		atomic.AddInt32(&count, 1)
+		ticker.Done()
+	}, ticker)
+	defer tw.Stop()
+
+	tw.SetTimer("foo", 1, testStep*4)
+	drained := make(chan lang.PlaceholderType)
+	tw.Drain(func(key, value any) {
+		assert.Equal(t, "foo", key)
+		assert.Equal(t, 1, value)
+		close(drained)
+	})
+	<-drained
+
+	tw.SetTimer("foo", 2, testStep*4)
+	for i := 0; i < 4; i++ {
+		ticker.Tick()
+	}
+
+	assert.Nil(t, ticker.Wait(waitTime))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&count))
+}
+
 func TestTimingWheel_SetTimerSoon(t *testing.T) {
 	run := syncx.NewAtomicBool()
 	ticker := timex.NewFakeTicker()


### PR DESCRIPTION
## Description

`TimingWheel.Drain` removes timer entries from the wheel slots but leaves their active mappings in `tw.timers`.

When `SetTimer` is called again with the same key, `setTask` finds the stale mapping and updates the detached entry. If the new delay maps to the same slot, the entry is not reinserted and the timer never executes.

This issue is separate from #5315, which added the missing wait for drain callbacks but did not clean up the timer mappings.

### Changes Made

1. Remove a timer mapping when its entry is drained.
2. Check that the mapping still points to the drained entry before deleting it, so a newer entry with the same key is preserved.
3. Add a regression test that drains a timer, sets another timer with the same key, and verifies that the new callback executes exactly once.

### Testing

- `go test -race ./...`