### PR TITLE
chore(safemap): Use go standard library for maps copy

### DIFF
--- a/core/collection/safemap.go
+++ b/core/collection/safemap.go
@@ -1,6 +1,9 @@
 package collection
 
-import "sync"
+import (
+	"maps"
+	"sync"
+)
 
 const (
 	copyThreshold = 1000
@@ -39,18 +42,14 @@ func (m *SafeMap) Del(key any) {
 		m.deletionNew++
 	}
 	if m.deletionOld >= maxDeletion && len(m.dirtyOld) < copyThreshold {
-		for k, v := range m.dirtyOld {
-			m.dirtyNew[k] = v
-		}
+		maps.Copy(m.dirtyNew, m.dirtyOld)
 		m.dirtyOld = m.dirtyNew
 		m.deletionOld = m.deletionNew
 		m.dirtyNew = make(map[any]any)
 		m.deletionNew = 0
 	}
 	if m.deletionNew >= maxDeletion && len(m.dirtyNew) < copyThreshold {
-		for k, v := range m.dirtyNew {
-			m.dirtyOld[k] = v
-		}
+		maps.Copy(m.dirtyOld, m.dirtyNew)
 		m.dirtyNew = make(map[any]any)
 		m.deletionNew = 0
 	}


### PR DESCRIPTION
We can use the golang standard library `maps.Copy` as the go module is already 1.25