### PR TITLE
refactor: simplify code with Go 1.25 APIs

### DIFF
--- a/core/fx/stream.go
+++ b/core/fx/stream.go
@@ -477,8 +477,6 @@ func (s Stream) walkLimited(fn WalkFunc, option *rxOptions) Stream {
 		pool := make(chan lang.PlaceholderType, option.workers)
 
 		for item := range s.source {
-			// important, used in another goroutine
-			val := item
 			pool <- lang.Placeholder
 			wg.Add(1)
 
@@ -489,7 +487,7 @@ func (s Stream) walkLimited(fn WalkFunc, option *rxOptions) Stream {
 					<-pool
 				}()
 
-				fn(val, pipe)
+				fn(item, pipe)
 			})
 		}
 
@@ -507,13 +505,11 @@ func (s Stream) walkUnlimited(fn WalkFunc, option *rxOptions) Stream {
 		var wg sync.WaitGroup
 
 		for item := range s.source {
-			// important, used in another goroutine
-			val := item
 			wg.Add(1)
 			// better to safely run caller defined method
 			threading.GoSafe(func() {
 				defer wg.Done()
-				fn(val, pipe)
+				fn(item, pipe)
 			})
 		}
 

--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -312,7 +312,7 @@ func (u *Unmarshaler) fillUnmarshalerStruct(fieldType reflect.Type,
 	target := reflect.New(baseType)
 	switch u.key {
 	case jsonTagKey:
-		unmarshaler, ok := target.Interface().(json.Unmarshaler)
+		unmarshaler, ok := reflect.TypeAssert[json.Unmarshaler](target)
 		if !ok {
 			return errUnsupportedType
 		}
@@ -424,7 +424,7 @@ func (u *Unmarshaler) generateMap(keyType, elemType reflect.Type, mapValue any,
 func (u *Unmarshaler) implementsUnmarshaler(t reflect.Type) bool {
 	switch u.key {
 	case jsonTagKey:
-		return t.Implements(reflect.TypeOf((*json.Unmarshaler)(nil)).Elem())
+		return t.Implements(reflect.TypeFor[json.Unmarshaler]())
 	default:
 		return false
 	}
@@ -740,12 +740,12 @@ func (u *Unmarshaler) processFieldTextUnmarshaler(fieldType reflect.Type, value 
 		if value.Elem().Kind() == reflect.Ptr {
 			target := reflect.New(Deref(fieldType))
 			SetValue(fieldType.Elem(), value, target)
-			tval, ok = target.Interface().(encoding.TextUnmarshaler)
+			tval, ok = reflect.TypeAssert[encoding.TextUnmarshaler](target)
 		} else {
-			tval, ok = value.Interface().(encoding.TextUnmarshaler)
+			tval, ok = reflect.TypeAssert[encoding.TextUnmarshaler](value)
 		}
 	} else {
-		tval, ok = value.Addr().Interface().(encoding.TextUnmarshaler)
+		tval, ok = reflect.TypeAssert[encoding.TextUnmarshaler](value.Addr())
 	}
 	if ok {
 		switch mv := mapValue.(type) {

--- a/core/stat/internal/cgroup_linux.go
+++ b/core/stat/internal/cgroup_linux.go
@@ -185,8 +185,7 @@ func currentCgroupV1() (cgroup, error) {
 
 		// https://man7.org/linux/man-pages/man7/cgroups.7.html
 		// comma-separated list of controllers for cgroup version 1
-		fields := strings.Split(subsys, ",")
-		for _, val := range fields {
+		for val := range strings.SplitSeq(subsys, ",") {
 			cgroups[val] = path.Join(cgroupDir, val)
 		}
 	}
@@ -260,8 +259,7 @@ func parseUints(val string) ([]uint64, error) {
 
 	var sets []uint64
 	ints := make(map[uint64]lang.PlaceholderType)
-	cols := strings.Split(val, ",")
-	for _, r := range cols {
+	for r := range strings.SplitSeq(val, ",") {
 		if strings.Contains(r, "-") {
 			fields := strings.SplitN(r, "-", 2)
 			minimum, err := parseUint(fields[0])

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -70,9 +70,6 @@ func (s *Server) Stop() {
 
 	group := threading.NewRoutineGroup()
 	for _, conn := range s.conns {
-		// new variable to avoid closure problems, can be removed after go 1.22
-		// see https://golang.org/doc/faq#closures_and_goroutines
-		conn := conn
 		group.Run(func() {
 			// ignore the error when closing the connection
 			_ = conn.Conn().Close()

--- a/rest/httpx/requests.go
+++ b/rest/httpx/requests.go
@@ -94,9 +94,7 @@ func ParseForm(r *http.Request, v any) error {
 // ParseHeader parses the request header and returns a map.
 func ParseHeader(headerValue string) map[string]string {
 	ret := make(map[string]string)
-	fields := strings.Split(headerValue, separator)
-
-	for _, field := range fields {
+	for field := range strings.SplitSeq(headerValue, separator) {
 		field = strings.TrimSpace(field)
 		if len(field) == 0 {
 			continue

--- a/tools/goctl/api/gogen/util.go
+++ b/tools/goctl/api/gogen/util.go
@@ -141,7 +141,7 @@ func getMiddleware(api *spec.ApiSpec) []string {
 	for _, g := range api.Service.Groups {
 		middleware := g.GetAnnotation("middleware")
 		if len(middleware) > 0 {
-			for _, item := range strings.Split(middleware, ",") {
+			for item := range strings.SplitSeq(middleware, ",") {
 				result.Add(strings.TrimSpace(item))
 			}
 		}

--- a/tools/goctl/api/swagger/response.go
+++ b/tools/goctl/api/swagger/response.go
@@ -91,7 +91,7 @@ func responseStatusCode(atDoc apiSpec.AtDoc) int {
 
 func responseDescriptions(atDoc apiSpec.AtDoc) map[int]string {
 	descriptions := make(map[int]string)
-	for _, item := range strings.Split(getStringFromKVOrDefault(atDoc.Properties, propertyKeyResponses, ""), "<br>") {
+	for item := range strings.SplitSeq(getStringFromKVOrDefault(atDoc.Properties, propertyKeyResponses, ""), "<br>") {
 		codeText, description, ok := strings.Cut(item, "-")
 		if !ok {
 			continue

--- a/tools/goctl/pkg/env/env.go
+++ b/tools/goctl/pkg/env/env.go
@@ -135,9 +135,8 @@ func readEnv(goctlHome string) *sortedmap.SortedMap {
 		return nil
 	}
 	dataStr := string(data)
-	lines := strings.Split(dataStr, "\n")
 	sm := sortedmap.New()
-	for _, line := range lines {
+	for line := range strings.SplitSeq(dataStr, "\n") {
 		_, _, err = sm.SetExpression(line)
 		if err != nil {
 			continue

--- a/tools/goctl/pkg/parser/api/ast/print.go
+++ b/tools/goctl/pkg/parser/api/ast/print.go
@@ -178,7 +178,7 @@ func (p *printer) print(x reflect.Value) {
 		p.printf("}")
 
 	case reflect.Slice:
-		if s, ok := x.Interface().([]byte); ok {
+		if s, ok := reflect.TypeAssert[[]byte](x); ok {
 			p.printf("%#q", s)
 			return
 		}
@@ -196,7 +196,7 @@ func (p *printer) print(x reflect.Value) {
 		p.printf("}")
 
 	case reflect.Struct:
-		if val, ok := x.Interface().(apitoken.Position); ok {
+		if val, ok := reflect.TypeAssert[apitoken.Position](x); ok {
 			p.printf("%s", val.String())
 			return
 		}


### PR DESCRIPTION
With both modules targeting Go 1.25, replace reflection interface round-trips with `reflect.TypeAssert` and `reflect.TypeFor`, use `strings.SplitSeq` for single-pass parsing, and remove redundant loop-variable captures in stream workers and gateway shutdown. These changes preserve parsing results, panic recovery, and task scheduling.

Validation (Go 1.26.3 on macOS):
- Passed `go test ./core/mapping ./core/fx ./rest/httpx ./gateway`.
- Passed `go test ./pkg/parser/api/ast ./pkg/env ./api/gogen ./api/swagger` in `tools/goctl`; AST and environment packages compile but have no test files.
- Cross-compiled Linux cgroup tests with `GOOS=linux GOARCH=amd64 go test -c -o /tmp/go-zero-stat-go125.test ./core/stat/internal`; not executed on macOS.
- Passed formatting and `git diff --check`.
