### PR TITLE
docs: clarify AI tooling roles and make MCP optional

### DIFF
--- a/readme-cn.md
+++ b/readme-cn.md
@@ -78,53 +78,36 @@ GO111MODULE=on GOPROXY=https://goproxy.cn/,direct go get -u github.com/zeromicro
 
 ## AI 原生开发
 
-go-zero 团队构建了完整的 AI 工具生态，让 Claude、GitHub Copilot、Cursor 生成符合 go-zero 规范的代码。
+go-zero 团队为 Claude Code、GitHub Copilot、Cursor 等 AI 编程助手提供工作流程指南和实现模式。对于支持终端操作的助手，推荐直接运行 `goctl`，生成符合框架规范的代码。
 
-### 三大核心项目
+### AI 工具项目
 
-**[ai-context](https://github.com/zeromicro/ai-context)** - AI 的工作流程指南
-
-**[zero-skills](https://github.com/zeromicro/zero-skills)** - 模式库和示例
-
-**[mcp-zero](https://github.com/zeromicro/mcp-zero)** - 基于 MCP 的代码生成工具
+- **[ai-context](https://github.com/zeromicro/ai-context)** - 工作流程指南：如何处理 go-zero 开发任务，以及何时使用 goctl。
+- **[zero-skills](https://github.com/zeromicro/zero-skills)** - 按需查阅的实现模式、示例和 goctl 命令参考。
+- **[mcp-zero](https://github.com/zeromicro/mcp-zero)** - 可选适配器，通过模型上下文协议（MCP）提供 goctl 代码生成能力。
 
 ### 快速配置
 
-#### GitHub Copilot
+安装 goctl，并确保它在 `$PATH` 环境变量中：
+
 ```bash
-git submodule add https://github.com/zeromicro/ai-context.git .github/ai-context
-ln -s ai-context/00-instructions.md .github/copilot-instructions.md  # macOS/Linux
-# Windows: mklink .github\copilot-instructions.md .github\ai-context\00-instructions.md
-git submodule update --remote .github/ai-context  # 更新
+go install github.com/zeromicro/go-zero/tools/goctl@latest
+goctl --version
 ```
 
-#### Cursor
-```bash
-git submodule add https://github.com/zeromicro/ai-context.git .cursorrules
-git submodule update --remote .cursorrules  # 更新
-```
+参考 [ai-context 配置指南](https://github.com/zeromicro/ai-context#manual-setup) 和 [zero-skills 集成指南](https://github.com/zeromicro/zero-skills/tree/main/getting-started)，为助手配置工作流程指令和模式库。
 
-#### Windsurf
-```bash
-git submodule add https://github.com/zeromicro/ai-context.git .windsurfrules
-git submodule update --remote .windsurfrules  # 更新
-```
+### 工作原理
 
-#### Claude Desktop
-```bash
-git clone https://github.com/zeromicro/mcp-zero.git && cd mcp-zero && go build
-# 配置: ~/Library/Application Support/Claude/claude_desktop_config.json
-# 或: claude mcp add --transport stdio mcp-zero --env GOCTL_PATH=/path/to/goctl -- /path/to/mcp-zero
-```
+1. 查阅 **ai-context** 了解工作流程，按需参考 **zero-skills** 中的实现模式。
+2. 定义 `.api` 或 `.proto` 文件，然后在终端运行 **goctl** 生成代码。
+3. 实现业务逻辑、整理依赖、构建并测试服务。
 
-### 协同工作原理
+**示例**：创建 REST API → 编写 `.api` 文件 → 运行 `goctl api go` → 参考 **zero-skills** 实现业务逻辑 → 运行 `go mod tidy`、`go build ./...` 和 `go test ./...`。
 
-AI 助手通过三个工具协同配合:
-1. **ai-context** - 工作流程指导
-2. **zero-skills** - 实现模式
-3. **mcp-zero** - 实时代码生成
+### 可选的 MCP 集成
 
-**示例**:创建新的 REST API → AI 读取 **ai-context** 了解工作流 → 调用 **mcp-zero** 生成代码 → 参考 **zero-skills** 实现模式 → 生成符合规范的代码 ✅
+对于 Claude Desktop 等使用 MCP 工具的客户端，可以配置 **[mcp-zero](https://github.com/zeromicro/mcp-zero)**，通过 MCP 调用 goctl。两种方式使用相同的代码生成引擎；支持终端操作的助手可以直接使用上述流程，无需 MCP 服务器。
 
 ## Quick Start
 

--- a/readme-ko.md
+++ b/readme-ko.md
@@ -84,53 +84,36 @@ go get -u github.com/zeromicro/go-zero
 
 ## AI 네이티브 개발
 
-go-zero 팀은 Claude, GitHub Copilot, Cursor가 프레임워크 규칙을 따르는 코드를 생성할 수 있도록 AI 도구를 제공합니다.
+go-zero 팀은 Claude Code, GitHub Copilot, Cursor 등의 AI 코딩 어시스턴트를 위한 워크플로 가이드와 구현 패턴을 제공합니다. 터미널을 사용할 수 있는 어시스턴트에는 `goctl`을 직접 실행하여 프레임워크 규칙을 따르는 코드를 생성하는 방식을 권장합니다.
 
-### 세 가지 핵심 프로젝트
+### AI 도구 프로젝트
 
-**[ai-context](https://github.com/zeromicro/ai-context)** - AI 어시스턴트를 위한 워크플로 가이드
-
-**[zero-skills](https://github.com/zeromicro/zero-skills)** - 예제가 포함된 패턴 라이브러리
-
-**[mcp-zero](https://github.com/zeromicro/mcp-zero)** - Model Context Protocol을 통한 코드 생성 도구
+- **[ai-context](https://github.com/zeromicro/ai-context)** - go-zero 개발 작업의 진행 방식과 goctl 사용 시점을 안내하는 워크플로 가이드.
+- **[zero-skills](https://github.com/zeromicro/zero-skills)** - 필요할 때 참조하는 구현 패턴, 예제, goctl 명령어 레퍼런스.
+- **[mcp-zero](https://github.com/zeromicro/mcp-zero)** - Model Context Protocol(MCP)을 통해 goctl 코드 생성 기능을 제공하는 선택적 어댑터.
 
 ### 빠른 설정
 
-#### GitHub Copilot
+goctl을 설치하고 `$PATH`에 포함되어 있는지 확인하세요.
+
 ```bash
-git submodule add https://github.com/zeromicro/ai-context.git .github/ai-context
-ln -s ai-context/00-instructions.md .github/copilot-instructions.md  # macOS/Linux
-# Windows: mklink .github\copilot-instructions.md .github\ai-context\00-instructions.md
-git submodule update --remote .github/ai-context  # 업데이트
+go install github.com/zeromicro/go-zero/tools/goctl@latest
+goctl --version
 ```
 
-#### Cursor
-```bash
-git submodule add https://github.com/zeromicro/ai-context.git .cursorrules
-git submodule update --remote .cursorrules  # 업데이트
-```
-
-#### Windsurf
-```bash
-git submodule add https://github.com/zeromicro/ai-context.git .windsurfrules
-git submodule update --remote .windsurfrules  # 업데이트
-```
-
-#### Claude Desktop
-```bash
-git clone https://github.com/zeromicro/mcp-zero.git && cd mcp-zero && go build
-# 설정: ~/Library/Application Support/Claude/claude_desktop_config.json
-# 또는: claude mcp add --transport stdio mcp-zero --env GOCTL_PATH=/path/to/goctl -- /path/to/mcp-zero
-```
+[ai-context 설정 가이드](https://github.com/zeromicro/ai-context#manual-setup)와 [zero-skills 통합 가이드](https://github.com/zeromicro/zero-skills/tree/main/getting-started)를 참고하여 어시스턴트의 워크플로 지침과 패턴 라이브러리를 설정하세요.
 
 ### 동작 방식
 
-AI 어시스턴트는 다음 도구를 함께 사용합니다.
-1. **ai-context** - 워크플로 안내
-2. **zero-skills** - 구현 패턴
-3. **mcp-zero** - 실시간 코드 생성
+1. **ai-context**에서 워크플로를 확인하고 **zero-skills**에서 관련 패턴을 참조합니다.
+2. `.api` 또는 `.proto` 명세를 작성한 뒤 터미널에서 **goctl**을 실행하여 코드를 생성합니다.
+3. 비즈니스 로직을 구현하고 의존성을 정리한 뒤 서비스를 빌드하고 테스트합니다.
 
-**예시**: REST API 생성 → AI가 **ai-context**에서 워크플로를 읽음 → **mcp-zero**를 호출해 코드 생성 → **zero-skills**에서 패턴 참조 → 프로덕션 준비가 된 코드 생성 ✅
+**예시**: REST API 생성 → `.api` 명세 작성 → `goctl api go` 실행 → **zero-skills** 패턴을 참고하여 로직 구현 → `go mod tidy`, `go build ./...`, `go test ./...` 실행.
+
+### 선택적 MCP 통합
+
+Claude Desktop처럼 MCP 도구를 사용하는 클라이언트에서는 **[mcp-zero](https://github.com/zeromicro/mcp-zero)**를 설정하여 MCP를 통해 goctl을 호출할 수 있습니다. 두 방식은 같은 코드 생성 엔진을 사용하며, 터미널을 사용할 수 있는 어시스턴트는 MCP 서버 없이 위의 직접 실행 워크플로를 사용할 수 있습니다.
 
 ## 빠른 시작
 

--- a/readme.md
+++ b/readme.md
@@ -84,53 +84,36 @@ go get -u github.com/zeromicro/go-zero
 
 ## AI-Native Development
 
-The go-zero team provides AI tooling for Claude, GitHub Copilot, Cursor to generate framework-compliant code.
+The go-zero team provides workflow guidance and implementation patterns for AI coding assistants such as Claude Code, GitHub Copilot, and Cursor. For assistants with terminal access, the recommended workflow is to run `goctl` directly to generate framework-compliant code.
 
-### Three Core Projects
+### AI Tooling Projects
 
-**[ai-context](https://github.com/zeromicro/ai-context)** - Workflow guide for AI assistants
-
-**[zero-skills](https://github.com/zeromicro/zero-skills)** - Pattern library with examples
-
-**[mcp-zero](https://github.com/zeromicro/mcp-zero)** - Code generation tools via Model Context Protocol
+- **[ai-context](https://github.com/zeromicro/ai-context)** - Workflow guidance: how to approach go-zero development tasks and when to use goctl.
+- **[zero-skills](https://github.com/zeromicro/zero-skills)** - Implementation patterns, examples, and goctl command reference, loaded as needed.
+- **[mcp-zero](https://github.com/zeromicro/mcp-zero)** - Optional adapter that exposes goctl code generation through the Model Context Protocol (MCP).
 
 ### Quick Setup
 
-#### GitHub Copilot
+Install goctl and ensure it is available in your `$PATH`:
+
 ```bash
-git submodule add https://github.com/zeromicro/ai-context.git .github/ai-context
-ln -s ai-context/00-instructions.md .github/copilot-instructions.md  # macOS/Linux
-# Windows: mklink .github\copilot-instructions.md .github\ai-context\00-instructions.md
-git submodule update --remote .github/ai-context  # Update
+go install github.com/zeromicro/go-zero/tools/goctl@latest
+goctl --version
 ```
 
-#### Cursor
-```bash
-git submodule add https://github.com/zeromicro/ai-context.git .cursorrules
-git submodule update --remote .cursorrules  # Update
-```
-
-#### Windsurf
-```bash
-git submodule add https://github.com/zeromicro/ai-context.git .windsurfrules
-git submodule update --remote .windsurfrules  # Update
-```
-
-#### Claude Desktop
-```bash
-git clone https://github.com/zeromicro/mcp-zero.git && cd mcp-zero && go build
-# Configure: ~/Library/Application Support/Claude/claude_desktop_config.json
-# Or: claude mcp add --transport stdio mcp-zero --env GOCTL_PATH=/path/to/goctl -- /path/to/mcp-zero
-```
+Follow the [ai-context setup guide](https://github.com/zeromicro/ai-context#manual-setup) and [zero-skills integration guides](https://github.com/zeromicro/zero-skills/tree/main/getting-started) to configure your assistant's workflow instructions and pattern library.
 
 ### How It Works
 
-AI assistants use these tools together:
-1. **ai-context** - workflow guidance
-2. **zero-skills** - implementation patterns
-3. **mcp-zero** - real-time code generation
+1. Consult **ai-context** for the workflow and **zero-skills** for relevant patterns.
+2. Define the `.api` or `.proto` specification, then run **goctl** in the terminal to generate code.
+3. Implement business logic, resolve dependencies, build, and test the service.
 
-**Example**: Creating a REST API → AI reads **ai-context** for workflow → calls **mcp-zero** to generate code → references **zero-skills** for patterns → produces production-ready code ✅
+**Example**: Create a REST API → write the `.api` specification → run `goctl api go` → implement the logic using **zero-skills** patterns → run `go mod tidy`, `go build ./...`, and `go test ./...`.
+
+### Optional MCP Integration
+
+For clients that use MCP tools, such as Claude Desktop, configure **[mcp-zero](https://github.com/zeromicro/mcp-zero)** to invoke goctl through MCP. It uses the same code generation engine; assistants with terminal access can use the direct workflow above without an MCP server.
 
 ## Quick Start
 


### PR DESCRIPTION
The README presents ai-context, zero-skills, and mcp-zero as a required three-tool workflow, while ai-context and zero-skills already recommend running goctl directly. Update the English, Chinese, and Korean READMEs to recommend direct goctl execution for assistants with terminal access and describe mcp-zero as an optional MCP adapter.

Clarify each project's role, link to the tooling projects' setup guides instead of duplicating editor configuration, and include implementation, build, and test steps in the example workflow.

Validation: `git diff --check` passed. Confirmed that only the AI sections changed, Markdown fences are balanced, and all three translations use identical links and setup commands. Documentation only; no runtime tests required.
